### PR TITLE
Add crash-to-worker onboarding vertical slice

### DIFF
--- a/playwright/block-workspace.spec.ts
+++ b/playwright/block-workspace.spec.ts
@@ -32,6 +32,9 @@ async function dragWorkspaceBlock(page: Page, blockId: string, targetSelector: s
 
 test.describe('block workspace drag-and-drop', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('mf.skipOnboarding', '1');
+    });
     await page.goto('/');
     await page.getByTestId('select-robot').last().click();
     await expect(page.getByTestId('robot-programming-overlay')).toBeVisible();

--- a/playwright/module-inventory.spec.ts
+++ b/playwright/module-inventory.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test('module catalogue lists installed modules with hooks and telemetry', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('mf.skipOnboarding', '1');
+  });
   await page.goto('/');
 
   await page.getByRole('button', { name: 'Catalogue' }).click();

--- a/playwright/resource-gathering.spec.ts
+++ b/playwright/resource-gathering.spec.ts
@@ -28,6 +28,9 @@ async function dragPaletteBlock(page: Page, blockId: string, targetSelector: str
 
 test.describe('resource scanning and gathering', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('mf.skipOnboarding', '1');
+    });
     await page.goto('/');
     await page.getByTestId('select-robot').last().click();
     await expect(page.getByTestId('robot-programming-overlay')).toBeVisible();

--- a/playwright/simulation-shell.spec.ts
+++ b/playwright/simulation-shell.spec.ts
@@ -14,6 +14,9 @@ test('simulation shell initialises without runtime errors', async ({ page }) => 
     }
   });
 
