### PR TITLE
Fix Pixi initialisation and add Playwright smoke test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.3",
@@ -1079,6 +1080,22 @@
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3743,6 +3760,53 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.3",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './playwright',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run preview -- --host 0.0.0.0 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/playwright/simulation-shell.spec.js
+++ b/playwright/simulation-shell.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('simulation shell initialises without runtime errors', async ({ page }) => {
+  const pageErrors = [];
+  const consoleErrors = [];
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error);
+  });
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Simulation Shell' })).toBeVisible();
+  await expect(page.locator('.simulation-shell canvas')).toHaveCount(1);
+
+  expect(pageErrors).toEqual([]);
+  expect(consoleErrors).toEqual([]);
+});

--- a/src/simulation/SimulationShell.jsx
+++ b/src/simulation/SimulationShell.jsx
@@ -15,9 +15,8 @@ function SimulationShell() {
     let disposed = false;
     let cleanupResize;
 
-    const init = async () => {
-      app = new Application();
-      await app.init({
+    const init = () => {
+      app = new Application({
         backgroundAlpha: 0,
         antialias: true,
         resolution: window.devicePixelRatio || 1,
@@ -30,7 +29,7 @@ function SimulationShell() {
         return;
       }
 
-      containerRef.current.appendChild(app.canvas);
+      containerRef.current.appendChild(app.view);
       rootScene = new RootScene(app);
       rootScene.resize(app.renderer.width, app.renderer.height);
 
@@ -52,7 +51,7 @@ function SimulationShell() {
       cleanupResize?.();
       rootScene?.destroy();
       if (app) {
-        const view = app.canvas;
+        const view = app.view;
         view?.remove?.();
         app.destroy(true, { children: true });
       }

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -14,19 +14,18 @@ vi.mock('pixi.js', () => {
       this.width = 0;
       this.height = 0;
       this.events = {};
+      this.generateTexture = vi.fn(() => ({ destroy: vi.fn() }));
     }
   }
 
   class MockApplication {
-    constructor() {
+    constructor(options = {}) {
       this.ticker = new MockTicker();
       this.renderer = new MockRenderer();
-      this.stage = { addChild: vi.fn() };
-      this.canvas = {};
-    }
-
-    async init() {
-      return this;
+      this.stage = { addChild: vi.fn(), destroy: vi.fn() };
+      this.view = { remove: vi.fn() };
+      this.resizeTo = options.resizeTo ?? null;
+      this.render = vi.fn();
     }
 
     destroy() {}

--- a/src/test/stubs/pixi.js
+++ b/src/test/stubs/pixi.js
@@ -1,14 +1,18 @@
 export class Application {
-  constructor() {
-    this.renderer = { width: 0, height: 0, events: {} };
+  constructor(options = {}) {
+    this.renderer = {
+      width: 0,
+      height: 0,
+      events: {},
+      generateTexture: () => ({ destroy: () => {} }),
+    };
     this.ticker = { add: () => {}, remove: () => {} };
-    this.stage = { addChild: () => {} };
-    this.canvas = {};
+    this.stage = { addChild: () => {}, destroy: () => {} };
+    this.view = { remove: () => {} };
+    this.resizeTo = options.resizeTo ?? null;
   }
 
-  async init() {
-    return this;
-  }
+  render() {}
 
   destroy() {}
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { configDefaults } from 'vitest/config';
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const pixiTestAliases = {
@@ -23,6 +24,7 @@ export default defineConfig(() => {
       setupFiles: './src/test/setup.js',
       css: false,
       alias: pixiTestAliases,
+      exclude: [...configDefaults.exclude, 'playwright/**'],
     },
   };
 });


### PR DESCRIPTION
## Summary
- replace the Pixi application initialisation in the simulation shell with the synchronous constructor and mount the returned view element
- update the Pixi test stubs and Vitest configuration to reflect the new API and exclude Playwright specs
- add a Playwright smoke test and configuration that exercises the production preview in headless Chromium

## Testing
- npm test
- npm run build
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cda43f87b4832e9e28092a6338e2dc