### PR TITLE
Execute loop bodies repeatedly in runtime

### DIFF
--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -41,6 +41,25 @@ describe('compileWorkspaceProgram', () => {
     ]);
   });
 
+  it('wraps forever blocks in loop instructions so the runner can repeat them', () => {
+    const start = createBlockInstance('start');
+    const forever = createBlockInstance('forever');
+    const gather = createBlockInstance('gather-resource');
+    forever.slots!.do = [gather];
+    start.slots!.do = [forever];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+
+    expect(result.program.instructions).toHaveLength(1);
+    expect(result.program.instructions[0]).toMatchObject({ kind: 'loop' });
+    const loop = result.program.instructions[0];
+    if (loop.kind !== 'loop') {
+      throw new Error('Expected a loop instruction to be emitted.');
+    }
+    expect(loop.instructions).toHaveLength(1);
+    expect(loop.instructions[0]).toMatchObject({ kind: 'gather', target: 'auto' });
+  });
+
   it('expands repeat blocks three times by default', () => {
     const start = createBlockInstance('start');
     const repeat = createBlockInstance('repeat');


### PR DESCRIPTION
## Summary
- compile forever blocks into loop instructions that own their child instruction sequences
- teach the program runner to manage a stack of execution frames so loop bodies repeat indefinitely
- update runtime tests to assert the compiler emits loop instructions and that gather loops run until depletion

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa1c6f5b0832e96444e6ab8131812