### PR TITLE
Update Pixi runtime and add Playwright coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Playwright tests
+        run: npx playwright test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mind-fragment-app",
       "version": "0.1.0",
       "dependencies": {
-        "pixi-viewport": "^5.1.0",
-        "pixi.js": "^7.4.3",
+        "pixi-viewport": "^6.0.3",
+        "pixi.js": "^8.13.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -951,136 +951,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@pixi/color": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
-      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/colord": "^2.9.6"
-      }
-    },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
       "license": "MIT"
-    },
-    "node_modules/@pixi/constants": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
-      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@pixi/core": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
-      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
-      }
-    },
-    "node_modules/@pixi/display": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
-      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
-      }
-    },
-    "node_modules/@pixi/extensions": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
-      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@pixi/interaction": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
-      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
-      }
-    },
-    "node_modules/@pixi/math": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
-      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@pixi/runner": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
-      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@pixi/settings": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
-      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10"
-      }
-    },
-    "node_modules/@pixi/ticker": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
-      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/extensions": "6.5.10",
-        "@pixi/settings": "6.5.10"
-      }
-    },
-    "node_modules/@pixi/utils": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
-      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/settings": "6.5.10"
-      }
     },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
@@ -1586,9 +1461,9 @@
       "license": "MIT"
     },
     "node_modules/@types/earcut": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
-      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1597,13 +1472,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1769,6 +1637,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -1941,6 +1824,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1954,6 +1838,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2272,6 +2157,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2283,9 +2169,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
@@ -2312,6 +2198,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2321,6 +2208,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2358,6 +2246,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2445,11 +2334,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "license": "MIT",
-      "peer": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -2531,6 +2419,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2560,6 +2449,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2584,6 +2474,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2593,10 +2484,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2645,6 +2546,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2673,6 +2575,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3021,6 +2924,12 @@
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "license": "MIT"
     },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3147,6 +3056,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3229,6 +3139,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3285,6 +3196,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3336,430 +3253,36 @@
       }
     },
     "node_modules/pixi-viewport": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.1.0.tgz",
-      "integrity": "sha512-CNvw0H+Z+OfVCIAUkQ5TmwLEe+7W1dcIS6Wjt+AwQXWEjZPL3QpH2xFE/GAaqZ0qRkDxDV07dbRetZULFOvoew==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
+      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
       "license": "MIT",
       "peerDependencies": {
-        "@pixi/display": "^6.5.8",
-        "@pixi/interaction": "^6.5.8",
-        "@pixi/math": "^6.5.8",
-        "@pixi/ticker": "^6.5.8"
+        "pixi.js": ">=8"
       }
     },
     "node_modules/pixi.js": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
