### PR TITLE
Replace crash-zone renders with generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository is the stripped-back planning space for rebooting Mind Fragment 
 ### Steering
 - [Experience & Loop Direction](docs/steering/experience.md) — Narrative framing, opening sequence, and the layered play loops we are preserving as the north star.
 - [Voice & Tone Sheet](docs/steering/voice-and-tone.md) — Dialogue direction and sample barks that keep the Mind Fragment’s personality intact while we rebuild systems.
+- [Visual Asset Studies — Crash Zone Set](docs/steering/visual-assets.md) — Palette, silhouettes, animation hooks, and a render script for the opening crash-zone core, first worker drone, and local sporeling nest.
 
 ### Planning
 - [Block Programming Plan](docs/planning/block-programming.md) — Architectural goals, player flow, and implementation priorities for the editor and runtime we need to recreate first.

--- a/docs/steering/assets/crash-zone/README.md
+++ b/docs/steering/assets/crash-zone/README.md
@@ -1,0 +1,8 @@
+# Crash-Zone Render Output
+
+Run `tools/render_crash_zone_assets.py` to regenerate the PNGs referenced in
+`docs/steering/visual-assets.md`. The script reconstructs the pixel grids defined
+in the study and exports 48×48 and 96×96 renders by default.
+
+The tool depends on Pillow. Install it with `pip install pillow` before running
+the script.