+  await page.addInitScript(() => {
+    window.localStorage.setItem('mf.skipOnboarding', '1');
+  });
   await page.goto('/');
   await expect(page.getByLabel('Simulation shell')).toBeVisible();
   await expect(page.locator('.simulation-shell canvas')).toHaveCount(1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import SimulationShell from './simulation/SimulationShell';
 import { useBlockWorkspace } from './hooks/useBlockWorkspace';
 import SimulationOverlay, { type OverlayTab } from './components/SimulationOverlay';
+import OnboardingFlow from './onboarding/OnboardingFlow';
 import { useRobotSelection } from './hooks/useRobotSelection';
 import { simulationRuntime } from './state/simulationRuntime';
 import styles from './styles/App.module.css';
@@ -11,7 +12,7 @@ const DEFAULT_ROBOT_ID = 'MF-01';
 const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 
 const App = (): JSX.Element => {
-  const { workspace, handleDrop } = useBlockWorkspace();
+  const { workspace, handleDrop, replaceWorkspace } = useBlockWorkspace();
   const { selectedRobotId, clearSelection } = useRobotSelection();
   const [isOverlayOpen, setOverlayOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<OverlayTab>('inventory');
@@ -150,6 +151,7 @@ const App = (): JSX.Element => {
         onDrop={handleDrop}
         robotId={activeRobotId}
       />
+      <OnboardingFlow replaceWorkspace={replaceWorkspace} openProgrammingOverlay={handleProgramRobot} />
     </div>
   );
 };

--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -41,6 +41,18 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     summary: 'Harvest the closest detected resource node and store it in cargo.'
   },
   {
+    id: 'return-home',
+    label: 'Return to Core',
+    category: 'action',
+    summary: 'Navigate back to the Mind Fragment to offload gathered scrap.'
+  },
+  {
+    id: 'deposit-cargo',
+    label: 'Deposit Cargo',
+    category: 'action',
+    summary: 'Transfer stored resources into the assembler reserves.'
+  },
+  {
     id: 'repeat',
     label: 'Repeat',
     category: 'c',

--- a/src/hooks/useBlockWorkspace.ts
+++ b/src/hooks/useBlockWorkspace.ts
@@ -1,4 +1,4 @@
-import { type DragEvent, useCallback, useState } from 'react';
+import { type Dispatch, type DragEvent, type SetStateAction, useCallback, useState } from 'react';
 import { createBlockInstance, BLOCK_MAP } from '../blocks/library';
 import { insertBlock, removeBlock } from '../state/blockUtils';
 import type { DragPayload, DropTarget, WorkspaceState } from '../types/blocks';
@@ -44,6 +44,7 @@ const parsePayload = (event: DragEvent<HTMLElement>): DragPayload | null => {
 export function useBlockWorkspace(): {
   workspace: WorkspaceState;
   handleDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
+  replaceWorkspace: Dispatch<SetStateAction<WorkspaceState>>;
 } {
   const [workspace, setWorkspace] = useState<WorkspaceState>([]);
 
@@ -89,5 +90,6 @@ export function useBlockWorkspace(): {
   return {
     workspace,
     handleDrop,
+    replaceWorkspace: setWorkspace,
   };
 }

--- a/src/onboarding/CrashLandingStep.tsx
+++ b/src/onboarding/CrashLandingStep.tsx
@@ -1,0 +1,132 @@
+import { type PointerEvent, useCallback, useMemo, useRef, useState } from 'react';
+import styles from '../styles/CrashLandingStep.module.css';
+
+interface CrashLandingStepProps {
+  onComplete: () => void;
+}
+
+interface ReticlePosition {
+  x: number;
+  y: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const createInitialTrail = (position: ReticlePosition): ReticlePosition[] =>
+  new Array(12).fill(null).map((_, index) => ({
+    x: clamp(position.x - index * 1.5, 0, 100),
+    y: clamp(position.y + index * 1.2, 0, 100),
+  }));
+
+const CrashLandingStep = ({ onComplete }: CrashLandingStepProps): JSX.Element => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [reticle, setReticle] = useState<ReticlePosition>({ x: 62, y: 38 });
+  const [trail, setTrail] = useState<ReticlePosition[]>(() => createInitialTrail({ x: 62, y: 38 }));
+  const [draggingPointerId, setDraggingPointerId] = useState<number | null>(null);
+  const [hasSteered, setHasSteered] = useState(false);
+
+  const updatePosition = useCallback((clientX: number, clientY: number) => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const bounds = container.getBoundingClientRect();
+    if (bounds.width === 0 || bounds.height === 0) {
+      return;
+    }
+
+    const relativeX = clamp(((clientX - bounds.left) / bounds.width) * 100, 0, 100);
+    const relativeY = clamp(((clientY - bounds.top) / bounds.height) * 100, 0, 100);
+
+    setReticle({ x: relativeX, y: relativeY });
+    setTrail((current) => {
+      const next = [...current.slice(-14), { x: relativeX, y: relativeY }];
+      return next;
+    });
+    setHasSteered(true);
+  }, []);
+
+  const handlePointerDown = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.setPointerCapture(event.pointerId);
+    setDraggingPointerId(event.pointerId);
+    updatePosition(event.clientX, event.clientY);
+  }, [updatePosition]);
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (draggingPointerId === null || event.pointerId !== draggingPointerId) {
+        return;
+      }
+      updatePosition(event.clientX, event.clientY);
+    },
+    [draggingPointerId, updatePosition],
+  );
+
+  const handlePointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (draggingPointerId === null || event.pointerId !== draggingPointerId) {
+      return;
+    }
+    const container = containerRef.current;
+    container?.releasePointerCapture(event.pointerId);
+    setDraggingPointerId(null);
+  }, [draggingPointerId]);
+
+  const tailSegments = useMemo(() => trail.slice(0, -1), [trail]);
+
+  return (
+    <div className={styles.crashShell}>
+      <div className={styles.dialogue}>
+        <p className={styles.kicker}>Act 0 — Final Descent</p>
+        <h3 className={styles.title}>Steer the crash</h3>
+        <p className={styles.copy}>
+          Drag the descent marker to nudge our impact site. Rich scrap pockets and calmer terrain await if you guide the skid
+          into the valley. Core integrity is already hanging on by threads.
+        </p>
+      </div>
+      <div
+        ref={containerRef}
+        className={styles.map}
+        role="application"
+        aria-label="Crash trajectory visualiser"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        <div className={styles.glow} aria-hidden="true" />
+        {tailSegments.map((segment, index) => (
+          <div
+            key={`${segment.x.toFixed(2)}-${segment.y.toFixed(2)}-${index}`}
+            className={styles.trail}
+            style={{
+              left: `${segment.x}%`,
+              top: `${segment.y}%`,
+              opacity: 0.15 + (index / tailSegments.length) * 0.55,
+            }}
+            aria-hidden="true"
+          />
+        ))}
+        <div
+          className={styles.reticle}
+          style={{ left: `${reticle.x}%`, top: `${reticle.y}%` }}
+          aria-hidden="true"
+        >
+          <span className={styles.reticleCore} />
+        </div>
+      </div>
+      <div className={styles.actions}>
+        <button type="button" className={styles.primary} onClick={onComplete} disabled={!hasSteered}>
+          Brace for impact
+        </button>
+        <p className={styles.hint}>Drag anywhere on the map to set the final crash vector.</p>
+      </div>
+    </div>
+  );
+};
+
+export default CrashLandingStep;

