### PR TITLE
Fix overlay tab visibility

### DIFF
--- a/src/components/SimulationOverlay.tsx
+++ b/src/components/SimulationOverlay.tsx
@@ -129,7 +129,7 @@ const SimulationOverlay = ({
               role="tab"
               id={`simulation-overlay-tab-${tab}`}
               aria-selected={activeTab === tab}
-              aria-controls={`simulation-overlay-panel-${tab}`}
+              aria-controls={activeTab === tab ? `simulation-overlay-panel-${tab}` : undefined}
               tabIndex={activeTab === tab ? 0 : -1}
               className={`${styles.tab} ${activeTab === tab ? styles.tabActive : ''}`.trim()}
               data-variant={tab}
@@ -145,6 +145,8 @@ const SimulationOverlay = ({
             role="tabpanel"
             aria-labelledby="simulation-overlay-tab-inventory"
             hidden={activeTab !== 'inventory'}
+            aria-hidden={activeTab !== 'inventory'}
+            style={{ display: activeTab === 'inventory' ? undefined : 'none' }}
             className={styles.panel}
           >
             <InventoryStatus />
@@ -154,6 +156,8 @@ const SimulationOverlay = ({
             role="tabpanel"
             aria-labelledby="simulation-overlay-tab-catalog"
             hidden={activeTab !== 'catalog'}
+            aria-hidden={activeTab !== 'catalog'}
+            style={{ display: activeTab === 'catalog' ? undefined : 'none' }}
             className={styles.panel}
           >
             <ModuleInventory />
@@ -163,6 +167,8 @@ const SimulationOverlay = ({
             role="tabpanel"
             aria-labelledby="simulation-overlay-tab-programming"
             hidden={activeTab !== 'programming'}
+            aria-hidden={activeTab !== 'programming'}
+            style={{ display: activeTab === 'programming' ? undefined : 'none' }}
             className={`${styles.panel} ${styles.panelProgramming}`}
           >
             <RobotProgrammingPanel

--- a/src/components/__tests__/SimulationOverlay.test.tsx
+++ b/src/components/__tests__/SimulationOverlay.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import SimulationOverlay, { type OverlayTab } from '../SimulationOverlay';
+import type { WorkspaceState } from '../../types/blocks';
+
+vi.mock('../InventoryStatus', () => ({
+  default: () => <div>Inventory Mock</div>,
+}));
+
+vi.mock('../ModuleInventory', () => ({
+  default: () => <div>Catalogue Mock</div>,
+}));
+
+vi.mock('../RobotProgrammingPanel', () => ({
+  default: () => <div>Programming Mock</div>,
+}));
+
+describe('SimulationOverlay panels', () => {
+  const mockProps = {
+    onTabChange: vi.fn(),
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    workspace: [] as WorkspaceState,
+    onDrop: vi.fn(),
+    robotId: 'MF-01',
+  } as const;
+
+  const renderOverlay = (tab: OverlayTab) =>
+    render(
+      <SimulationOverlay
+        isOpen
+        activeTab={tab}
+        {...mockProps}
+      />,
+    );
+
+  it('only displays the inventory panel when inventory is active', () => {
+    const { container } = renderOverlay('inventory');
+
+    const inventory = container.querySelector('#simulation-overlay-panel-inventory');
+    const catalog = container.querySelector('#simulation-overlay-panel-catalog');
+    const programming = container.querySelector('#simulation-overlay-panel-programming');
+
+    expect(inventory).not.toBeNull();
+    expect(catalog).not.toBeNull();
+    expect(programming).not.toBeNull();
+    expect(inventory).toBeVisible();
+    expect(catalog).not.toBeVisible();
+    expect(programming).not.toBeVisible();
+  });
+
+  it('only displays the catalogue panel when catalogue is active', () => {
+    const { container } = renderOverlay('catalog');
+
+    const inventory = container.querySelector('#simulation-overlay-panel-inventory');
+    const catalog = container.querySelector('#simulation-overlay-panel-catalog');
+    const programming = container.querySelector('#simulation-overlay-panel-programming');
+
+    expect(inventory).not.toBeNull();
+    expect(catalog).not.toBeNull();
+    expect(programming).not.toBeNull();
+    expect(inventory).not.toBeVisible();
+    expect(catalog).toBeVisible();
+    expect(programming).not.toBeVisible();
+  });
+
+  it('only displays the programming panel when programming is active', () => {
+    const { container } = renderOverlay('programming');
+
+    const inventory = container.querySelector('#simulation-overlay-panel-inventory');
+    const catalog = container.querySelector('#simulation-overlay-panel-catalog');
+    const programming = container.querySelector('#simulation-overlay-panel-programming');
+
+    expect(inventory).not.toBeNull();
+    expect(catalog).not.toBeNull();
+    expect(programming).not.toBeNull();
+    expect(inventory).not.toBeVisible();
+    expect(catalog).not.toBeVisible();
+    expect(programming).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the simulation overlay only exposes the active panel and keep inactive sections hidden for assistive tech
- update the tab buttons to avoid referencing non-existent panels when inactive
- add focused component tests that lock in panel visibility for each overlay tab

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9d9cfdf8832e9f981672145dca2d