### PR TITLE
Add CI workflow and scope Pixi aliases to Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,19 +4,25 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
+const pixiTestAliases = {
+  'pixi.js': resolve(rootDir, 'src/test/stubs/pixi.js'),
+  'pixi-viewport': resolve(rootDir, 'src/test/stubs/pixi-viewport.js'),
+};
 
-export default defineConfig({
-  base: './',
-  resolve: {
-    alias: {
-      'pixi.js': resolve(rootDir, 'src/test/stubs/pixi.js'),
-      'pixi-viewport': resolve(rootDir, 'src/test/stubs/pixi-viewport.js'),
+export default defineConfig(() => {
+  const isVitest = Boolean(process.env.VITEST);
+
+  return {
+    base: './',
+    resolve: {
+      alias: isVitest ? pixiTestAliases : {},
     },
-  },
-  plugins: [react()],
-  test: {
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.js',
-    css: false
-  }
+    plugins: [react()],
+    test: {
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.js',
+      css: false,
+      alias: pixiTestAliases,
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the install, build, and test steps on every push
- scope the Pixi stub aliases to the Vitest environment so production builds use the real packages

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9dd7d00c832e92ba9e7a5a5f9da5