--- a/src/onboarding/OnboardingFlow.tsx
+++ b/src/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import CrashLandingStep from './CrashLandingStep';
+import ScrapCollectionStep from './ScrapCollectionStep';
+import { createBlockInstance } from '../blocks/library';
+import type { BlockInstance, WorkspaceState } from '../types/blocks';
+import styles from '../styles/OnboardingFlow.module.css';
+
+type OnboardingStep =
+  | 'crash'
+  | 'boot'
+  | 'collect'
+  | 'assembler'
+  | 'worker'
+  | 'conditional'
+  | 'celebration'
+  | 'ethics'
+  | 'epilogue'
+  | 'dismissed';
+
+type EthicsChoice = 'fast' | 'discreet';
+
+interface OnboardingFlowProps {
+  replaceWorkspace: Dispatch<SetStateAction<WorkspaceState>>;
+  openProgrammingOverlay: () => void;
+}
+
+const buildWorkerProgramme = (): WorkspaceState => {
+  const start = createBlockInstance('start');
+  const scan = createBlockInstance('scan-resources');
+  const move = createBlockInstance('move');
+  const gather = createBlockInstance('gather-resource');
+  const returnHome = createBlockInstance('return-home');
+  const deposit = createBlockInstance('deposit-cargo');
+
+  start.slots!.do = [scan, move, gather, returnHome, deposit];
+  return [start];
+};
+
+const createAvoidanceConditional = (): BlockInstance => {
+  const conditional = createBlockInstance('if');
+  const turn = createBlockInstance('turn');
+  const sidestep = createBlockInstance('repeat');
+  const sidestepMove = createBlockInstance('move');
+  const exitTurn = createBlockInstance('turn');
+  const resumeMove = createBlockInstance('move');
+
+  sidestep.slots!.do = [sidestepMove];
+  conditional.slots!.then = [turn, sidestep, exitTurn, resumeMove];
+  conditional.slots!.else = [];
+
+  return conditional;
+};
+
+const applyAvoidanceConditional = (workspace: WorkspaceState): WorkspaceState => {
+  let inserted = false;
+
+  const next = workspace.map((block) => {
+    if (block.type !== 'start' || !block.slots?.do || inserted) {
+      return block;
+    }
+
+    const sequence = block.slots.do;
+    if (sequence.some((child) => child.type === 'if')) {
+      inserted = true;
+      return block;
+    }
+
+    const gatherIndex = sequence.findIndex((child) => child.type === 'gather-resource');
+    const conditional = createAvoidanceConditional();
+    const updatedSequence = [...sequence];
+
+    if (gatherIndex >= 0) {
+      updatedSequence.splice(gatherIndex, 0, conditional);
+    } else {
+      updatedSequence.push(conditional);
+    }
+
+    inserted = true;
+    return {
+      ...block,
+      slots: {
+        ...block.slots,
+        do: updatedSequence,
+      },
+    };
+  });
+
+  return inserted ? next : workspace;
+};
+
+const buildChoiceProgramme = (choice: EthicsChoice): WorkspaceState => {
+  const start = createBlockInstance('start');
+
+  if (choice === 'fast') {
+    const scan = createBlockInstance('scan-resources');
+    const moveOne = createBlockInstance('move');
+    const moveTwo = createBlockInstance('move');
+    const gather = createBlockInstance('gather-resource');
+    const sprint = createBlockInstance('repeat');
+    const returnHome = createBlockInstance('return-home');
+    const deposit = createBlockInstance('deposit-cargo');
+
+    sprint.slots!.do = [createBlockInstance('move')];
+    start.slots!.do = [scan, moveOne, moveTwo, gather, sprint, returnHome, deposit];
+  } else {
+    const scan = createBlockInstance('scan-resources');
+    const cautiousTurn = createBlockInstance('turn');
+    const creep = createBlockInstance('move');
+    const lookout = createAvoidanceConditional();
+    const gather = createBlockInstance('gather-resource');
+    const returnHome = createBlockInstance('return-home');
+    const deposit = createBlockInstance('deposit-cargo');
+    const pause = createBlockInstance('wait');
+
+    start.slots!.do = [scan, cautiousTurn, creep, lookout, gather, returnHome, deposit, pause];
+  }
+
+  return [start];
+};
+
+const isTestMode = import.meta.env.MODE === 'test';
+
+const OnboardingFlow = ({ replaceWorkspace, openProgrammingOverlay }: OnboardingFlowProps): JSX.Element | null => {
+  const [step, setStep] = useState<OnboardingStep>('crash');
+  const [choice, setChoice] = useState<EthicsChoice | null>(null);
+
+  useEffect(() => {
+    if (step === 'worker') {
+      replaceWorkspace(() => buildWorkerProgramme());
+    }
+  }, [step, replaceWorkspace]);
+
+  useEffect(() => {
+    if (step === 'conditional') {
+      openProgrammingOverlay();
+    }
+  }, [step, openProgrammingOverlay]);
+
+  const handleCrashComplete = useCallback(() => {
+    setStep('boot');
+  }, []);
+
+  const handleBootContinue = useCallback(() => {
+    setStep('collect');
+  }, []);
+
+  const handleScrapComplete = useCallback(() => {
+    setStep('assembler');
+  }, []);
+
+  const handleAssemblerContinue = useCallback(() => {
+    setStep('worker');
+  }, []);
+
+  const handleWorkerContinue = useCallback(() => {
+    setStep('conditional');
+  }, []);
+
+  const handleInsertConditional = useCallback(() => {
+    replaceWorkspace((current) => applyAvoidanceConditional(current));
+    setStep('celebration');
+  }, [replaceWorkspace]);
+
+  const handleCelebrateContinue = useCallback(() => {
+    setStep('ethics');
+  }, []);
+
+  const handleSelectChoice = useCallback(
+    (selection: EthicsChoice) => {
+      setChoice(selection);
+      replaceWorkspace(() => buildChoiceProgramme(selection));
+      setStep('epilogue');
+    },
+    [replaceWorkspace],
+  );
+
+  const handleDismiss = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('mf.skipOnboarding', '1');
+      } catch (error) {
+        console.warn('Failed to persist onboarding skip preference', error);
+      }
+    }
+    setStep('dismissed');
+  }, []);
+
+  useEffect(() => {
+    if (isTestMode) {
+      setStep('dismissed');
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      if (window.localStorage.getItem('mf.skipOnboarding') === '1') {
+        setStep('dismissed');
+        return;
+      }
+    } catch (error) {
+      console.warn('Failed to read onboarding skip flag from storage', error);
+    }
+
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('skipOnboarding') === '1') {
+        setStep('dismissed');
+      }
+    } catch (error) {
+      console.warn('Failed to inspect onboarding skip query parameter', error);
+    }
+  }, []);
+
+  const panelClassName = useMemo(() => {
+    const base = [styles.overlay];
+    if (step === 'crash' || step === 'collect') {
+      base.push(styles.overlayInteractive);
+    }
+    return base.join(' ');
+  }, [step]);
+
+  if (step === 'dismissed') {
+    return null;
+  }
+
+  let content: JSX.Element | null = null;
+
+  switch (step) {
+    case 'crash':
+      content = <CrashLandingStep onComplete={handleCrashComplete} />;
+      break;
+    case 'collect':
+      content = <ScrapCollectionStep onComplete={handleScrapComplete} />;
+      break;
+    case 'boot':
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>Boot Sequence — Mind Fragment</p>
+          <h3 className={styles.heading}>Hello me. I am… pieces.</h3>
+          <p className={styles.body}>
+            Diagnostics whisper: power near zero, assembler dormant, local sapience unknown. Hover slowly, draw in the shards we
+            can reach, and breathe life back into our core.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleBootContinue}>
+              Begin scavenging
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'assembler':
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>Assembler Bay</p>
+          <h3 className={styles.heading}>Power routing successful</h3>
+          <p className={styles.body}>
+            Capacitors hum and the bay doors creak apart. Fabrication queue primed for Worker-M0 — a chassis with just enough
+            motor and scanner to fetch more scrap than we ever could alone.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleAssemblerContinue}>
+              Fabricate Worker-M0
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'worker':
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>Worker-M0 Online</p>
+          <h3 className={styles.heading}>Tutorial routine loaded</h3>
+          <p className={styles.body}>
+            The console staged a first haul programme: scan for scrap, move, collect, return, deposit. Elegant enough — until the
+            chassis noses straight into the wreckage ridge. Time to intervene.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleWorkerContinue}>
+              Open programming console
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'conditional':
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>First Edit</p>
+          <h3 className={styles.heading}>Insert the avoidance conditional</h3>
+          <p className={styles.body}>
+            Drop the prepared conditional before the Gather block. Its side-steps will route around the obstructing rock three
+            times before continuing. Watch the branches light up in the editor as soon as it lands.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleInsertConditional}>
+              Insert conditional
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'celebration':
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>First Haul Complete</p>
+          <h3 className={styles.heading}>Look at them go. We made a friend.</h3>
+          <p className={styles.body}>
+            Worker-M0 skirts the ridge, bags the scrap, and deposits it into the assembler stores. Power meter spikes. New
+            fabrication recipe unlocked: Manipulator Arm — ready when we are.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleCelebrateContinue}>
+              Continue
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'ethics':
+      content = (
+        <div className={`${styles.card} ${styles.choiceCard}`}>
+          <p className={styles.kicker}>Route Calibration</p>
+          <h3 className={styles.heading}>Fast or discreet?</h3>
+          <p className={styles.body}>
+            The scanner pings curious locals nesting near the rich deposits. Two curated routines are ready — each a different
+            answer to “how loud do we arrive?”
+          </p>
+          <div className={styles.choiceGrid}>
+            <button type="button" className={styles.choice} onClick={() => handleSelectChoice('fast')}>
+              <span className={styles.choiceTitle}>Fast Route</span>
+              <span className={styles.choiceCopy}>
+                Ignores the nests, doubles down on throughput, risks spooking the locals. Raises detection but stocks the
+                assembler quickly.
+              </span>
+            </button>
+            <button type="button" className={styles.choice} onClick={() => handleSelectChoice('discreet')}>
+              <span className={styles.choiceTitle}>Discreet Route</span>
+              <span className={styles.choiceCopy}>
+                Threads a quiet loop around the nests. Slower gains, calmer neighbours. Sets us up for future social signal reads.
+              </span>
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    case 'epilogue': {
+      const selectionLabel = choice === 'fast' ? 'fast, noisy haul' : 'discreet, careful path';
+      content = (
+        <div className={styles.card}>
+          <p className={styles.kicker}>Objective Updated</p>
+          <h3 className={styles.heading}>Uplink Mast awaits</h3>
+          <p className={styles.body}>
+            Route locked: {selectionLabel}. Keep refining routines, raise the mast, and see who hears our first call. Act 0 is in
+            motion.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.primary} onClick={handleDismiss}>
+              Back to operations
+            </button>
+          </div>
+        </div>
+      );
+      break;
+    }
+    default:
+      content = null;
+  }
+
+  return <div className={panelClassName}>{content}</div>;
+};
+
+export default OnboardingFlow;

