### PR TITLE
Add GitHub Pages deployment workflow for game

### DIFF
--- a/.github/workflows/deploy-game.yml
+++ b/.github/workflows/deploy-game.yml
@@ -1,0 +1,51 @@
+name: Deploy game to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build game
+        run: npm run build --workspace=game
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: game/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the game workspace and publishes it to GitHub Pages on pushes to main
- configure the workflow to install dependencies, build the Vite project, and upload the static site artifact before deploying

## Testing
- npm run build --workspace=game


------
https://chatgpt.com/codex/tasks/task_e_68cd03db7000832c88f8a237d3f14be2