### PR TITLE
Add runtime robot selection plumbing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,32 @@
+import { useCallback, useMemo } from 'react';
 import SimulationShell from './simulation/SimulationShell';
 import ModuleInventory from './components/ModuleInventory';
 import { useBlockWorkspace } from './hooks/useBlockWorkspace';
 import InventoryStatus from './components/InventoryStatus';
 import RobotProgrammingOverlay from './components/RobotProgrammingOverlay';
-import {
-  RobotProgrammingOverlayProvider,
-  useRobotProgrammingOverlay,
-} from './state/RobotProgrammingOverlayContext';
+import { useRobotSelection } from './hooks/useRobotSelection';
+import { simulationRuntime } from './state/simulationRuntime';
 
 const DEFAULT_ROBOT_ID = 'MF-01';
 
-const AppContent = (): JSX.Element => {
+const App = (): JSX.Element => {
   const { workspace, handleDrop } = useBlockWorkspace();
-  const { isOpen, selectedRobotId, openOverlay, closeOverlay } = useRobotProgrammingOverlay();
+  const { selectedRobotId, clearSelection } = useRobotSelection();
 
-  const handleProgramRobot = () => {
-    openOverlay(DEFAULT_ROBOT_ID);
-  };
+  const handleProgramRobot = useCallback(() => {
+    simulationRuntime.setSelectedRobot(DEFAULT_ROBOT_ID);
+  }, []);
 
-  const handleOverlayClose = () => {
-    closeOverlay();
-  };
+  const handleOverlayClose = useCallback(() => {
+    clearSelection();
+  }, [clearSelection]);
 
-  const activeRobotId = selectedRobotId ?? DEFAULT_ROBOT_ID;
+  const activeRobotId = useMemo(() => selectedRobotId ?? DEFAULT_ROBOT_ID, [selectedRobotId]);
+  const isOverlayOpen = selectedRobotId !== null;
 
   return (
     <div className="app-shell">
-      <SimulationShell onRobotSelect={handleProgramRobot} />
+      <SimulationShell />
       <div className="world-hud" role="region" aria-label="World interface HUD">
         <header className="world-hud-header">
           <div>
@@ -50,7 +50,7 @@ const AppContent = (): JSX.Element => {
           <ModuleInventory />
         </div>
       </div>
-      {isOpen ? (
+      {isOverlayOpen ? (
         <RobotProgrammingOverlay
           workspace={workspace}
           onDrop={handleDrop}
@@ -62,13 +62,5 @@ const AppContent = (): JSX.Element => {
     </div>
   );
 };
-
-function App(): JSX.Element {
-  return (
-    <RobotProgrammingOverlayProvider>
-      <AppContent />
-    </RobotProgrammingOverlayProvider>
-  );
-}
 
 export default App;

--- a/src/hooks/useRobotSelection.ts
+++ b/src/hooks/useRobotSelection.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from 'react';
+import { simulationRuntime } from '../state/simulationRuntime';
+
+interface RobotSelection {
+  selectedRobotId: string | null;
+  clearSelection: () => void;
+}
+
+export const useRobotSelection = (): RobotSelection => {
+  const [selectedRobotId, setSelectedRobotId] = useState<string | null>(simulationRuntime.getSelectedRobot());
+
+  useEffect(() => simulationRuntime.subscribeSelectedRobot(setSelectedRobotId), []);
+
+  const clearSelection = useCallback(() => {
+    simulationRuntime.clearSelectedRobot();
+  }, []);
+
+  return { selectedRobotId, clearSelection };
+};
+
+export default useRobotSelection;

--- a/src/simulation/SimulationShell.tsx
+++ b/src/simulation/SimulationShell.tsx
@@ -19,6 +19,7 @@ const SimulationShell = ({ onRobotSelect }: SimulationShellProps): JSX.Element =
     let rootScene: RootScene | null = null;
     let disposed = false;
     let cleanupResize: (() => void) | undefined;
+    let selectionCleanup: (() => void) | undefined;
 
     const init = async () => {
       const container = containerRef.current;
@@ -54,6 +55,15 @@ const SimulationShell = ({ onRobotSelect }: SimulationShellProps): JSX.Element =
       simulationRuntime.registerScene(rootScene);
       rootScene.resize(activeApp.renderer.width, activeApp.renderer.height);
 
+      selectionCleanup = rootScene.subscribeRobotSelection((robotId) => {
+        if (robotId) {
+          simulationRuntime.setSelectedRobot(robotId);
+          onRobotSelect?.();
+        } else {
+          simulationRuntime.clearSelectedRobot();
+        }
+      });
+
       const handleResize = () => {
         if (!rootScene || disposed) {
           return;
@@ -70,6 +80,7 @@ const SimulationShell = ({ onRobotSelect }: SimulationShellProps): JSX.Element =
     const cleanup = () => {
       disposed = true;
       cleanupResize?.();
+      selectionCleanup?.();
       if (rootScene) {
         simulationRuntime.unregisterScene(rootScene);
         rootScene.destroy();
@@ -92,7 +103,6 @@ const SimulationShell = ({ onRobotSelect }: SimulationShellProps): JSX.Element =
       className="simulation-shell"
       ref={containerRef}
       aria-label="Simulation shell"
-      onDoubleClick={onRobotSelect}
     />
   );
 };


### PR DESCRIPTION
## Summary
- make the placeholder robot sprite interactive and broadcast selection events from the Pixi root scene
- surface robot selection state through the simulation runtime and a dedicated React hook
- trigger the programming overlay from runtime selection updates in the app shell

## Testing
- `npm test`
- `npm run typecheck`
- `npx playwright test` *(fails: missing Playwright browsers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce99d8a558832ebebde3bd51dce7fe