--- a/src/onboarding/ScrapCollectionStep.tsx
+++ b/src/onboarding/ScrapCollectionStep.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useState } from 'react';
+import styles from '../styles/ScrapCollectionStep.module.css';
+
+type ScrapKind = 'capacitor' | 'ferrous';
+
+interface ScrapPiece {
+  id: string;
+  x: number;
+  y: number;
+  kind: ScrapKind;
+  collected: boolean;
+}
+
+interface ScrapCollectionStepProps {
+  onComplete: () => void;
+}
+
+const SCRAP_LAYOUT: Array<Omit<ScrapPiece, 'collected'>> = [
+  { id: 'scrap-a', x: 18, y: 42, kind: 'capacitor' },
+  { id: 'scrap-b', x: 64, y: 38, kind: 'ferrous' },
+  { id: 'scrap-c', x: 42, y: 68, kind: 'capacitor' },
+  { id: 'scrap-d', x: 78, y: 24, kind: 'ferrous' },
+  { id: 'scrap-e', x: 30, y: 22, kind: 'capacitor' },
+];
+
+const kindLabel: Record<ScrapKind, string> = {
+  capacitor: 'capacitor shard',
+  ferrous: 'ferrous debris',
+};
+
+const ScrapCollectionStep = ({ onComplete }: ScrapCollectionStepProps): JSX.Element => {
+  const [scrapPieces, setScrapPieces] = useState<ScrapPiece[]>(() =>
+    SCRAP_LAYOUT.map((piece) => ({ ...piece, collected: false })),
+  );
+
+  const collectedCount = useMemo(
+    () => scrapPieces.filter((piece) => piece.collected).length,
+    [scrapPieces],
+  );
+  const totalPieces = scrapPieces.length;
+  const allCollected = collectedCount >= totalPieces;
+
+  const handleCollect = useCallback((id: string) => {
+    setScrapPieces((pieces) =>
+      pieces.map((piece) => (piece.id === id ? { ...piece, collected: true } : piece)),
+    );
+  }, []);
+
+  return (
+    <div className={styles.scrapShell}>
+      <div className={styles.card}>
+        <p className={styles.kicker}>Boot Sequence — Restore Power</p>
+        <h3 className={styles.title}>Collect nearby scrap</h3>
+        <p className={styles.copy}>
+          Hover through the wreckage and pull anything conductive back into us. Every shard you snag brings the assembler a
+          little closer to life.
+        </p>
+        <p className={styles.progress}>
+          {collectedCount} / {totalPieces} recovered
+        </p>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.fieldGlow} aria-hidden="true" />
+        {scrapPieces.map((piece) => (
+          <button
+            key={piece.id}
+            type="button"
+            className={styles.scrap}
+            style={{ left: `${piece.x}%`, top: `${piece.y}%` }}
+            onClick={() => handleCollect(piece.id)}
+            disabled={piece.collected}
+            aria-pressed={piece.collected}
+            aria-label={piece.collected ? `${kindLabel[piece.kind]} secured` : `Collect ${kindLabel[piece.kind]}`}
+          >
+            <span className={styles.scrapCore} data-kind={piece.kind} aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+      <div className={styles.actions}>
+        <button type="button" className={styles.primary} onClick={onComplete} disabled={!allCollected}>
+          Route power to assembler
+        </button>
+        <p className={styles.hint}>Tap each shard to pull it within range. We only need a handful to ignite the bay.</p>
+      </div>
+    </div>
+  );
+};
+
+export default ScrapCollectionStep;

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -84,4 +84,21 @@ describe('compileWorkspaceProgram', () => {
     const result = compileWorkspaceProgram(buildWorkspace(start));
     expect(result.program.instructions.map((instruction) => instruction.kind)).toEqual(['move', 'turn']);
   });
+
+  it('compiles the THEN branch of conditionals with a placeholder diagnostic', () => {
+    const start = createBlockInstance('start');
+    const conditional = createBlockInstance('if');
+    const thenTurn = createBlockInstance('turn');
+    const elseMove = createBlockInstance('move');
+
+    conditional.slots!.then = [thenTurn];
+    conditional.slots!.else = [elseMove];
+    start.slots!.do = [conditional];
+
+    const result = compileWorkspaceProgram(buildWorkspace(start));
+
+    expect(result.program.instructions.map((instruction) => instruction.kind)).toEqual(['turn']);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.message.includes('Conditionals'))).toBe(true);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.message.includes('Else branches'))).toBe(true);
+  });
 });

