### PR TITLE
Add basic ECS world with component and system support

### DIFF
--- a/src/simulation/ecs/__tests__/world.test.ts
+++ b/src/simulation/ecs/__tests__/world.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { ECSWorld } from '../world';
+
+describe('ECSWorld', () => {
+  it('creates and destroys entities', () => {
+    const world = new ECSWorld();
+    const first = world.createEntity();
+    const second = world.createEntity();
+
+    expect(first).not.toBe(second);
+    expect(world.hasEntity(first)).toBe(true);
+    expect(world.hasEntity(second)).toBe(true);
+
+    world.destroyEntity(first);
+
+    expect(world.hasEntity(first)).toBe(false);
+    expect(world.hasEntity(second)).toBe(true);
+  });
+
+  it('manages components for entities', () => {
+    const world = new ECSWorld();
+    const position = world.defineComponent<{ x: number; y: number }>('position');
+    const entity = world.createEntity();
+
+    position.set(entity, { x: 4, y: 9 });
+
+    expect(position.get(entity)).toEqual({ x: 4, y: 9 });
+
+    world.destroyEntity(entity);
+
+    expect(position.has(entity)).toBe(false);
+    expect(position.get(entity)).toBeUndefined();
+
+    expect(() => position.set(entity, { x: 0, y: 0 })).toThrowError(
+      `Entity ${entity} does not exist in this world.`,
+    );
+  });
+
+  it('filters query results to matching component sets', () => {
+    const world = new ECSWorld();
+    const position = world.defineComponent<{ x: number; y: number }>('position');
+    const velocity = world.defineComponent<{ x: number; y: number }>('velocity');
+
+    const walker = world.createEntity();
+    const statue = world.createEntity();
+
+    position.set(walker, { x: 1, y: 1 });
+    velocity.set(walker, { x: 1, y: 0 });
+    position.set(statue, { x: 5, y: 5 });
+
+    const positionOnly = world.query(position);
+    const moving = world.query(position, velocity);
+
+    expect(positionOnly).toEqual([
+      [walker, { x: 1, y: 1 }],
+      [statue, { x: 5, y: 5 }],
+    ]);
+    expect(moving).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
+  });
+
+  it('runs systems against matching entities', () => {
+    const world = new ECSWorld();
+    const position = world.defineComponent<{ x: number; y: number }>('position');
+    const velocity = world.defineComponent<{ x: number; y: number }>('velocity');
+
+    const mover = world.createEntity();
+    const parked = world.createEntity();
+
+    position.set(mover, { x: 0, y: 0 });
+    velocity.set(mover, { x: 2, y: -1 });
+    position.set(parked, { x: 10, y: 10 });
+
+    world.addSystem({
+      name: 'movement',
+      components: [position, velocity],
+      update: (_, entities, delta) => {
+        for (const [entity, pos, vel] of entities) {
+          position.set(entity, {
+            x: pos.x + vel.x * delta,
+            y: pos.y + vel.y * delta,
+          });
+        }
+      },
+    });
+
+    world.runSystems(0.5);
+
+    expect(position.get(mover)).toEqual({ x: 1, y: -0.5 });
+    expect(position.get(parked)).toEqual({ x: 10, y: 10 });
+  });
+});

--- a/src/simulation/ecs/index.ts
+++ b/src/simulation/ecs/index.ts
@@ -1,0 +1,1 @@
+export * from './world';