-      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
+      "version": "8.13.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.13.2.tgz",
+      "integrity": "sha512-9KVGZ4a99TA5SwUEWs9m5gliX6XUCS1aGc/DOPsXxpqLMDRa+FhzpT5ao9z1UwLYJkSvt3rcQs+aZXECBHSSHg==",
       "license": "MIT",
       "dependencies": {
-        "@pixi/accessibility": "7.4.3",
-        "@pixi/app": "7.4.3",
-        "@pixi/assets": "7.4.3",
-        "@pixi/compressed-textures": "7.4.3",
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/events": "7.4.3",
-        "@pixi/extensions": "7.4.3",
-        "@pixi/extract": "7.4.3",
-        "@pixi/filter-alpha": "7.4.3",
-        "@pixi/filter-blur": "7.4.3",
-        "@pixi/filter-color-matrix": "7.4.3",
-        "@pixi/filter-displacement": "7.4.3",
-        "@pixi/filter-fxaa": "7.4.3",
-        "@pixi/filter-noise": "7.4.3",
-        "@pixi/graphics": "7.4.3",
-        "@pixi/mesh": "7.4.3",
-        "@pixi/mesh-extras": "7.4.3",
-        "@pixi/mixin-cache-as-bitmap": "7.4.3",
-        "@pixi/mixin-get-child-by-name": "7.4.3",
-        "@pixi/mixin-get-global-position": "7.4.3",
-        "@pixi/particle-container": "7.4.3",
-        "@pixi/prepare": "7.4.3",
-        "@pixi/sprite": "7.4.3",
-        "@pixi/sprite-animated": "7.4.3",
-        "@pixi/sprite-tiling": "7.4.3",
-        "@pixi/spritesheet": "7.4.3",
-        "@pixi/text": "7.4.3",
-        "@pixi/text-bitmap": "7.4.3",
-        "@pixi/text-html": "7.4.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/accessibility": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
-      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/events": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/app": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
-      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/assets": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
-      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/css-font-loading-module": "^0.0.12"
-      },
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/compressed-textures": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
-      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.3",
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/constants": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
-      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
-      "license": "MIT"
-    },
-    "node_modules/pixi.js/node_modules/@pixi/core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
-      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/color": "7.4.3",
-        "@pixi/constants": "7.4.3",
-        "@pixi/extensions": "7.4.3",
-        "@pixi/math": "7.4.3",
-        "@pixi/runner": "7.4.3",
-        "@pixi/settings": "7.4.3",
-        "@pixi/ticker": "7.4.3",
-        "@pixi/utils": "7.4.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/display": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
-      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/events": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
-      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extensions": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
-      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
-      "license": "MIT"
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extract": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
-      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-alpha": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
-      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-blur": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
-      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-color-matrix": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
-      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-displacement": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
-      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-fxaa": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
-      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-noise": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
-      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/graphics": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
-      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/math": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
-      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
-      "license": "MIT"
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
-      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh-extras": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
-      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/mesh": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
-      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
-      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
-      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/particle-container": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
-      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/prepare": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
-      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/graphics": "7.4.3",
-        "@pixi/text": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/runner": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
-      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
-      "license": "MIT"
-    },
-    "node_modules/pixi.js/node_modules/@pixi/settings": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
-      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/constants": "7.4.3",
+        "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
-        "ismobilejs": "^1.1.0"
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
-      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-animated": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
-      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-tiling": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
-      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/spritesheet": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
-      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.3",
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
-      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-bitmap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
-      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.3",
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/mesh": "7.4.3",
-        "@pixi/text": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-html": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
-      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3",
-        "@pixi/text": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/ticker": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
-      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/extensions": "7.4.3",
-        "@pixi/settings": "7.4.3",
-        "@pixi/utils": "7.4.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/utils": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
-      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/color": "7.4.3",
-        "@pixi/constants": "7.4.3",
-        "@pixi/settings": "7.4.3",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^4.0.0",
-        "url": "^0.11.0"
-      }
-    },
-    "node_modules/pixi.js/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.55.0",
@@ -3883,21 +3406,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/querystringify": {
@@ -4134,6 +3642,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4153,6 +3662,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4169,6 +3679,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4187,6 +3698,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4299,6 +3811,15 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
+      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4431,19 +3952,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.4.1",
-        "qs": "^6.12.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -4454,12 +3962,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "pixi-viewport": "^5.1.0",
-    "pixi.js": "^7.4.3",
+    "pixi-viewport": "^6.0.3",
+    "pixi.js": "^8.13.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/playwright/block-workspace.spec.js
+++ b/playwright/block-workspace.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+const workspaceDropzone = '[data-testid="workspace-dropzone"]';
+
+async function performDragAndDrop(page, sourceSelector, targetSelector) {
+  await page.evaluate(({ sourceSelector, targetSelector }) => {
+    const source = document.querySelector(sourceSelector);
+    const target = document.querySelector(targetSelector);
+    if (!source) {
+      throw new Error(`No drag source found for selector: ${sourceSelector}`);
+    }
+    if (!target) {
+      throw new Error(`No drop target found for selector: ${targetSelector}`);
+    }
+
+    const dataTransfer = new DataTransfer();
+    source.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }));
+    source.dispatchEvent(new DragEvent('dragend', { bubbles: true, cancelable: true, dataTransfer }));
+  }, { sourceSelector, targetSelector });
+}
+
+async function dragPaletteBlock(page, blockId, targetSelector) {
+  await performDragAndDrop(page, `[data-testid="palette-${blockId}"]`, targetSelector);
+}
+
+async function dragWorkspaceBlock(page, blockId, targetSelector) {
+  await performDragAndDrop(page, `[data-testid="block-${blockId}"]`, targetSelector);
+}
+
+test.describe('block workspace drag-and-drop', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('adds a palette block to the workspace root', async ({ page }) => {
+    await dragPaletteBlock(page, 'start', workspaceDropzone);
+
+    await expect(page.getByTestId('block-start')).toHaveCount(1);
+    await expect(page.locator(`${workspaceDropzone} .block`)).toHaveCount(1);
+  });
+
+  test('nests a block inside another block slot', async ({ page }) => {
+    await dragPaletteBlock(page, 'start', workspaceDropzone);
+    await dragPaletteBlock(page, 'move', '[data-testid="slot-do-dropzone"]');
+
+    const slot = page.getByTestId('slot-do-dropzone');
+    await expect(slot.getByTestId('block-move')).toHaveCount(1);
+    await expect(slot.locator('.slot-placeholder')).toHaveCount(0);
+  });
+
+  test('moves a block between containers', async ({ page }) => {
+    await dragPaletteBlock(page, 'start', workspaceDropzone);
+    await dragPaletteBlock(page, 'move', '[data-testid="slot-do-dropzone"]');
+
+    await dragWorkspaceBlock(page, 'move', workspaceDropzone);
+
+    const slot = page.getByTestId('slot-do-dropzone');
+    await expect(slot.locator('.slot-placeholder')).toHaveCount(1);
+    await expect(page.locator(`${workspaceDropzone} .block`)).toHaveCount(2);
+    await expect(page.locator(`${workspaceDropzone} [data-testid="block-move"]`)).toHaveCount(1);
+  });
+});