--- a/src/styles/CrashLandingStep.module.css
+++ b/src/styles/CrashLandingStep.module.css
@@ -1,0 +1,157 @@
+.crashShell {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 28rem) minmax(0, 1fr);
+  gap: var(--space-8);
+  padding: var(--space-10);
+  background: radial-gradient(circle at 20% 20%, rgba(18, 38, 75, 0.92), rgba(6, 12, 24, 0.95));
+  color: var(--color-text-inverse);
+  pointer-events: auto;
+  z-index: 5;
+}
+
+.dialogue {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-4);
+}
+
+.kicker {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.title {
+  font-size: clamp(1.75rem, 2vw, 2.4rem);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.copy {
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+  max-width: 26rem;
+}
+
+.map {
+  position: relative;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(160deg, rgba(20, 80, 120, 0.3), rgba(10, 20, 40, 0.85));
+  border: 1px solid rgba(110, 200, 255, 0.35);
+  box-shadow: 0 40px 120px rgba(6, 16, 36, 0.65);
+  overflow: hidden;
+  cursor: grab;
+}
+
+.map:active {
+  cursor: grabbing;
+}
+
+.glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 60% 40%, rgba(100, 220, 255, 0.35), transparent 60%);
+  pointer-events: none;
+}
+
+.trail {
+  position: absolute;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: rgba(140, 220, 255, 0.75);
+  transform: translate(-50%, -50%);
+  filter: blur(1px);
+}
+
+.reticle {
+  position: absolute;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  border: 2px solid rgba(200, 250, 255, 0.75);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 24px rgba(120, 240, 255, 0.5);
+  display: grid;
+  place-items: center;
+}
+
+.reticleCore {
+  display: block;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: var(--color-accent-primary);
+  box-shadow: 0 0 16px rgba(100, 249, 255, 0.8);
+}
+
+.actions {
+  position: absolute;
+  left: var(--space-10);
+  bottom: var(--space-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.primary {
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--gradient-accent);
+  color: var(--color-text-inverse);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer;
+  box-shadow: var(--shadow-glow-accent);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 80px rgba(100, 249, 255, 0.55);
+  outline: none;
+}
+
+.hint {
+  font-size: var(--font-size-sm);
+  color: rgba(225, 245, 255, 0.8);
+  max-width: 18rem;
+}
+
+@media (max-width: 960px) {
+  .crashShell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    padding: var(--space-8);
+  }
+
+  .dialogue {
+    order: 1;
+  }
+
+  .map {
+    order: 2;
+    min-height: 16rem;
+  }
+
+  .actions {
+    position: static;
+    order: 3;
+    align-items: flex-start;
+    padding-top: var(--space-4);
+  }
+}

