### PR TITLE
Simplify default startup program

### DIFF
--- a/src/simulation/runtime/defaultProgram.ts
+++ b/src/simulation/runtime/defaultProgram.ts
@@ -1,25 +1,14 @@
 import type { CompiledProgram } from './blockProgram';
 
-const MOVE_DURATION = 1;
-const MOVE_SPEED = 80;
-const TURN_DURATION = 1;
-const TURN_RATE = Math.PI / 2;
-const SCAN_DURATION = 1;
-const GATHER_DURATION = 1.5;
-const WAIT_DURATION = 1;
+const BLINK_INTERVAL_SECONDS = 2;
 
 export const DEFAULT_STARTUP_PROGRAM: CompiledProgram = {
   instructions: [
-    { kind: 'scan', duration: SCAN_DURATION, filter: null },
     {
       kind: 'loop',
       instructions: [
-        { kind: 'move', duration: MOVE_DURATION, speed: MOVE_SPEED },
-        { kind: 'gather', duration: GATHER_DURATION, target: 'auto' },
-        { kind: 'turn', duration: TURN_DURATION, angularVelocity: TURN_RATE / 2 },
-        { kind: 'wait', duration: WAIT_DURATION },
-        { kind: 'move', duration: MOVE_DURATION, speed: MOVE_SPEED },
-        { kind: 'turn', duration: TURN_DURATION, angularVelocity: -TURN_RATE / 2 },
+        { kind: 'status-toggle', duration: 0 },
+        { kind: 'wait', duration: BLINK_INTERVAL_SECONDS },
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- replace the simulated startup routine with a simple loop that toggles the status indicator and waits two seconds, creating a blink

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d16d8e767c832e94b00479a9c96fb0