--- a/docs/steering/visual-assets.md
+++ b/docs/steering/visual-assets.md
@@ -1,0 +1,124 @@
+# Visual Asset Studies — Crash Zone Set
+
+These studies capture the opening crash-zone visuals we need for early prototypes. Each motif is designed to scale from rough block-outs to eventual production art without losing the Mind Fragment feel.
+
+## Palette Overview
+- **Carry-over:** Keep the cooled-metal blues and ember oranges from the original prototype’s HUD for continuity with existing narrative beats.
+- **New Work:** Introduce muted violets and moss greens to emphasise alien twilight and the gentle ethical tension around disturbing local life.
+
+| Swatch | Hex | Usage |
+| --- | --- | --- |
+| ![#1f2a44](https://via.placeholder.com/16/1f2a44/1f2a44.png) | `#1F2A44` | Night-sky shadows, chassis recesses. |
+| ![#3c6ba6](https://via.placeholder.com/16/3c6ba6/3c6ba6.png) | `#3C6BA6` | Powered plating highlights. |
+| ![#f38b2a](https://via.placeholder.com/16/f38b2a/f38b2a.png) | `#F38B2A` | Ember core glow, warning trims. |
+| ![#8d4fd3](https://via.placeholder.com/16/8d4fd3/8d4fd3.png) | `#8D4FD3` | Exotic energy veins. |
+| ![#5a8453](https://via.placeholder.com/16/5a8453/5a8453.png) | `#5A8453` | Local flora, nest cushioning. |
+
+> **Call-out — Workflow**
+> Use these values as the base palette in Figma or Aseprite. When building pixel or vector passes, stick to this quintet and use luminosity shifts rather than new hues to keep the crash zone cohesive.
+
+## Asset 1 — Mind Fragment Core (Crash Resting State)
+- **Carry-over:** Retains the fractured plating silhouette and asymmetric ember glow from the legacy splash art.
+- **Purpose:** Serves as the player avatar on the world map and in UI call-outs. Needs to read clearly at 48×48 and 96×96.
+- **Shape Notes:** Weighted heavily on the left to imply imminent slide; exposed conduits on the right hint at vulnerability.
+
+> **Export Reminder** — Run `python tools/render_crash_zone_assets.py` to rebuild
+> `docs/steering/assets/crash-zone/mind-fragment-core_48.png` and
+> `_96.png` variants.
+
+```
+..aaAAaa..
+.aBBBBBBa.
+ABBBBBBBBA
+ABBCDDCBBA
+ABBCEEDBBA
+ABBCEEDBBA
+ABBCDDCBBA
+ABBBBBBBBA
+.aBBBBBBa.
+..aaAAaa..
+```
+
+Legend: `A=#1F2A44`, `B=#3C6BA6`, `C=#8D4FD3`, `D=#F38B2A`, `E=#5A8453`, `a` is 30% opacity of `#1F2A44` for rim glow.
+
+### Animation Hooks
+- Idle shimmer: pulse the `D` pixels on a 2-second sine curve.
+- Damage feedback: briefly invert `B` to `D` and desaturate `C` when integrity drops.
+
+## Asset 2 — Worker-M0 Drone (First Craftable Chassis)
+- **New Work:** Built to match the revised block-programming-first onboarding; previous drone art was too busy for quick reads.
+- **Purpose:** Appears as both an in-world unit and a HUD portrait. Requires clear module slots for tutorial overlays.
+- **Silhouette Beats:** Wide stance, low profile; forward sensor “beak” communicates curiosity.
+
+> **Export Reminder** — The render script will output
+> `worker-m0-drone_48.png` and `_96.png` under
+> `docs/steering/assets/crash-zone/`.
+
+```
+...AA....
+..ABBBA..
+.ABCCCBa.
+ABCDDDBBA
+BBCD1DBCB
+ABCDDDBBA
+.ABCCCBa.
+..ABBBA..
+...AA....
+```
+
+Legend: `A=#1F2A44`, `B=#3C6BA6`, `C=#8D4FD3`, `D=#5A8453`, `1=#F38B2A` (core eye), `a` is 40% opacity of `#3C6BA6` for soft limb light.
+
+### Module Call-outs
+1. **Motor Mounts:** Outer `B` pads — swap palette accent to indicate upgraded mobility modules.
+2. **Scanner Array:** `1` pixel — animate with a rotating triangle mask to show sweep.
+3. **Manipulator Hardpoint:** Lower `C` strip — brightens when carrying resources.
+
+## Asset 3 — Nestled Sporeling (Local Fauna Home)
+- **New Work:** Visual language for the ethical-choice encounters; must look delicate yet bioluminescent.
+- **Purpose:** Environmental prop that reacts to player programming decisions (disturb vs. protect).
+- **Lighting:** Soft moss bed with an internal lavender glow.
+
+> **Export Reminder** — Use the render script to regenerate
+> `nestled-sporeling_48.png` and `_96.png` in
+> `docs/steering/assets/crash-zone/`.
+
+```
+....aaa....
+...aBBBaa..
+..aBEEEBAa.
+.aBEEfEEBa.
+.aBEFFFEBa.
+.aBEEfEEBa.
+..aBEEEBAa.
+...aBBBaa..
+....aaa....
+```
+
+Legend: `A=#1F2A44` anchor roots, `B=#5A8453`, `E=#8D4FD3`, `F=#F38B2A` at 60% opacity for pulsating spores, `f` is 30% opacity of `#F38B2A`, `a` is 25% opacity of `#1F2A44` for soft shading.
+
+### Interaction Notes
+- When robots disturb the nest, increase the intensity of `F` pixels and add particle motes drifting upward.
+- Protective programmes dim `F` and expand the `E` region by one pixel to show growth.
+
+## Implementation Checklist
+- Run `python tools/render_crash_zone_assets.py` to export 48×48 and 96×96 PNGs
+  with nearest-neighbour scaling so the studies stay crisp.
+- Store the generated files under `docs/steering/assets/crash-zone/` so future
+  updates stay discoverable from this study.
+- Bundle palette swatches as a shared ASE/ACO file for cross-tool consistency.
+- Document animation timings alongside block-programming tutorials so art and
+  logic stay in sync.
+
+## Rendering Automation
+
+The crash-zone render script at `tools/render_crash_zone_assets.py` rebuilds the
+pixel studies directly from these grids. Install Pillow (`pip install pillow`)
+and run:
+
+```bash
+python tools/render_crash_zone_assets.py
+```
+
+Use `--dry-run` to inspect the output paths, `--sizes` to request additional
+square resolutions, and `--include-base` if you need the unscaled grids for
+reference.

--- a/tools/render_crash_zone_assets.py
+++ b/tools/render_crash_zone_assets.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Render the crash-zone pixel studies described in docs/steering/visual-assets.md.
+
+The script reconstructs each study from the ASCII grids and legends in the
+steering document, then exports nearest-neighbour scaled PNGs. Pillow must be
+installed in the environment running this tool.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence, Tuple
+
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class AssetDefinition:
+    """Container for the ASCII grid and palette legend used by an asset."""
+
+    slug: str
+    grid: Sequence[str]
+    legend: Mapping[str, Tuple[str | None, float]]
+
+
+ASSETS: Tuple[AssetDefinition, ...] = (
+    AssetDefinition(
+        slug="mind-fragment-core",
+        grid=(
+            "..aaAAaa..",
+            ".aBBBBBBa.",
+            "ABBBBBBBBA",
+            "ABBCDDCBBA",
+            "ABBCEEDBBA",
+            "ABBCEEDBBA",
+            "ABBCDDCBBA",
+            "ABBBBBBBBA",
+            ".aBBBBBBa.",
+            "..aaAAaa..",
+        ),
+        legend={
+            ".": (None, 0.0),
+            "A": ("#1F2A44", 1.0),
+            "B": ("#3C6BA6", 1.0),
+            "C": ("#8D4FD3", 1.0),
+            "D": ("#F38B2A", 1.0),
+            "E": ("#5A8453", 1.0),
+            "a": ("#1F2A44", 0.3),
+        },
+    ),
+    AssetDefinition(
+        slug="worker-m0-drone",
+        grid=(
+            "...AA....",
+            "..ABBBA..",
+            ".ABCCCBa.",
+            "ABCDDDBBA",
+            "BBCD1DBCB",
+            "ABCDDDBBA",
+            ".ABCCCBa.",
+            "..ABBBA..",
+            "...AA....",
+        ),
+        legend={
+            ".": (None, 0.0),
+            "A": ("#1F2A44", 1.0),
+            "B": ("#3C6BA6", 1.0),
+            "C": ("#8D4FD3", 1.0),
+            "D": ("#5A8453", 1.0),
+            "a": ("#3C6BA6", 0.4),
+            "1": ("#F38B2A", 1.0),
+        },
+    ),
+    AssetDefinition(
+        slug="nestled-sporeling",
+        grid=(
+            "....aaa....",
+            "...aBBBaa..",
+            "..aBEEEBAa.",
+            ".aBEEfEEBa.",
+            ".aBEFFFEBa.",
+            ".aBEEfEEBa.",
+            "..aBEEEBAa.",
+            "...aBBBaa..",
+            "....aaa....",
+        ),
+        legend={
+            ".": (None, 0.0),
+            "A": ("#1F2A44", 1.0),
+            "B": ("#5A8453", 1.0),
+            "E": ("#8D4FD3", 1.0),
+            "F": ("#F38B2A", 0.6),
+            "a": ("#1F2A44", 0.25),
+            "f": ("#F38B2A", 0.3),
+        },
+    ),
+)
+
+DEFAULT_SIZES: Tuple[int, ...] = (48, 96)
+DEFAULT_OUTPUT_DIR = Path("docs/steering/assets/crash-zone")
+TRANSPARENT_PIXEL = (0, 0, 0, 0)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate crash-zone PNGs from the ASCII grids recorded in "
+            "docs/steering/visual-assets.md."
+        )
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=(
+            "Directory to store rendered PNGs. Defaults to docs/steering/"
+            "assets/crash-zone."
+        ),
+    )
+    parser.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SIZES),
+        help="Square resolutions to export (e.g. 48 96).",
+    )
+    parser.add_argument(
+        "--include-base",
+        action="store_true",
+        help="Also save the unscaled base grids for inspection.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the files that would be generated without writing them.",
+    )
+    return parser
+
+
+def hex_to_rgb(hex_colour: str) -> Tuple[int, int, int]:
+    colour = hex_colour.lstrip("#")
+    if len(colour) != 6:
+        raise ValueError(f"Unsupported colour value: {hex_colour!r}")
+    return tuple(int(colour[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def to_rgba(hex_colour: str | None, opacity: float) -> Tuple[int, int, int, int]:
+    if hex_colour is None or opacity <= 0.0:
+        return TRANSPARENT_PIXEL
+    rgb = hex_to_rgb(hex_colour)
+    alpha = int(opacity * 255 + 0.5)
+    alpha = max(0, min(alpha, 255))
+    return rgb + (alpha,)
+
+
+def normalise_legend(legend: Mapping[str, Tuple[str | None, float]]) -> Dict[str, Tuple[int, int, int, int]]:
+    return {symbol: to_rgba(hex_colour, opacity) for symbol, (hex_colour, opacity) in legend.items()}
+
+
+def render_asset_grid(asset: AssetDefinition) -> Image.Image:
+    legend = normalise_legend(asset.legend)
+    base_dimension = max(len(asset.grid), *(len(row) for row in asset.grid))
+    canvas = Image.new("RGBA", (base_dimension, base_dimension), TRANSPARENT_PIXEL)
+
+    vertical_offset = (base_dimension - len(asset.grid)) // 2
+    for row_index, row in enumerate(asset.grid):
+        horizontal_offset = (base_dimension - len(row)) // 2
+        for column_index, symbol in enumerate(row):
+            try:
+                pixel = legend[symbol]
+            except KeyError as error:
+                available = ", ".join(sorted(legend))
+                raise KeyError(
+                    f"Symbol {symbol!r} in {asset.slug} is not defined. "
+                    f"Known symbols: {available}"
+                ) from error
+            if pixel == TRANSPARENT_PIXEL:
+                continue
+            canvas.putpixel(
+                (horizontal_offset + column_index, vertical_offset + row_index), pixel
+            )
+    return canvas
+
+
+def export_asset(asset: AssetDefinition, sizes: Iterable[int], output_dir: Path, include_base: bool, dry_run: bool) -> None:
+    base_image = render_asset_grid(asset)
+
+    if include_base:
+        base_name = f"{asset.slug}_base.png"
+        base_path = output_dir / base_name
+        if dry_run:
+            print(f"[dry-run] {base_path}")
+        else:
+            base_image.save(base_path)
+            print(f"Saved {base_path}")
+
+    for size in sorted({size for size in sizes if size > 0}):
+        filename = f"{asset.slug}_{size}.png"
+        target_path = output_dir / filename
+        if dry_run:
+            print(f"[dry-run] {target_path}")
+            continue
+        scaled = base_image.resize((size, size), resample=Image.NEAREST)
+        scaled.save(target_path)
+        print(f"Saved {target_path}")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    output_dir: Path = args.output_dir
+    if not args.dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    for asset in ASSETS:
+        export_asset(
+            asset=asset,
+            sizes=args.sizes,
+            output_dir=output_dir,
+            include_base=args.include_base,
+            dry_run=args.dry_run,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Pillow-based helper that reconstructs the crash-zone studies from their ASCII grids and exports PNG renders on demand
- document how to run the generator, update the steering notes with export reminders, and remove the committed binary renders
- flag the new workflow in the repository map and keep an asset-readme placeholder so the target directory stays discoverable

## Testing
- python tools/render_crash_zone_assets.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68cd80c58b38832cb6e726ba5ef121f6