### PR TITLE
Auto-start default robot program

### DIFF
--- a/playwright/block-workspace.spec.ts
+++ b/playwright/block-workspace.spec.ts
@@ -39,6 +39,12 @@ test.describe('block workspace drag-and-drop', () => {
     await page.goto('/');
     await page.getByTestId('select-robot').last().click();
     await expect(page.getByTestId('robot-programming-overlay')).toBeVisible();
+
+    const stopButton = page.getByTestId('stop-program');
+    if (await stopButton.isEnabled()) {
+      await stopButton.click();
+      await expect(page.getByTestId('run-program')).toBeEnabled();
+    }
   });
 
   test('adds a palette block to the workspace root', async ({ page }) => {

--- a/playwright/resource-gathering.spec.ts
+++ b/playwright/resource-gathering.spec.ts
@@ -34,6 +34,12 @@ test.describe('resource scanning and gathering', () => {
     await page.goto('/');
     await page.getByTestId('select-robot').last().click();
     await expect(page.getByTestId('robot-programming-overlay')).toBeVisible();
+
+    const stopButton = page.getByTestId('stop-program');
+    if (await stopButton.isEnabled()) {
+      await stopButton.click();
+    }
+    await expect(page.getByTestId('run-program')).toBeEnabled();
   });
 
   test('player can scan the area and gather resources into cargo', async ({ page }) => {

--- a/src/simulation/runtime/defaultProgram.ts
+++ b/src/simulation/runtime/defaultProgram.ts
@@ -1,0 +1,27 @@
+import type { CompiledProgram } from './blockProgram';
+
+const MOVE_DURATION = 1;
+const MOVE_SPEED = 80;
+const TURN_DURATION = 1;
+const TURN_RATE = Math.PI / 2;
+const SCAN_DURATION = 1;
+const GATHER_DURATION = 1.5;
+const WAIT_DURATION = 1;
+
+export const DEFAULT_STARTUP_PROGRAM: CompiledProgram = {
+  instructions: [
+    { kind: 'scan', duration: SCAN_DURATION, filter: null },
+    {
+      kind: 'loop',
+      instructions: [
+        { kind: 'move', duration: MOVE_DURATION, speed: MOVE_SPEED },
+        { kind: 'gather', duration: GATHER_DURATION, target: 'auto' },
+        { kind: 'turn', duration: TURN_DURATION, angularVelocity: TURN_RATE / 2 },
+        { kind: 'wait', duration: WAIT_DURATION },
+        { kind: 'move', duration: MOVE_DURATION, speed: MOVE_SPEED },
+        { kind: 'turn', duration: TURN_DURATION, angularVelocity: -TURN_RATE / 2 },
+      ],
+    },
+  ],
+};
+

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { simulationRuntime } from '../simulationRuntime';
+import { DEFAULT_STARTUP_PROGRAM } from '../../simulation/runtime/defaultProgram';
+import type { RootScene } from '../../simulation/rootScene';
+
+const createSceneStub = () => {
+  const subscriptions: { status: ((status: string) => void) | null } = { status: null };
+  return {
+    subscribeProgramStatus: vi.fn((listener: (status: string) => void) => {
+      subscriptions.status = listener;
+      return () => {
+        subscriptions.status = null;
+      };
+    }),
+    getProgramStatus: vi.fn(() => 'idle' as const),
+    runProgram: vi.fn(),
+    stopProgram: vi.fn(),
+    getInventorySnapshot: vi.fn(() => ({ capacity: 0, used: 0, available: 0, entries: [] })),
+    subscribeInventory: vi.fn(() => () => {}),
+    selectRobot: vi.fn(),
+    clearRobotSelection: vi.fn(),
+    triggerStatus: (status: Parameters<NonNullable<typeof subscriptions.status>>[0]) => {
+      subscriptions.status?.(status);
+    },
+  } as unknown as RootScene & { triggerStatus: (status: Parameters<NonNullable<typeof subscriptions.status>>[0]) => void };
+};
+
+describe('simulationRuntime', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    simulationRuntime.stopProgram();
+  });
+
+  it('runs the default startup program when a scene registers', () => {
+    const scene = createSceneStub();
+
+    simulationRuntime.registerScene(scene);
+
+    expect(scene.runProgram).toHaveBeenCalledWith(DEFAULT_STARTUP_PROGRAM);
+
+    scene.triggerStatus('running');
+    expect(simulationRuntime.getStatus()).toBe('running');
+
+    simulationRuntime.unregisterScene(scene);
+  });
+
+  it('restarts the default program after unregistering the previous scene', () => {
+    const firstScene = createSceneStub();
+    simulationRuntime.registerScene(firstScene);
+    simulationRuntime.unregisterScene(firstScene);
+
+    const secondScene = createSceneStub();
+    simulationRuntime.registerScene(secondScene);
+
+    expect(secondScene.runProgram).toHaveBeenCalledWith(DEFAULT_STARTUP_PROGRAM);
+
+    simulationRuntime.unregisterScene(secondScene);
+  });
+
+  it('prioritises queued programs over the default startup routine', () => {
+    const customProgram = { instructions: [{ kind: 'wait' as const, duration: 1 }] };
+    simulationRuntime.runProgram(customProgram);
+
+    const scene = createSceneStub();
+    simulationRuntime.registerScene(scene);
+
+    expect(scene.runProgram).toHaveBeenCalledWith(customProgram);
+    expect(scene.runProgram).not.toHaveBeenCalledWith(DEFAULT_STARTUP_PROGRAM);
+
+    simulationRuntime.unregisterScene(scene);
+  });
+});
+

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -1,6 +1,7 @@
 import type { RootScene } from '../simulation/rootScene';
 import type { CompiledProgram } from '../simulation/runtime/blockProgram';
 import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
+import { DEFAULT_STARTUP_PROGRAM } from '../simulation/runtime/defaultProgram';
 import type { InventorySnapshot } from '../simulation/robot/inventory';
 
 type StatusListener = (status: ProgramRunnerStatus) => void;
@@ -25,6 +26,7 @@ class SimulationRuntime {
   private status: ProgramRunnerStatus = 'idle';
   private inventorySnapshot: InventorySnapshot = EMPTY_INVENTORY_SNAPSHOT;
   private selectedRobotId: string | null = null;
+  private hasAutoStarted = false;
 
   registerScene(scene: RootScene): void {
     if (this.scene === scene) {
@@ -42,6 +44,11 @@ class SimulationRuntime {
     this.ensureInventorySubscription();
     if (this.selectedRobotId !== null) {
       scene.selectRobot(this.selectedRobotId);
+    }
+
+    if (!this.pendingProgram && !this.hasAutoStarted) {
+      scene.runProgram(DEFAULT_STARTUP_PROGRAM);
+      this.hasAutoStarted = true;
     }
 
     if (this.pendingProgram) {
@@ -63,6 +70,7 @@ class SimulationRuntime {
     this.updateStatus('idle');
     this.updateInventorySnapshot(EMPTY_INVENTORY_SNAPSHOT);
     this.updateSelectedRobot(null);
+    this.hasAutoStarted = false;
   }
 
   runProgram(program: CompiledProgram): void {


### PR DESCRIPTION
## Summary
- add a default startup program for the lead robot and launch it automatically when a scene becomes active
- cover the new auto-start behaviour and queued-program priority with unit tests
- update Playwright specs to stop the default routine before running scripted interactions

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d15e99e98c832ebc4711435870ef71