### PR TITLE
Improve overlay responsiveness on small screens

### DIFF
--- a/src/components/RobotProgrammingPanel.tsx
+++ b/src/components/RobotProgrammingPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type DragEvent } from 'react';
+import { useCallback, useLayoutEffect, useRef, type DragEvent } from 'react';
 import BlockPalette from './BlockPalette';
 import Workspace from './Workspace';
 import RuntimeControls from './RuntimeControls';
@@ -21,9 +21,18 @@ const RobotProgrammingPanel = ({
   onConfirm,
   robotId,
 }: RobotProgrammingPanelProps): JSX.Element => {
+  const paletteRef = useRef<HTMLDivElement | null>(null);
   const handleConfirm = useCallback(() => {
     onConfirm();
   }, [onConfirm]);
+
+  useLayoutEffect(() => {
+    const paletteList = paletteRef.current?.querySelector('[data-testid=\"block-palette-list\"]') as HTMLElement | null;
+    const target = paletteList ?? paletteRef.current;
+    if (target && typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ block: 'start' });
+    }
+  }, [robotId]);
 
   return (
     <div className={styles.programming}>
@@ -35,7 +44,7 @@ const RobotProgrammingPanel = ({
         </p>
       </div>
       <div className={styles.layout} data-testid="programming-layout">
-        <aside className={styles.palette}>
+        <aside className={styles.palette} ref={paletteRef}>
           <h4>Block palette</h4>
           <BlockPalette blocks={BLOCK_LIBRARY} />
         </aside>

--- a/src/styles/BlockPalette.module.css
+++ b/src/styles/BlockPalette.module.css
@@ -3,9 +3,12 @@
   flex-direction: column;
   gap: var(--space-3);
   flex: 1;
-  min-height: 0;
+  min-height: 14rem;
+  height: 100%;
   overflow-y: auto;
   padding-right: var(--space-2);
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
 }
 
 .paletteItem {
@@ -69,6 +72,26 @@
 
   .paletteLabel {
     font-size: var(--font-size-sm);
+  }
+
+  .paletteSummary {
+    font-size: var(--font-size-xs);
+  }
+}
+
+@media (max-width: 520px) {
+  .blockPalette {
+    gap: var(--space-1);
+  }
+
+  .paletteItem {
+    padding: var(--space-2);
+    gap: var(--space-1);
+    border-radius: var(--radius-sm);
+  }
+
+  .paletteLabel {
+    font-size: var(--font-size-xs);
   }
 
   .paletteSummary {

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -111,3 +111,43 @@
     padding: var(--space-2);
   }
 }
+
+@media (max-width: 520px) {
+  .block {
+    padding: var(--space-2);
+    gap: var(--space-1);
+  }
+
+  .blockHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+  }
+
+  .blockTitle {
+    font-size: var(--font-size-xs);
+  }
+
+  .blockSummary {
+    font-size: var(--font-size-xs);
+  }
+
+  .blockSlots {
+    gap: var(--space-1);
+  }
+
+  .blockSlot {
+    padding: var(--space-2);
+    gap: var(--space-1);
+  }
+
+  .slotBody {
+    min-height: 2rem;
+    gap: var(--space-1);
+  }
+
+  .slotPlaceholder {
+    font-size: var(--font-size-xs);
+    padding: var(--space-1) var(--space-2);
+  }
+}

--- a/src/styles/ModuleInventory.module.css
+++ b/src/styles/ModuleInventory.module.css
@@ -203,13 +203,54 @@
 @media (max-width: 520px) {
   .inventory {
     padding: var(--space-3) var(--space-3) var(--space-4);
+    gap: var(--space-2);
+  }
+
+  .heading {
+    font-size: var(--font-size-md);
+  }
+
+  .summary {
+    font-size: var(--font-size-xs);
+  }
+
+  .list {
+    gap: var(--space-2);
   }
 
   .card {
-    padding: var(--space-3);
+    padding: var(--space-2) var(--space-2) var(--space-3);
+    gap: var(--space-2);
+  }
+
+  .cardTitle h4 {
+    font-size: var(--font-size-md);
+  }
+
+  .cardTitle p {
+    font-size: var(--font-size-xs);
+  }
+
+  .meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+  }
+
+  .status {
+    padding: var(--space-1) var(--space-2);
+  }
+
+  .details {
+    gap: var(--space-2);
+  }
+
+  .section {
+    gap: var(--space-1);
   }
 
   .section ul {
-    padding-left: 1rem;
+    padding-left: 0.9rem;
+    gap: var(--space-1);
   }
 }

