### PR TITLE
Add resource scanning and gathering blocks with inventory UI

### DIFF
--- a/playwright/resource-gathering.spec.ts
+++ b/playwright/resource-gathering.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const workspaceDropzone = '[data-testid="workspace-dropzone"]';
+
+async function performDragAndDrop(page: Page, sourceSelector: string, targetSelector: string): Promise<void> {
+  await page.evaluate(({ sourceSelector, targetSelector }) => {
+    const source = document.querySelector(sourceSelector);
+    const target = document.querySelector(targetSelector);
+    if (!source) {
+      throw new Error(`No drag source found for selector: ${sourceSelector}`);
+    }
+    if (!target) {
+      throw new Error(`No drop target found for selector: ${targetSelector}`);
+    }
+
+    const dataTransfer = new DataTransfer();
+    source.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer }));
+    target.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }));
+    source.dispatchEvent(new DragEvent('dragend', { bubbles: true, cancelable: true, dataTransfer }));
+  }, { sourceSelector, targetSelector });
+}
+
+async function dragPaletteBlock(page: Page, blockId: string, targetSelector: string): Promise<void> {
+  await performDragAndDrop(page, `[data-testid="palette-${blockId}"]`, targetSelector);
+}
+
+test.describe('resource scanning and gathering', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('player can scan the area and gather resources into cargo', async ({ page }) => {
+    await expect(page.getByTestId('inventory-status')).toBeVisible();
+
+    await dragPaletteBlock(page, 'start', workspaceDropzone);
+    await dragPaletteBlock(page, 'scan-resources', '[data-testid="slot-do-dropzone"]');
+    await dragPaletteBlock(page, 'gather-resource', '[data-testid="slot-do-dropzone"]');
+
+    await page.getByTestId('run-program').click();
+
+    await expect(page.getByText('Routine completed')).toBeVisible({ timeout: 10_000 });
+    const contents = page.getByTestId('inventory-contents');
+    await expect(contents).toBeVisible();
+    await expect(contents).toContainText('Ferrous Ore');
+    await expect(contents).toContainText('units');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ModuleInventory from './components/ModuleInventory';
 import { BLOCK_LIBRARY } from './blocks/library';
 import { useBlockWorkspace } from './hooks/useBlockWorkspace';
 import RuntimeControls from './components/RuntimeControls';
+import InventoryStatus from './components/InventoryStatus';
 
 function App(): JSX.Element {
   const { workspace, handleDrop } = useBlockWorkspace();
@@ -27,6 +28,7 @@ function App(): JSX.Element {
         <section className="panel simulation-panel">
           <h2>Simulation</h2>
           <RuntimeControls workspace={workspace} />
+          <InventoryStatus />
           <SimulationShell />
           <ModuleInventory />
         </section>

--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -29,6 +29,18 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     summary: 'Pause the routine for a single beat.'
   },
   {
+    id: 'scan-resources',
+    label: 'Scan Area',
+    category: 'action',
+    summary: 'Trigger the survey scanner to look for nearby resource nodes.'
+  },
+  {
+    id: 'gather-resource',
+    label: 'Gather Resource',
+    category: 'action',
+    summary: 'Harvest the closest detected resource node and store it in cargo.'
+  },
+  {
     id: 'repeat',
     label: 'Repeat',
     category: 'c',

--- a/src/components/InventoryStatus.tsx
+++ b/src/components/InventoryStatus.tsx
@@ -1,0 +1,42 @@
+import useInventoryTelemetry from '../hooks/useInventoryTelemetry';
+
+const formatResourceName = (resource: string): string =>
+  resource
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const formatUnits = (value: number): string => `${Math.round(value)} units`;
+
+const InventoryStatus = (): JSX.Element => {
+  const snapshot = useInventoryTelemetry();
+  const hasContents = snapshot.entries.length > 0;
+
+  return (
+    <section className="inventory-status" aria-labelledby="inventory-status-heading" data-testid="inventory-status">
+      <header className="inventory-status-header">
+        <h3 id="inventory-status-heading">Cargo Inventory</h3>
+        <p className="inventory-status-capacity" data-testid="inventory-capacity">
+          <strong>{Math.round(snapshot.used)}</strong>
+          <span aria-hidden="true"> / </span>
+          {Math.round(snapshot.capacity)} units occupied
+        </p>
+      </header>
+      {hasContents ? (
+        <ul className="inventory-status-list" data-testid="inventory-contents">
+          {snapshot.entries.map((entry) => (
+            <li key={entry.resource} className="inventory-status-entry">
+              <span className="inventory-resource-name">{formatResourceName(entry.resource)}</span>
+              <span className="inventory-resource-quantity">{formatUnits(entry.quantity)}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="inventory-status-empty">No resources stored yet. Run a gather routine to collect materials.</p>
+      )}
+    </section>
+  );
+};
+
+export default InventoryStatus;

--- a/src/hooks/useInventoryTelemetry.ts
+++ b/src/hooks/useInventoryTelemetry.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import type { InventorySnapshot } from '../simulation/robot/inventory';
+import { simulationRuntime } from '../state/simulationRuntime';
+
+export const useInventoryTelemetry = (): InventorySnapshot => {
+  const [snapshot, setSnapshot] = useState<InventorySnapshot>(simulationRuntime.getInventorySnapshot());
+
+  useEffect(() => simulationRuntime.subscribeInventory(setSnapshot), []);
+
+  return snapshot;
+};
+
+export default useInventoryTelemetry;

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -5,6 +5,7 @@ import { RobotChassis } from './robot';
 import { DEFAULT_MODULE_LOADOUT, createModuleInstance } from './robot/modules/moduleLibrary';
 import type { CompiledProgram } from './runtime/blockProgram';
 import { BlockProgramRunner, type ProgramRunnerStatus } from './runtime/blockProgramRunner';
+import type { InventorySnapshot } from './robot/inventory';
 
 interface TickPayload {
   deltaMS: number;
@@ -152,6 +153,21 @@ export class RootScene {
 
   getProgramStatus(): ProgramRunnerStatus {
     return this.programStatus;
+  }
+
+  getInventorySnapshot(): InventorySnapshot {
+    if (!this.robotCore) {
+      return { capacity: 0, used: 0, available: 0, entries: [] };
+    }
+    return this.robotCore.getInventorySnapshot();
+  }
+
+  subscribeInventory(listener: (snapshot: InventorySnapshot) => void): () => void {
+    if (!this.robotCore) {
+      listener({ capacity: 0, used: 0, available: 0, entries: [] });
+      return () => {};
+    }
+    return this.robotCore.inventory.subscribe(listener);
   }
 
   subscribeProgramStatus(listener: (status: ProgramRunnerStatus) => void): () => void {

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -27,6 +27,20 @@ describe('compileWorkspaceProgram', () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it('emits scan and gather instructions', () => {
+    const start = createBlockInstance('start');
+    const scan = createBlockInstance('scan-resources');
+    const gather = createBlockInstance('gather-resource');
+    start.slots!.do = [scan, gather];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+
+    expect(result.program.instructions).toEqual([
+      { kind: 'scan', duration: expect.any(Number), filter: null },
+      { kind: 'gather', duration: expect.any(Number), target: 'auto' },
+    ]);
+  });
+
   it('expands repeat blocks three times by default', () => {
     const start = createBlockInstance('start');
     const repeat = createBlockInstance('repeat');

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -10,7 +10,9 @@ export interface Diagnostic {
 export type BlockInstruction =
   | { kind: 'move'; duration: number; speed: number }
   | { kind: 'turn'; duration: number; angularVelocity: number }
-  | { kind: 'wait'; duration: number };
+  | { kind: 'wait'; duration: number }
+  | { kind: 'scan'; duration: number; filter: string | null }
+  | { kind: 'gather'; duration: number; target: 'auto' };
 
 export interface CompiledProgram {
   instructions: BlockInstruction[];
@@ -24,6 +26,8 @@ export interface CompilationResult {
 const MOVE_SPEED = 80;
 const TURN_RATE = Math.PI / 2;
 const WAIT_DURATION = 1;
+const SCAN_DURATION = 1;
+const GATHER_DURATION = 1.5;
 const DEFAULT_REPEAT_COUNT = 3;
 
 interface CompilationContext {
@@ -64,6 +68,10 @@ const compileBlock = (
       return [{ kind: 'turn', duration: 1, angularVelocity: TURN_RATE }];
     case 'wait':
       return [{ kind: 'wait', duration: WAIT_DURATION }];
+    case 'scan-resources':
+      return [{ kind: 'scan', duration: SCAN_DURATION, filter: null }];
+    case 'gather-resource':
+      return [{ kind: 'gather', duration: GATHER_DURATION, target: 'auto' }];
     case 'repeat': {
       const inner = compileSequence(block.slots?.do, diagnostics, context);
       if (inner.length === 0) {

--- a/src/simulation/runtime/blockProgramRunner.ts
+++ b/src/simulation/runtime/blockProgramRunner.ts
@@ -1,10 +1,25 @@
 import type { RobotChassis } from '../robot';
+import type { ResourceNode } from '../resources/resourceField';
 import type { BlockInstruction, CompiledProgram } from './blockProgram';
 
 export type ProgramRunnerStatus = 'idle' | 'running' | 'completed';
 
 const MOVEMENT_MODULE_ID = 'core.movement';
+const SCANNER_MODULE_ID = 'sensor.survey';
+const MANIPULATOR_MODULE_ID = 'arm.manipulator';
 const EPSILON = 1e-5;
+
+interface ScanMemoryHit {
+  id: string;
+  type: string;
+  quantity: number;
+  distance: number;
+}
+
+interface ScanMemory {
+  filter: string | null;
+  hits: ScanMemoryHit[];
+}
 
 export class BlockProgramRunner {
   private readonly robot: RobotChassis;
@@ -14,6 +29,7 @@ export class BlockProgramRunner {
   private timeRemaining = 0;
   private status: ProgramRunnerStatus = 'idle';
   private statusListener: ((status: ProgramRunnerStatus) => void) | null = null;
+  private scanMemory: ScanMemory | null = null;
 
   constructor(robot: RobotChassis, onStatusChange?: (status: ProgramRunnerStatus) => void) {
     this.robot = robot;
@@ -38,6 +54,7 @@ export class BlockProgramRunner {
     this.currentInstruction = null;
     this.currentIndex = -1;
     this.timeRemaining = 0;
+    this.scanMemory = null;
     this.resetMovement();
 
     if (!program.instructions || program.instructions.length === 0) {
@@ -54,6 +71,7 @@ export class BlockProgramRunner {
     this.currentInstruction = null;
     this.currentIndex = -1;
     this.timeRemaining = 0;
+    this.scanMemory = null;
     this.resetMovement();
     this.updateStatus('idle');
   }
@@ -131,6 +149,18 @@ export class BlockProgramRunner {
         this.applyAngularVelocity(instruction.angularVelocity);
         break;
       }
+      case 'scan': {
+        this.applyLinearVelocity(0, 0);
+        this.applyAngularVelocity(0);
+        this.executeScan(instruction.filter);
+        break;
+      }
+      case 'gather': {
+        this.applyLinearVelocity(0, 0);
+        this.applyAngularVelocity(0);
+        this.executeGather();
+        break;
+      }
       case 'wait':
       default: {
         this.applyLinearVelocity(0, 0);
@@ -156,6 +186,124 @@ export class BlockProgramRunner {
       return;
     }
     this.robot.invokeAction(MOVEMENT_MODULE_ID, 'setAngularVelocity', { value });
+  }
+
+  private executeScan(filter: string | null): void {
+    if (!this.robot.moduleStack.getModule(SCANNER_MODULE_ID)) {
+      this.scanMemory = null;
+      return;
+    }
+
+    const payload = filter ? { resourceType: filter } : {};
+    const result = this.robot.invokeAction(SCANNER_MODULE_ID, 'scan', payload);
+    this.recordScanResult(result);
+  }
+
+  private recordScanResult(result: unknown): void {
+    if (!result || typeof result !== 'object') {
+      this.scanMemory = null;
+      return;
+    }
+
+    const typed = result as {
+      filter?: string | null;
+      resources?: { hits?: Array<Record<string, unknown>> };
+    };
+
+    const hits = Array.isArray(typed.resources?.hits)
+      ? typed.resources!.hits
+          .map((hit) => {
+            const id = typeof hit.id === 'string' ? hit.id : '';
+            const type = typeof hit.type === 'string' ? hit.type : 'unknown';
+            const quantityRaw = (hit as { quantity?: unknown }).quantity;
+            const distanceRaw = (hit as { distance?: unknown }).distance;
+            const quantity =
+              typeof quantityRaw === 'number' && Number.isFinite(quantityRaw)
+                ? Math.max(quantityRaw, 0)
+                : 0;
+            const distance =
+              typeof distanceRaw === 'number' && Number.isFinite(distanceRaw)
+                ? Math.max(distanceRaw, 0)
+                : Number.POSITIVE_INFINITY;
+            return { id, type, quantity, distance } satisfies ScanMemoryHit;
+          })
+          .filter((hit) => hit.id)
+      : [];
+
+    this.scanMemory = {
+      filter: typeof typed.filter === 'string' ? typed.filter : null,
+      hits,
+    };
+  }
+
+  private executeGather(): void {
+    if (!this.robot.moduleStack.getModule(MANIPULATOR_MODULE_ID)) {
+      return;
+    }
+
+    const nodeId = this.resolveGatherTarget();
+    if (!nodeId) {
+      return;
+    }
+
+    const result = this.robot.invokeAction(MANIPULATOR_MODULE_ID, 'gatherResource', { nodeId });
+    this.updateScanMemoryAfterGather(result);
+  }
+
+  private resolveGatherTarget(): string | null {
+    const scanned = this.scanMemory?.hits.find((hit) => hit.quantity > 0);
+    if (scanned) {
+      return scanned.id;
+    }
+
+    const state = this.robot.getStateSnapshot();
+    const nodes = this.robot.resourceField.list();
+    let closest: ResourceNode | null = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (const node of nodes) {
+      if (node.quantity <= 0) {
+        continue;
+      }
+      const dx = node.position.x - state.position.x;
+      const dy = node.position.y - state.position.y;
+      const distance = Math.hypot(dx, dy);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        closest = node;
+      }
+    }
+
+    return closest?.id ?? null;
+  }
+
+  private updateScanMemoryAfterGather(result: unknown): void {
+    if (!this.scanMemory || !result || typeof result !== 'object') {
+      return;
+    }
+
+    const typed = result as { nodeId?: unknown; remaining?: unknown };
+    if (typeof typed.nodeId !== 'string') {
+      return;
+    }
+
+    const remaining =
+      typeof typed.remaining === 'number' && Number.isFinite(typed.remaining)
+        ? Math.max(typed.remaining, 0)
+        : null;
+
+    if (remaining === null) {
+      return;
+    }
+
+    const nextHits = this.scanMemory.hits
+      .map((hit) => (hit.id === typed.nodeId ? { ...hit, quantity: remaining } : hit))
+      .filter((hit) => hit.quantity > 0);
+
+    this.scanMemory = {
+      ...this.scanMemory,
+      hits: nextHits,
+    };
   }
 
   private updateStatus(status: ProgramRunnerStatus): void {

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -1,15 +1,27 @@
 import type { RootScene } from '../simulation/rootScene';
 import type { CompiledProgram } from '../simulation/runtime/blockProgram';
 import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
+import type { InventorySnapshot } from '../simulation/robot/inventory';
 
 type StatusListener = (status: ProgramRunnerStatus) => void;
+type InventoryListener = (snapshot: InventorySnapshot) => void;
+
+const EMPTY_INVENTORY_SNAPSHOT: InventorySnapshot = {
+  capacity: 0,
+  used: 0,
+  available: 0,
+  entries: [],
+};
 
 class SimulationRuntime {
   private scene: RootScene | null = null;
   private pendingProgram: CompiledProgram | null = null;
   private readonly listeners = new Set<StatusListener>();
+  private readonly inventoryListeners = new Set<InventoryListener>();
   private unsubscribeScene: (() => void) | null = null;
+  private sceneInventoryUnsubscribe: (() => void) | null = null;
   private status: ProgramRunnerStatus = 'idle';
+  private inventorySnapshot: InventorySnapshot = EMPTY_INVENTORY_SNAPSHOT;
 
   registerScene(scene: RootScene): void {
     if (this.scene === scene) {
@@ -17,11 +29,14 @@ class SimulationRuntime {
     }
 
     this.unsubscribeScene?.();
+    this.teardownInventorySubscription();
     this.scene = scene;
     this.unsubscribeScene = scene.subscribeProgramStatus((nextStatus) => {
       this.updateStatus(nextStatus);
     });
     this.updateStatus(scene.getProgramStatus());
+    this.updateInventorySnapshot(scene.getInventorySnapshot());
+    this.ensureInventorySubscription();
 
     if (this.pendingProgram) {
       scene.runProgram(this.pendingProgram);
@@ -36,9 +51,11 @@ class SimulationRuntime {
 
     this.unsubscribeScene?.();
     this.unsubscribeScene = null;
+    this.teardownInventorySubscription();
     this.scene = null;
     this.pendingProgram = null;
     this.updateStatus('idle');
+    this.updateInventorySnapshot(EMPTY_INVENTORY_SNAPSHOT);
   }
 
   runProgram(program: CompiledProgram): void {
@@ -70,6 +87,22 @@ class SimulationRuntime {
     return this.status;
   }
 
+  subscribeInventory(listener: InventoryListener): () => void {
+    this.inventoryListeners.add(listener);
+    listener(this.inventorySnapshot);
+    this.ensureInventorySubscription();
+    return () => {
+      this.inventoryListeners.delete(listener);
+      if (this.inventoryListeners.size === 0) {
+        this.teardownInventorySubscription();
+      }
+    };
+  }
+
+  getInventorySnapshot(): InventorySnapshot {
+    return this.inventorySnapshot;
+  }
+
   private updateStatus(status: ProgramRunnerStatus): void {
     if (this.status === status) {
       return;
@@ -77,6 +110,29 @@ class SimulationRuntime {
     this.status = status;
     for (const listener of this.listeners) {
       listener(status);
+    }
+  }
+
+  private updateInventorySnapshot(snapshot: InventorySnapshot): void {
+    this.inventorySnapshot = snapshot;
+    for (const listener of this.inventoryListeners) {
+      listener(snapshot);
+    }
+  }
+
+  private ensureInventorySubscription(): void {
+    if (!this.scene || this.inventoryListeners.size === 0 || this.sceneInventoryUnsubscribe) {
+      return;
+    }
+    this.sceneInventoryUnsubscribe = this.scene.subscribeInventory((snapshot) => {
+      this.updateInventorySnapshot(snapshot);
+    });
+  }
+
+  private teardownInventorySubscription(): void {
+    if (this.sceneInventoryUnsubscribe) {
+      this.sceneInventoryUnsubscribe();
+      this.sceneInventoryUnsubscribe = null;
     }
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -292,6 +292,73 @@ body {
   font-style: italic;
 }
 
+.inventory-status {
+  margin: 1rem 0;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(53, 91, 134, 0.12), rgba(23, 42, 74, 0.08));
+  border: 1px solid rgba(23, 42, 74, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.inventory-status-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.inventory-status h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.inventory-status-capacity {
+  margin: 0;
+  color: rgba(27, 35, 48, 0.7);
+  font-weight: 500;
+}
+
+.inventory-status-capacity strong {
+  font-size: 1.1rem;
+  color: #1e2a44;
+}
+
+.inventory-status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.inventory-status-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(30, 42, 68, 0.08);
+}
+
+.inventory-resource-name {
+  font-weight: 600;
+  color: #1e2a44;
+}
+
+.inventory-resource-quantity {
+  color: rgba(27, 35, 48, 0.65);
+}
+
+.inventory-status-empty {
+  margin: 0;
+  color: rgba(27, 35, 48, 0.6);
+  font-style: italic;
+}
+
 .module-inventory {
   margin-top: 1.5rem;
   padding: 1.1rem 1.25rem 1.35rem;


### PR DESCRIPTION
## Summary
- add scan and gather blocks to the palette and compile/runtime pipeline so the robot can survey and harvest resources automatically
- expose cargo inventory telemetry through the runtime, surface it in a new Inventory Status panel, and style the display
- cover the flow with unit tests and a Playwright scenario that runs the scan and gather blocks end-to-end

## Testing
- npm test
- npm run typecheck
- npx playwright test


------
https://chatgpt.com/codex/tasks/task_e_68ce8d2fe610832eafca62aed6e5f2b1