### PR TITLE
Implement block runtime execution and simulation controls

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: 'npm run preview -- --host 0.0.0.0 --port 4173',
+    command: 'npm run build && npm run preview -- --host 0.0.0.0 --port 4173',
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,
-    timeout: 120000,
+    timeout: 180000,
   },
   projects: [
     {

--- a/playwright/simulation-shell.spec.ts
+++ b/playwright/simulation-shell.spec.ts
@@ -15,7 +15,8 @@ test('simulation shell initialises without runtime errors', async ({ page }) => 
   });
 
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Simulation Shell' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Simulation' })).toBeVisible();
+  await expect(page.getByLabel('Simulation shell')).toBeVisible();
   await expect(page.locator('.simulation-shell canvas')).toHaveCount(1);
 
   await page.mouse.move(10, 10);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import SimulationShell from './simulation/SimulationShell';
 import ModuleInventory from './components/ModuleInventory';
 import { BLOCK_LIBRARY } from './blocks/library';
 import { useBlockWorkspace } from './hooks/useBlockWorkspace';
+import RuntimeControls from './components/RuntimeControls';
 
 function App(): JSX.Element {
   const { workspace, handleDrop } = useBlockWorkspace();
@@ -24,7 +25,8 @@ function App(): JSX.Element {
           <Workspace blocks={workspace} onDrop={handleDrop} />
         </section>
         <section className="panel simulation-panel">
-          <h2>Simulation Shell</h2>
+          <h2>Simulation</h2>
+          <RuntimeControls workspace={workspace} />
           <SimulationShell />
           <ModuleInventory />
         </section>

--- a/src/components/RuntimeControls.tsx
+++ b/src/components/RuntimeControls.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { WorkspaceState } from '../types/blocks';
+import type { Diagnostic } from '../simulation/runtime/blockProgram';
+import { compileWorkspaceProgram } from '../simulation/runtime/blockProgram';
+import { useSimulationRuntime } from '../hooks/useSimulationRuntime';
+
+interface RuntimeControlsProps {
+  workspace: WorkspaceState;
+}
+
+const formatStatus = (status: string): string => {
+  switch (status) {
+    case 'running':
+      return 'Executing routine';
+    case 'completed':
+      return 'Routine completed';
+    default:
+      return 'Idle';
+  }
+};
+
+const RuntimeControls = ({ workspace }: RuntimeControlsProps): JSX.Element => {
+  const { status, runProgram, stopProgram } = useSimulationRuntime();
+  const [diagnostics, setDiagnostics] = useState<Diagnostic[]>([]);
+
+  const handleRun = useCallback(() => {
+    const result = compileWorkspaceProgram(workspace);
+    const stepCount = result.program.instructions.length;
+    const infoMessage = stepCount
+      ? [{
+          severity: 'info' as const,
+          message: `Queued ${stepCount} ${stepCount === 1 ? 'step' : 'steps'} for execution.`,
+        }]
+      : [];
+    setDiagnostics(result.diagnostics.length > 0 ? result.diagnostics : infoMessage);
+    runProgram(result.program);
+  }, [runProgram, workspace]);
+
+  const handleStop = useCallback(() => {
+    stopProgram();
+  }, [stopProgram]);
+
+  const statusLabel = useMemo(() => formatStatus(status), [status]);
+
+  return (
+    <div className="runtime-controls" data-testid="runtime-controls">
+      <div className="runtime-actions">
+        <button
+          type="button"
+          onClick={handleRun}
+          disabled={status === 'running'}
+          className="runtime-button primary"
+          data-testid="run-program"
+        >
+          {status === 'running' ? 'Running…' : 'Run Program'}
+        </button>
+        <button
+          type="button"
+          onClick={handleStop}
+          disabled={status !== 'running'}
+          className="runtime-button secondary"
+          data-testid="stop-program"
+        >
+          Stop
+        </button>
+      </div>
+      <p className="runtime-status">
+        <strong>Status:</strong> {statusLabel}
+      </p>
+      {diagnostics.length > 0 ? (
+        <ul className="runtime-diagnostics">
+          {diagnostics.map((diagnostic, index) => (
+            <li key={`${diagnostic.message}-${index}`} data-severity={diagnostic.severity}>
+              <span className="runtime-diagnostic-icon" aria-hidden="true">
+                {diagnostic.severity === 'warning' ? '⚠️' : 'ℹ️'}
+              </span>
+              <span>{diagnostic.message}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="runtime-hint">Drag a "When Started" block into the workspace, add movement blocks, and press Run.</p>
+      )}
+    </div>
+  );
+};
+
+export default RuntimeControls;

--- a/src/hooks/useSimulationRuntime.ts
+++ b/src/hooks/useSimulationRuntime.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { CompiledProgram } from '../simulation/runtime/blockProgram';
+import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
+import { simulationRuntime } from '../state/simulationRuntime';
+
+export interface SimulationRuntimeControls {
+  status: ProgramRunnerStatus;
+  runProgram: (program: CompiledProgram) => void;
+  stopProgram: () => void;
+}
+
+export const useSimulationRuntime = (): SimulationRuntimeControls => {
+  const [status, setStatus] = useState<ProgramRunnerStatus>(simulationRuntime.getStatus());
+
+  useEffect(() => simulationRuntime.subscribe(setStatus), []);
+
+  const runProgram = useCallback((program: CompiledProgram) => {
+    simulationRuntime.runProgram(program);
+  }, []);
+
+  const stopProgram = useCallback(() => {
+    simulationRuntime.stopProgram();
+  }, []);
+
+  return {
+    status,
+    runProgram,
+    stopProgram,
+  };
+};

--- a/src/simulation/SimulationShell.tsx
+++ b/src/simulation/SimulationShell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Application } from 'pixi.js';
 import { RootScene } from './rootScene';
+import { simulationRuntime } from '../state/simulationRuntime';
 
 const SimulationShell = (): JSX.Element => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -46,6 +47,7 @@ const SimulationShell = (): JSX.Element => {
       const view = (activeApp as Application & { canvas?: HTMLCanvasElement }).canvas ?? activeApp.view;
       containerRef.current.appendChild(view as HTMLElement);
       rootScene = new RootScene(activeApp);
+      simulationRuntime.registerScene(rootScene);
       rootScene.resize(activeApp.renderer.width, activeApp.renderer.height);
 
       const handleResize = () => {
@@ -65,6 +67,7 @@ const SimulationShell = (): JSX.Element => {
       disposed = true;
       cleanupResize?.();
       if (rootScene) {
+        simulationRuntime.unregisterScene(rootScene);
         rootScene.destroy();
         rootScene = null;
       }

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { compileWorkspaceProgram } from '../blockProgram';
+import { createBlockInstance } from '../../../blocks/library';
+
+const buildWorkspace = (...blocks: ReturnType<typeof createBlockInstance>[]) => blocks;
+
+describe('compileWorkspaceProgram', () => {
+  it('warns when no start block is present', () => {
+    const result = compileWorkspaceProgram(buildWorkspace(createBlockInstance('move')));
+
+    expect(result.program.instructions).toHaveLength(0);
+    expect(result.diagnostics.some((diag) => diag.message.includes('When Started'))).toBe(true);
+  });
+
+  it('compiles a simple move routine', () => {
+    const start = createBlockInstance('start');
+    const move = createBlockInstance('move');
+    const wait = createBlockInstance('wait');
+    start.slots!.do = [move, wait];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+
+    expect(result.program.instructions).toEqual([
+      { kind: 'move', duration: 1, speed: expect.any(Number) },
+      { kind: 'wait', duration: 1 },
+    ]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('expands repeat blocks three times by default', () => {
+    const start = createBlockInstance('start');
+    const repeat = createBlockInstance('repeat');
+    const move = createBlockInstance('move');
+    repeat.slots!.do = [move];
+    start.slots!.do = [repeat];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+    expect(result.program.instructions).toHaveLength(3);
+    expect(result.diagnostics.some((diag) => diag.message.includes('loop three times'))).toBe(true);
+  });
+
+  it('runs parallel branches sequentially', () => {
+    const start = createBlockInstance('start');
+    const parallel = createBlockInstance('parallel');
+    const move = createBlockInstance('move');
+    const turn = createBlockInstance('turn');
+    parallel.slots!.branchA = [move];
+    parallel.slots!.branchB = [turn];
+    start.slots!.do = [parallel];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+    expect(result.program.instructions.map((instruction) => instruction.kind)).toEqual(['move', 'turn']);
+  });
+});

--- a/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BlockProgramRunner } from '../blockProgramRunner';
+import type { CompiledProgram } from '../blockProgram';
+import { RobotChassis } from '../../robot';
+import { DEFAULT_MODULE_LOADOUT, createModuleInstance } from '../../robot/modules/moduleLibrary';
+
+const createRobot = (): RobotChassis => {
+  const robot = new RobotChassis();
+  for (const moduleId of DEFAULT_MODULE_LOADOUT) {
+    robot.attachModule(createModuleInstance(moduleId));
+  }
+  return robot;
+};
+
+describe('BlockProgramRunner', () => {
+  it('applies movement instructions and returns to idle', () => {
+    const robot = createRobot();
+    const runner = new BlockProgramRunner(robot);
+    const program: CompiledProgram = {
+      instructions: [{ kind: 'move', duration: 1, speed: 40 }],
+    };
+    const actionSpy = vi.spyOn(robot, 'invokeAction');
+
+    runner.load(program);
+    expect(runner.getStatus()).toBe('running');
+
+    runner.update(0.5);
+    robot.tick(0.5);
+    expect(actionSpy).toHaveBeenCalledWith(
+      'core.movement',
+      'setLinearVelocity',
+      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
+    );
+    const linearCommand = actionSpy.mock.calls.find(([, actionName, payload]) => {
+      if (actionName !== 'setLinearVelocity') {
+        return false;
+      }
+      const typed = payload as { x?: number; y?: number } | undefined;
+      const magnitude = Math.hypot(typed?.x ?? 0, typed?.y ?? 0);
+      return magnitude > 0;
+    });
+    const linearPayload = linearCommand?.[2] as { x?: number; y?: number } | undefined;
+    expect(linearPayload?.x).toBeCloseTo(40);
+    expect(linearPayload?.y).toBeCloseTo(0);
+
+    runner.update(0.6);
+    robot.tick(0.6);
+    expect(runner.getStatus()).toBe('completed');
+    const finalLinearCommand = actionSpy.mock.calls
+      .filter(([, actionName]) => actionName === 'setLinearVelocity')
+      .at(-1);
+    const finalLinearPayload = finalLinearCommand?.[2] as { x?: number; y?: number } | undefined;
+    expect(finalLinearPayload?.x).toBeCloseTo(0);
+    expect(finalLinearPayload?.y).toBeCloseTo(0);
+  });
+
+  it('applies turn instructions by adjusting angular velocity', () => {
+    const robot = createRobot();
+    const runner = new BlockProgramRunner(robot);
+    const program: CompiledProgram = {
+      instructions: [{ kind: 'turn', duration: 0.5, angularVelocity: Math.PI }],
+    };
+    const actionSpy = vi.spyOn(robot, 'invokeAction');
+
+    runner.load(program);
+    runner.update(0.25);
+    robot.tick(0.25);
+    const angularCommand = actionSpy.mock.calls.find(([, actionName, payload]) => {
+      if (actionName !== 'setAngularVelocity') {
+        return false;
+      }
+      const typed = payload as { value?: number } | undefined;
+      return Math.abs(typed?.value ?? 0) > 0;
+    });
+    const angularPayload = angularCommand?.[2] as { value?: number } | undefined;
+    expect(angularPayload?.value).toBeCloseTo(Math.PI);
+
+    runner.update(0.5);
+    robot.tick(0.5);
+    const finalAngularCommand = actionSpy.mock.calls
+      .filter(([, actionName]) => actionName === 'setAngularVelocity')
+      .at(-1);
+    const finalAngularPayload = finalAngularCommand?.[2] as { value?: number } | undefined;
+    expect(finalAngularPayload?.value).toBeCloseTo(0);
+  });
+});

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -1,0 +1,144 @@
+import type { BlockInstance, WorkspaceState } from '../../types/blocks';
+
+export type DiagnosticSeverity = 'info' | 'warning' | 'error';
+
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  message: string;
+}
+
+export type BlockInstruction =
+  | { kind: 'move'; duration: number; speed: number }
+  | { kind: 'turn'; duration: number; angularVelocity: number }
+  | { kind: 'wait'; duration: number };
+
+export interface CompiledProgram {
+  instructions: BlockInstruction[];
+}
+
+export interface CompilationResult {
+  program: CompiledProgram;
+  diagnostics: Diagnostic[];
+}
+
+const MOVE_SPEED = 80;
+const TURN_RATE = Math.PI / 2;
+const WAIT_DURATION = 1;
+const DEFAULT_REPEAT_COUNT = 3;
+
+interface CompilationContext {
+  repeatInfoIssued: boolean;
+  unsupportedBlocks: Set<string>;
+}
+
+const createContext = (): CompilationContext => ({
+  repeatInfoIssued: false,
+  unsupportedBlocks: new Set<string>(),
+});
+
+const compileSequence = (
+  blocks: BlockInstance[] | undefined,
+  diagnostics: Diagnostic[],
+  context: CompilationContext,
+): BlockInstruction[] => {
+  if (!blocks || blocks.length === 0) {
+    return [];
+  }
+
+  const instructions: BlockInstruction[] = [];
+  for (const block of blocks) {
+    instructions.push(...compileBlock(block, diagnostics, context));
+  }
+  return instructions;
+};
+
+const compileBlock = (
+  block: BlockInstance,
+  diagnostics: Diagnostic[],
+  context: CompilationContext,
+): BlockInstruction[] => {
+  switch (block.type) {
+    case 'move':
+      return [{ kind: 'move', duration: 1, speed: MOVE_SPEED }];
+    case 'turn':
+      return [{ kind: 'turn', duration: 1, angularVelocity: TURN_RATE }];
+    case 'wait':
+      return [{ kind: 'wait', duration: WAIT_DURATION }];
+    case 'repeat': {
+      const inner = compileSequence(block.slots?.do, diagnostics, context);
+      if (inner.length === 0) {
+        return [];
+      }
+      if (!context.repeatInfoIssued) {
+        diagnostics.push({
+          severity: 'info',
+          message:
+            'Repeat blocks currently loop three times while parameter editing is under construction.',
+        });
+        context.repeatInfoIssued = true;
+      }
+      const repetitions: BlockInstruction[] = [];
+      for (let index = 0; index < DEFAULT_REPEAT_COUNT; index += 1) {
+        repetitions.push(...inner.map((instruction) => ({ ...instruction })));
+      }
+      return repetitions;
+    }
+    case 'parallel': {
+      const branchA = compileSequence(block.slots?.branchA, diagnostics, context);
+      const branchB = compileSequence(block.slots?.branchB, diagnostics, context);
+      if (branchA.length === 0 && branchB.length === 0) {
+        return [];
+      }
+      if (!context.unsupportedBlocks.has(block.type)) {
+        diagnostics.push({
+          severity: 'warning',
+          message:
+            'Parallel blocks execute their branches sequentially in this MVP preview.',
+        });
+        context.unsupportedBlocks.add(block.type);
+      }
+      return [...branchA, ...branchB];
+    }
+    case 'forever':
+    case 'if':
+    default: {
+      if (!context.unsupportedBlocks.has(block.type)) {
+        diagnostics.push({
+          severity: 'warning',
+          message: `The ${block.type} block is not runnable yet and will be ignored.`,
+        });
+        context.unsupportedBlocks.add(block.type);
+      }
+      return [];
+    }
+  }
+};
+
+export const compileWorkspaceProgram = (workspace: WorkspaceState): CompilationResult => {
+  const diagnostics: Diagnostic[] = [];
+  const context = createContext();
+
+  const startBlocks = workspace.filter((block) => block.type === 'start');
+  if (startBlocks.length === 0) {
+    diagnostics.push({
+      severity: 'warning',
+      message: 'Add a "When Started" block to trigger the routine.',
+    });
+    return { program: { instructions: [] }, diagnostics };
+  }
+
+  const entry = startBlocks[0];
+  const instructions = compileSequence(entry.slots?.do, diagnostics, context);
+
+  if (instructions.length === 0) {
+    diagnostics.push({
+      severity: 'warning',
+      message: 'Place movement or wait blocks under "When Started" to see the robot react.',
+    });
+  }
+
+  return {
+    program: { instructions },
+    diagnostics,
+  };
+};

--- a/src/simulation/runtime/blockProgramRunner.ts
+++ b/src/simulation/runtime/blockProgramRunner.ts
@@ -1,0 +1,168 @@
+import type { RobotChassis } from '../robot';
+import type { BlockInstruction, CompiledProgram } from './blockProgram';
+
+export type ProgramRunnerStatus = 'idle' | 'running' | 'completed';
+
+const MOVEMENT_MODULE_ID = 'core.movement';
+const EPSILON = 1e-5;
+
+export class BlockProgramRunner {
+  private readonly robot: RobotChassis;
+  private program: CompiledProgram | null = null;
+  private currentInstruction: BlockInstruction | null = null;
+  private currentIndex = -1;
+  private timeRemaining = 0;
+  private status: ProgramRunnerStatus = 'idle';
+  private statusListener: ((status: ProgramRunnerStatus) => void) | null = null;
+
+  constructor(robot: RobotChassis, onStatusChange?: (status: ProgramRunnerStatus) => void) {
+    this.robot = robot;
+    if (onStatusChange) {
+      this.statusListener = onStatusChange;
+    }
+  }
+
+  setStatusListener(listener: ((status: ProgramRunnerStatus) => void) | null): void {
+    this.statusListener = listener;
+    if (listener) {
+      listener(this.status);
+    }
+  }
+
+  getStatus(): ProgramRunnerStatus {
+    return this.status;
+  }
+
+  load(program: CompiledProgram): void {
+    this.program = program;
+    this.currentInstruction = null;
+    this.currentIndex = -1;
+    this.timeRemaining = 0;
+    this.resetMovement();
+
+    if (!program.instructions || program.instructions.length === 0) {
+      this.updateStatus('completed');
+      return;
+    }
+
+    this.updateStatus('running');
+    this.advanceInstruction();
+  }
+
+  stop(): void {
+    this.program = null;
+    this.currentInstruction = null;
+    this.currentIndex = -1;
+    this.timeRemaining = 0;
+    this.resetMovement();
+    this.updateStatus('idle');
+  }
+
+  update(stepSeconds: number): void {
+    if (this.status !== 'running' || stepSeconds <= 0) {
+      return;
+    }
+
+    if (!this.currentInstruction) {
+      this.advanceInstruction();
+      if (this.status !== 'running' || !this.currentInstruction) {
+        return;
+      }
+    }
+
+    let remaining = stepSeconds;
+    while (remaining > 0 && this.status === 'running' && this.currentInstruction) {
+      const delta = Math.min(remaining, this.timeRemaining);
+      this.timeRemaining -= delta;
+      remaining -= delta;
+
+      if (this.timeRemaining <= EPSILON) {
+        this.advanceInstruction();
+      }
+
+      if (this.status !== 'running') {
+        break;
+      }
+    }
+  }
+
+  private advanceInstruction(): void {
+    if (!this.program) {
+      return;
+    }
+
+    this.currentIndex += 1;
+    if (this.currentIndex >= this.program.instructions.length) {
+      this.finishProgram();
+      return;
+    }
+
+    const instruction = this.program.instructions[this.currentIndex];
+    this.currentInstruction = instruction;
+    this.timeRemaining = Math.max(instruction.duration, 0);
+    this.applyInstruction(instruction);
+
+    if (this.timeRemaining <= EPSILON) {
+      this.advanceInstruction();
+    }
+  }
+
+  private finishProgram(): void {
+    this.program = null;
+    this.currentInstruction = null;
+    this.currentIndex = -1;
+    this.timeRemaining = 0;
+    this.resetMovement();
+    this.updateStatus('completed');
+  }
+
+  private applyInstruction(instruction: BlockInstruction): void {
+    switch (instruction.kind) {
+      case 'move': {
+        const orientation = this.robot.getStateSnapshot().orientation;
+        const velocityX = Math.cos(orientation) * instruction.speed;
+        const velocityY = Math.sin(orientation) * instruction.speed;
+        this.applyLinearVelocity(velocityX, velocityY);
+        this.applyAngularVelocity(0);
+        break;
+      }
+      case 'turn': {
+        this.applyLinearVelocity(0, 0);
+        this.applyAngularVelocity(instruction.angularVelocity);
+        break;
+      }
+      case 'wait':
+      default: {
+        this.applyLinearVelocity(0, 0);
+        this.applyAngularVelocity(0);
+      }
+    }
+  }
+
+  private resetMovement(): void {
+    this.applyLinearVelocity(0, 0);
+    this.applyAngularVelocity(0);
+  }
+
+  private applyLinearVelocity(x: number, y: number): void {
+    if (!this.robot.moduleStack.getModule(MOVEMENT_MODULE_ID)) {
+      return;
+    }
+    this.robot.invokeAction(MOVEMENT_MODULE_ID, 'setLinearVelocity', { x, y });
+  }
+
+  private applyAngularVelocity(value: number): void {
+    if (!this.robot.moduleStack.getModule(MOVEMENT_MODULE_ID)) {
+      return;
+    }
+    this.robot.invokeAction(MOVEMENT_MODULE_ID, 'setAngularVelocity', { value });
+  }
+
+  private updateStatus(status: ProgramRunnerStatus): void {
+    if (this.status === status) {
+      return;
+    }
+    this.status = status;
+    this.statusListener?.(status);
+  }
+}

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -1,0 +1,84 @@
+import type { RootScene } from '../simulation/rootScene';
+import type { CompiledProgram } from '../simulation/runtime/blockProgram';
+import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
+
+type StatusListener = (status: ProgramRunnerStatus) => void;
+
+class SimulationRuntime {
+  private scene: RootScene | null = null;
+  private pendingProgram: CompiledProgram | null = null;
+  private readonly listeners = new Set<StatusListener>();
+  private unsubscribeScene: (() => void) | null = null;
+  private status: ProgramRunnerStatus = 'idle';
+
+  registerScene(scene: RootScene): void {
+    if (this.scene === scene) {
+      return;
+    }
+
+    this.unsubscribeScene?.();
+    this.scene = scene;
+    this.unsubscribeScene = scene.subscribeProgramStatus((nextStatus) => {
+      this.updateStatus(nextStatus);
+    });
+    this.updateStatus(scene.getProgramStatus());
+
+    if (this.pendingProgram) {
+      scene.runProgram(this.pendingProgram);
+      this.pendingProgram = null;
+    }
+  }
+
+  unregisterScene(scene: RootScene): void {
+    if (this.scene !== scene) {
+      return;
+    }
+
+    this.unsubscribeScene?.();
+    this.unsubscribeScene = null;
+    this.scene = null;
+    this.pendingProgram = null;
+    this.updateStatus('idle');
+  }
+
+  runProgram(program: CompiledProgram): void {
+    if (this.scene) {
+      this.scene.runProgram(program);
+      return;
+    }
+    this.pendingProgram = program;
+  }
+
+  stopProgram(): void {
+    this.pendingProgram = null;
+    if (this.scene) {
+      this.scene.stopProgram();
+    } else {
+      this.updateStatus('idle');
+    }
+  }
+
+  subscribe(listener: StatusListener): () => void {
+    this.listeners.add(listener);
+    listener(this.status);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getStatus(): ProgramRunnerStatus {
+    return this.status;
+  }
+
+  private updateStatus(status: ProgramRunnerStatus): void {
+    if (this.status === status) {
+      return;
+    }
+    this.status = status;
+    for (const listener of this.listeners) {
+      listener(status);
+    }
+  }
+}
+
+export const simulationRuntime = new SimulationRuntime();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -198,6 +198,100 @@ body {
   gap: 0.75rem;
 }
 
+.runtime-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  border: 1px solid rgba(19, 33, 60, 0.08);
+  background: linear-gradient(135deg, rgba(33, 88, 160, 0.08), rgba(33, 88, 160, 0.02));
+}
+
+.runtime-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.runtime-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.55rem 1.35rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+}
+
+.runtime-button.primary {
+  background: linear-gradient(120deg, #2b5fe0, #3f7bff);
+  color: #f5f8ff;
+  box-shadow: 0 8px 16px rgba(43, 95, 224, 0.25);
+}
+
+.runtime-button.primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.runtime-button.secondary {
+  background: #ffffff;
+  color: #1b2330;
+  border: 1px solid rgba(19, 33, 60, 0.12);
+}
+
+.runtime-button.secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.runtime-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(19, 33, 60, 0.18);
+}
+
+.runtime-status {
+  margin: 0;
+  color: rgba(27, 35, 48, 0.78);
+}
+
+.runtime-diagnostics {
+  margin: 0;
+  padding-left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.runtime-diagnostics li {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(19, 33, 60, 0.05);
+  border-left: 3px solid rgba(19, 33, 60, 0.2);
+}
+
+.runtime-diagnostics li[data-severity='warning'] {
+  border-left-color: #f57c00;
+  background: rgba(245, 124, 0, 0.12);
+}
+
+.runtime-diagnostic-icon {
+  font-size: 1rem;
+}
+
+.runtime-hint {
+  margin: 0;
+  color: rgba(27, 35, 48, 0.6);
+  font-style: italic;
+}
+
 .module-inventory {
   margin-top: 1.5rem;
   padding: 1.1rem 1.25rem 1.35rem;


### PR DESCRIPTION
## Summary
- add runtime controls so players can run/stop compiled programs and see status diagnostics inside the simulation panel【F:src/App.tsx†L1-L38】【F:src/components/RuntimeControls.tsx†L7-L85】【F:src/styles/app.css†L201-L293】
- compile workspace blocks into executable instructions and execute them through a BlockProgramRunner wired into the simulation shell via a shared runtime service【F:src/simulation/runtime/blockProgram.ts†L1-L142】【F:src/simulation/runtime/blockProgramRunner.ts†L1-L167】【F:src/state/simulationRuntime.ts†L1-L84】【F:src/hooks/useSimulationRuntime.ts†L1-L29】【F:src/simulation/rootScene.ts†L1-L190】【F:src/simulation/SimulationShell.tsx†L1-L89】
- add automated coverage for compilation, runner behaviour, and the run button workflow to guard the vertical slice【F:src/simulation/runtime/__tests__/blockProgram.test.ts†L1-L53】【F:src/simulation/runtime/__tests__/blockProgramRunner.test.ts†L1-L85】【F:src/App.test.tsx†L196-L236】

## Testing
- npm test【0eaf2f†L1-L23】
- npm run typecheck【0665cf†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68ce58334004832e9446db1ac88e9fa4