--- a/src/simulation/ecs/world.ts
+++ b/src/simulation/ecs/world.ts
@@ -1,0 +1,149 @@
+export type EntityId = number;
+
+export interface ComponentHandle<TValue> {
+  readonly id: symbol;
+  readonly name: string;
+  get(entity: EntityId): TValue | undefined;
+  set(entity: EntityId, value: TValue): void;
+  remove(entity: EntityId): void;
+  has(entity: EntityId): boolean;
+  entries(): IterableIterator<[EntityId, TValue]>;
+}
+
+export type ComponentTuple = readonly ComponentHandle<unknown>[];
+
+type ComponentValueTuple<TComponents extends ComponentTuple> = {
+  [Index in keyof TComponents]: TComponents[Index] extends ComponentHandle<infer TValue> ? TValue : never;
+} extends infer Values
+  ? Values extends readonly unknown[]
+    ? Values
+    : never
+  : never;
+
+export type QueryResult<TComponents extends ComponentTuple> = [
+  EntityId,
+  ...ComponentValueTuple<TComponents>,
+];
+
+export interface System<TComponents extends ComponentTuple = ComponentTuple> {
+  readonly name?: string;
+  readonly components: TComponents;
+  update(world: ECSWorld, entities: Iterable<QueryResult<TComponents>>, delta: number): void;
+}
+
+interface ComponentStore<TValue> extends ComponentHandle<TValue> {
+  readonly store: Map<EntityId, TValue>;
+}
+
+export class ECSWorld {
+  private nextEntityId = 1 as EntityId;
+  private readonly entities = new Set<EntityId>();
+  private readonly components = new Map<symbol, ComponentStore<unknown>>();
+  private readonly systems: System[] = [];
+
+  createEntity(): EntityId {
+    const entity = this.nextEntityId++;
+    this.entities.add(entity);
+    return entity;
+  }
+
+  destroyEntity(entity: EntityId): void {
+    if (!this.entities.delete(entity)) {
+      return;
+    }
+    for (const component of this.components.values()) {
+      component.remove(entity);
+    }
+  }
+
+  hasEntity(entity: EntityId): boolean {
+    return this.entities.has(entity);
+  }
+
+  defineComponent<TValue>(name: string): ComponentHandle<TValue> {
+    if (!name.trim()) {
+      throw new Error('Component names must be non-empty.');
+    }
+    const existing = Array.from(this.components.values()).find((component) => component.name === name);
+    if (existing) {
+      throw new Error(`Component ${name} already defined on this world.`);
+    }
+
+    const store = new Map<EntityId, TValue>();
+    const component: ComponentStore<TValue> = {
+      id: Symbol(name),
+      name,
+      store,
+      get: (entity) => store.get(entity),
+      set: (entity, value) => {
+        this.assertEntityExists(entity);
+        store.set(entity, value);
+      },
+      remove: (entity) => {
+        store.delete(entity);
+      },
+      has: (entity) => store.has(entity),
+      entries: () => store.entries(),
+    };
+
+    this.components.set(component.id, component as ComponentStore<unknown>);
+    return component;
+  }
+
+  addSystem<TComponents extends ComponentTuple>(system: System<TComponents>): void {
+    this.systems.push(system);
+  }
+
+  runSystems(delta: number): void {
+    for (const system of this.systems) {
+      const entities = this.iterateQuery(system.components);
+      system.update(this, entities, delta);
+    }
+  }
+
+  query<TComponents extends ComponentTuple>(
+    ...components: TComponents
+  ): QueryResult<TComponents>[] {
+    return Array.from(this.iterateQuery(components));
+  }
+
+  private *iterateQuery<TComponents extends ComponentTuple>(
+    components: TComponents,
+  ): IterableIterator<QueryResult<TComponents>> {
+    if (components.length === 0) {
+      for (const entity of this.entities) {
+        yield [entity] as unknown as QueryResult<TComponents>;
+      }
+      return;
+    }
+
+    const [first, ...rest] = components;
+
+    for (const [entity, firstValue] of first.entries()) {
+      if (!this.entities.has(entity)) {
+        continue;
+      }
+
+      const collected: unknown[] = [firstValue];
+      let missing = false;
+
+      for (const component of rest) {
+        if (!component.has(entity)) {
+          missing = true;
+          break;
+        }
+        collected.push(component.get(entity)!);
+      }
+
+      if (!missing) {
+        yield [entity, ...collected] as unknown as QueryResult<TComponents>;
+      }
+    }
+  }
+
+  private assertEntityExists(entity: EntityId): void {
+    if (!this.entities.has(entity)) {
+      throw new Error(`Entity ${entity} does not exist in this world.`);
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,13 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "types": ["vitest", "vite/client", "@testing-library/jest-dom"]
+    "types": [
+      "vitest",
+      "vite/client",
+      "@testing-library/jest-dom",
+      "@playwright/test",
+      "node"
+    ]
   },
   "include": [
     "src",


### PR DESCRIPTION
## Summary
- implement an `ECSWorld` with entity lifecycle management, component stores, queries, and a simple system runner
- expose the ECS entry point and add typings for node and Playwright consumers
- cover the ECS primitives with Vitest unit tests

## Testing
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cdbd140aa4832eaac8c1b5d245bdb6