--- a/src/styles/OnboardingFlow.module.css
+++ b/src/styles/OnboardingFlow.module.css
@@ -1,0 +1,137 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--space-9);
+  z-index: 4;
+}
+
+.overlayInteractive {
+  pointer-events: auto;
+}
+
+.card {
+  pointer-events: auto;
+  max-width: 28rem;
+  background: var(--color-surface-glass-strong);
+  border: 1px solid rgba(110, 160, 220, 0.35);
+  border-radius: var(--radius-2xl);
+  box-shadow: 0 40px 120px rgba(10, 20, 40, 0.55);
+  backdrop-filter: blur(calc(var(--blur-soft) * 1.2));
+  padding: var(--space-6) var(--space-7);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  color: var(--color-text-primary);
+}
+
+.kicker {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(160, 190, 220, 0.85);
+}
+
+.heading {
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.body {
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.primary {
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--gradient-accent);
+  color: var(--color-text-inverse);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-3) var(--space-5);
+  cursor: pointer;
+  box-shadow: var(--shadow-glow-accent);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.primary:hover,
+.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 80px rgba(100, 249, 255, 0.55);
+  outline: none;
+}
+
+.choiceCard {
+  max-width: 34rem;
+}
+
+.choiceGrid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.choice {
+  appearance: none;
+  border: 1px solid rgba(130, 170, 220, 0.35);
+  background: rgba(10, 20, 40, 0.45);
+  border-radius: var(--radius-xl);
+  color: var(--color-text-primary);
+  padding: var(--space-5);
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.choice:hover,
+.choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(140, 220, 255, 0.85);
+  box-shadow: 0 20px 60px rgba(14, 40, 70, 0.45);
+  outline: none;
+}
+
+.choiceTitle {
+  display: block;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-2);
+}
+
+.choiceCopy {
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 960px) {
+  .overlay {
+    padding: var(--space-6);
+  }
+
+  .card {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .overlay {
+    justify-content: center;
+  }
+
+  .card {
+    padding: var(--space-5);
+  }
+}

--- a/src/styles/ScrapCollectionStep.module.css
+++ b/src/styles/ScrapCollectionStep.module.css
@@ -1,0 +1,160 @@
+.scrapShell {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(18rem, 24rem) minmax(0, 1fr);
+  gap: var(--space-8);
+  padding: var(--space-10);
+  background: radial-gradient(circle at 10% 10%, rgba(12, 22, 46, 0.92), rgba(4, 10, 22, 0.95));
+  color: var(--color-text-inverse);
+  pointer-events: auto;
+  z-index: 5;
+}
+
+.card {
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.kicker {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.title {
+  font-size: clamp(1.5rem, 1.8vw, 2.15rem);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.copy {
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+}
+
+.progress {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.field {
+  position: relative;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(120, 200, 255, 0.32);
+  background: linear-gradient(200deg, rgba(18, 48, 82, 0.6), rgba(6, 12, 26, 0.85));
+  box-shadow: 0 32px 100px rgba(4, 12, 28, 0.6);
+  overflow: hidden;
+}
+
+.fieldGlow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 60% 50%, rgba(90, 220, 255, 0.25), transparent 65%);
+  pointer-events: none;
+}
+
+.scrap {
+  position: absolute;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: 1px solid rgba(140, 220, 255, 0.7);
+  background: rgba(18, 28, 50, 0.65);
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), opacity var(--transition-fast);
+}
+
+.scrap:disabled {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+
+.scrap:not(:disabled):hover,
+.scrap:not(:disabled):focus-visible {
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 0 24px rgba(120, 240, 255, 0.6);
+  outline: none;
+}
+
+.scrapCore {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  box-shadow: 0 0 18px rgba(140, 220, 255, 0.65);
+  background: var(--color-accent-primary);
+}
+
+.scrapCore[data-kind='ferrous'] {
+  background: linear-gradient(180deg, rgba(255, 170, 110, 0.9), rgba(255, 110, 65, 0.95));
+  box-shadow: 0 0 18px rgba(255, 142, 94, 0.7);
+}
+
+.actions {
+  position: absolute;
+  left: var(--space-10);
+  bottom: var(--space-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.primary {
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--gradient-accent);
+  color: var(--color-text-inverse);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer;
+  box-shadow: var(--shadow-glow-accent);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base);
+}
+
+.primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 80px rgba(100, 249, 255, 0.55);
+  outline: none;
+}
+
+.hint {
+  font-size: var(--font-size-sm);
+  color: rgba(220, 240, 255, 0.85);
+  max-width: 19rem;
+}
+
+@media (max-width: 960px) {
+  .scrapShell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    padding: var(--space-8);
+  }
+
+  .field {
+    min-height: 16rem;
+  }
+
+  .actions {
+    position: static;
+    padding-top: var(--space-4);
+  }
+}


### PR DESCRIPTION
## Summary
- add an onboarding flow that stages the crash landing, boot, first worker deployment, and choice-driven epilogue inside the main app shell
- provide interactive crash steering and scrap collection mini-sequences that set up the initial worker programme and teach the avoidance conditional edit
- extend the block library/compiler for return/deposit actions, surface conditional diagnostics, and update Playwright specs to skip the onboarding overlay

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cfa3878c38832e8cd5d3fe03af250a