--- a/src/styles/RobotProgrammingPanel.module.css
+++ b/src/styles/RobotProgrammingPanel.module.css
@@ -4,6 +4,10 @@
   gap: var(--space-6);
   height: 100%;
   min-height: 0;
+  overflow-y: auto;
+  padding-right: var(--space-2);
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
 }
 
 .summary {
@@ -134,6 +138,10 @@
 }
 
 @media (max-width: 960px) {
+  .programming {
+    padding-right: var(--space-1);
+  }
+
   .layout {
     grid-template-columns: 1fr;
     grid-template-rows: auto;
@@ -158,6 +166,7 @@
 
   .programming {
     gap: var(--space-5);
+    padding-right: 0;
   }
 
   .layout {
@@ -176,17 +185,63 @@
 }
 
 @media (max-width: 520px) {
+  .programming {
+    gap: var(--space-4);
+    padding-right: 0;
+  }
+
   .summary {
-    padding: var(--space-4);
+    padding: var(--space-3) var(--space-4);
     gap: var(--space-2);
+  }
+
+  .title {
+    font-size: var(--font-size-md);
+  }
+
+  .description {
+    font-size: var(--font-size-xs);
+  }
+
+  .palette,
+  .workspace {
+    padding: var(--space-2);
+    gap: var(--space-2);
+  }
+
+  .layout {
+    gap: var(--space-2);
+  }
+
+  .primary,
+  .secondary {
+    padding: var(--space-2) var(--space-4);
+  }
+
+  .actions {
+    gap: var(--space-2);
+  }
+}
+
+@media (max-height: 640px) {
+  .programming {
+    gap: var(--space-4);
+  }
+
+  .summary {
+    display: none;
+  }
+
+  .title {
+    font-size: var(--font-size-md);
+  }
+
+  .description {
+    font-size: var(--font-size-xs);
   }
 
   .palette,
   .workspace {
     padding: var(--space-3);
-  }
-
-  .layout {
-    gap: var(--space-3);
   }
 }

--- a/src/styles/SimulationOverlay.module.css
+++ b/src/styles/SimulationOverlay.module.css
@@ -135,16 +135,21 @@
 
 .panel {
   height: 100%;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding-right: var(--space-2);
   display: flex;
   flex-direction: column;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .panelProgramming {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding-right: 0;
 }
 
 @media (max-width: 960px) {
@@ -169,8 +174,10 @@
     padding: var(--space-5) var(--space-5) var(--space-6);
     border-radius: var(--radius-lg);
     gap: var(--space-5);
-    max-height: none;
     width: 100%;
+    max-height: calc(100vh - 2 * var(--space-5));
+    height: calc(100vh - 2 * var(--space-5));
+    align-self: stretch;
   }
 
   .tabList {
@@ -185,5 +192,6 @@
 
   .content {
     gap: var(--space-4);
+    min-height: 0;
   }
 }


### PR DESCRIPTION
## Summary
- allow the simulation overlay to scroll and adjust spacing on narrow viewports so every panel remains reachable
- tighten programming panel, block palette, and block view spacing to reduce block sizes on phones
- shrink catalogue card padding and stack metadata to improve readability in portrait mode

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d9e41ac832e9e9116158888d6cb