--- a/playwright/simulation-shell.spec.js
+++ b/playwright/simulation-shell.spec.js
@@ -18,6 +18,10 @@ test('simulation shell initialises without runtime errors', async ({ page }) => 
   await expect(page.getByRole('heading', { name: 'Simulation Shell' })).toBeVisible();
   await expect(page.locator('.simulation-shell canvas')).toHaveCount(1);
 
+  await page.mouse.move(10, 10);
+  await page.mouse.move(200, 150);
+  await page.mouse.move(350, 220);
+
   expect(pageErrors).toEqual([]);
   expect(consoleErrors).toEqual([]);
 });

--- a/src/simulation/assetService.js
+++ b/src/simulation/assetService.js
@@ -52,16 +52,18 @@ export const assetService = new AssetService();
 assetService.defineVectorAsset('robot/chassis', ({ radius = 28, fill = 0x4ecdc4, stroke = 0x1a535c } = {}) => {
   const graphic = new Graphics();
 
-  graphic.beginFill(fill, 0.92);
-  graphic.lineStyle({ width: 4, color: stroke, alpha: 1 });
-  graphic.drawCircle(0, 0, radius);
-  graphic.endFill();
+  graphic.circle(0, 0, radius);
+  graphic.fill({ color: fill, alpha: 0.92 });
+  graphic.setStrokeStyle({ width: 4, color: stroke, alpha: 1 });
+  graphic.stroke();
 
-  graphic.lineStyle({ width: 2, color: 0xffffff, alpha: 0.65 });
+  graphic.beginPath();
+  graphic.setStrokeStyle({ width: 2, color: 0xffffff, alpha: 0.65 });
   graphic.moveTo(-radius * 0.6, 0);
   graphic.lineTo(radius * 0.6, 0);
   graphic.moveTo(0, -radius * 0.6);
   graphic.lineTo(0, radius * 0.6);
+  graphic.stroke();
 
   return graphic;
 });

--- a/src/simulation/rootScene.js
+++ b/src/simulation/rootScene.js
@@ -57,7 +57,7 @@ export class RootScene {
     const layer = new Container();
 
     const grid = new Graphics();
-    grid.lineStyle({ width: 1, color: 0x2c3e50, alpha: 0.35 });
+    grid.setStrokeStyle({ width: 1, color: 0x2c3e50, alpha: 0.35 });
     for (let x = -GRID_EXTENT; x <= GRID_EXTENT; x += GRID_SPACING) {
       grid.moveTo(x, -GRID_EXTENT);
       grid.lineTo(x, GRID_EXTENT);
@@ -66,13 +66,15 @@ export class RootScene {
       grid.moveTo(-GRID_EXTENT, y);
       grid.lineTo(GRID_EXTENT, y);
     }
+    grid.stroke();
 
     const axes = new Graphics();
-    axes.lineStyle({ width: 2, color: 0xff6b6b, alpha: 0.75 });
+    axes.setStrokeStyle({ width: 2, color: 0xff6b6b, alpha: 0.75 });
     axes.moveTo(-GRID_EXTENT, 0);
     axes.lineTo(GRID_EXTENT, 0);
     axes.moveTo(0, -GRID_EXTENT);
     axes.lineTo(0, GRID_EXTENT);
+    axes.stroke();
 
     layer.addChild(grid);
     layer.addChild(axes);


### PR DESCRIPTION
## Summary
- upgrade the runtime to pixi.js 8 and pixi-viewport 6, and refresh the simulation shell to use the new Application init API and drawing helpers
- update the asset service and grid renderer to pixi 8 graphics APIs so the scene initialises without pointer errors
- add Playwright coverage for palette-to-workspace drag and drop alongside the existing runtime smoke test, and wire the suite into CI

## Testing
- npm run build
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cda8425fa4832ea04aecc2d95fc8ed