### PR TITLE
Add touch drag-and-drop support for block workspace

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ const DEFAULT_ROBOT_ID = 'MF-01';
 const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 
 const App = (): JSX.Element => {
-  const { workspace, handleDrop, replaceWorkspace, updateBlockInstance } = useBlockWorkspace();
+  const { workspace, handleDrop, handleTouchDrop, replaceWorkspace, updateBlockInstance } = useBlockWorkspace();
   const { selectedRobotId, clearSelection } = useRobotSelection();
   const [isOverlayOpen, setOverlayOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<OverlayTab>('inventory');
@@ -149,6 +149,7 @@ const App = (): JSX.Element => {
         onConfirm={handleOverlayClose}
         workspace={workspace}
         onDrop={handleDrop}
+        onTouchDrop={handleTouchDrop}
         onUpdateBlock={updateBlockInstance}
         robotId={activeRobotId}
       />

--- a/src/components/BlockPalette.tsx
+++ b/src/components/BlockPalette.tsx
@@ -1,15 +1,19 @@
-import type { DragEvent } from 'react';
-import type { BlockDefinition } from '../types/blocks';
+import { useCallback, useRef, type DragEvent, type TouchEvent as ReactTouchEvent } from 'react';
+import type { BlockDefinition, DragPayload, DropTarget } from '../types/blocks';
+import { getDropTargetFromTouchEvent } from '../utils/dropTarget';
 import styles from '../styles/BlockPalette.module.css';
 
 const PAYLOAD_MIME = 'application/json';
 
 interface BlockPaletteProps {
   blocks: BlockDefinition[];
+  onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
 }
 
-const BlockPalette = ({ blocks }: BlockPaletteProps): JSX.Element => {
-  const handleDragStart = (definition: BlockDefinition) => (event: DragEvent<HTMLDivElement>) => {
+const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element => {
+  const touchPayloadRef = useRef<DragPayload | null>(null);
+
+  const handleDragStart = useCallback((definition: BlockDefinition) => (event: DragEvent<HTMLDivElement>) => {
     const payload = {
       source: 'palette',
       blockType: definition.id
@@ -19,7 +23,41 @@ const BlockPalette = ({ blocks }: BlockPaletteProps): JSX.Element => {
     event.dataTransfer.dropEffect = 'copy';
     event.dataTransfer.setData(PAYLOAD_MIME, JSON.stringify(payload));
     event.dataTransfer.setData('text/plain', definition.label);
-  };
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (definition: BlockDefinition) => (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (!onTouchDrop) {
+        return;
+      }
+
+      touchPayloadRef.current = { source: 'palette', blockType: definition.id };
+      event.stopPropagation();
+    },
+    [onTouchDrop],
+  );
+
+  const handleTouchEnd = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (!onTouchDrop || !touchPayloadRef.current) {
+        touchPayloadRef.current = null;
+        return;
+      }
+
+      const dropTarget = getDropTargetFromTouchEvent(event.nativeEvent);
+      if (dropTarget) {
+        onTouchDrop(touchPayloadRef.current, dropTarget);
+        event.preventDefault();
+      }
+
+      touchPayloadRef.current = null;
+    },
+    [onTouchDrop],
+  );
+
+  const handleTouchCancel = useCallback(() => {
+    touchPayloadRef.current = null;
+  }, []);
 
   return (
     <div className={styles.blockPalette} role="list" data-testid="block-palette-list">
@@ -47,6 +85,9 @@ const BlockPalette = ({ blocks }: BlockPaletteProps): JSX.Element => {
             className={paletteItemClass}
             draggable
             onDragStart={handleDragStart(definition)}
+            onTouchStart={handleTouchStart(definition)}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchCancel}
             data-testid={`palette-${definition.id}`}
           >
             <span className={styles.paletteLabel}>{definition.label}</span>

--- a/src/components/RobotProgrammingPanel.tsx
+++ b/src/components/RobotProgrammingPanel.tsx
@@ -3,12 +3,13 @@ import BlockPalette from './BlockPalette';
 import Workspace from './Workspace';
 import RuntimeControls from './RuntimeControls';
 import { BLOCK_LIBRARY } from '../blocks/library';
-import type { WorkspaceState, DropTarget, BlockInstance } from '../types/blocks';
+import type { WorkspaceState, DropTarget, BlockInstance, DragPayload } from '../types/blocks';
 import styles from '../styles/RobotProgrammingPanel.module.css';
 
 interface RobotProgrammingPanelProps {
   workspace: WorkspaceState;
   onDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
+  onTouchDrop: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
   onClose: () => void;
   onConfirm: () => void;
@@ -18,6 +19,7 @@ interface RobotProgrammingPanelProps {
 const RobotProgrammingPanel = ({
   workspace,
   onDrop,
+  onTouchDrop,
   onUpdateBlock,
   onClose,
   onConfirm,
@@ -48,11 +50,16 @@ const RobotProgrammingPanel = ({
       <div className={styles.layout} data-testid="programming-layout">
         <aside className={styles.palette} ref={paletteRef}>
           <h4>Block palette</h4>
-          <BlockPalette blocks={BLOCK_LIBRARY} />
+          <BlockPalette blocks={BLOCK_LIBRARY} onTouchDrop={onTouchDrop} />
         </aside>
         <section className={styles.workspace}>
           <h4>Workspace</h4>
-          <Workspace blocks={workspace} onDrop={onDrop} onUpdateBlock={onUpdateBlock} />
+          <Workspace
+            blocks={workspace}
+            onDrop={onDrop}
+            onTouchDrop={onTouchDrop}
+            onUpdateBlock={onUpdateBlock}
+          />
         </section>
       </div>
       <footer className={styles.footer}>

--- a/src/components/SimulationOverlay.tsx
+++ b/src/components/SimulationOverlay.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, type DragEvent } from 'react';
 import InventoryStatus from './InventoryStatus';
 import ModuleInventory from './ModuleInventory';
 import RobotProgrammingPanel from './RobotProgrammingPanel';
-import type { WorkspaceState, DropTarget, BlockInstance } from '../types/blocks';
+import type { WorkspaceState, DropTarget, BlockInstance, DragPayload } from '../types/blocks';
 import styles from '../styles/SimulationOverlay.module.css';
 
 export type OverlayTab = 'inventory' | 'catalog' | 'programming';
@@ -23,6 +23,7 @@ interface SimulationOverlayProps {
   onConfirm: () => void;
   workspace: WorkspaceState;
   onDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
+  onTouchDrop: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
   robotId: string;
 }
@@ -35,6 +36,7 @@ const SimulationOverlay = ({
   onConfirm,
   workspace,
   onDrop,
+  onTouchDrop,
   onUpdateBlock,
   robotId,
 }: SimulationOverlayProps): JSX.Element | null => {
@@ -176,6 +178,7 @@ const SimulationOverlay = ({
             <RobotProgrammingPanel
               workspace={workspace}
               onDrop={onDrop}
+              onTouchDrop={onTouchDrop}
               onUpdateBlock={onUpdateBlock}
               onClose={onClose}
               onConfirm={onConfirm}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,15 +1,16 @@
 import { useCallback } from 'react';
 import BlockView from './BlockView';
-import type { BlockInstance, DropTarget } from '../types/blocks';
+import type { BlockInstance, DragPayload, DropTarget } from '../types/blocks';
 import styles from '../styles/Workspace.module.css';
 
 interface WorkspaceProps {
   blocks: BlockInstance[];
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
+  onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
 }
 
-const Workspace = ({ blocks, onDrop, onUpdateBlock }: WorkspaceProps): JSX.Element => {
+const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock }: WorkspaceProps): JSX.Element => {
   const handleRootDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
       onDrop(event, {
@@ -31,6 +32,9 @@ const Workspace = ({ blocks, onDrop, onUpdateBlock }: WorkspaceProps): JSX.Eleme
       <div
         className={styles.workspaceDropzone}
         data-testid="workspace-dropzone"
+        data-drop-target-kind="workspace"
+        data-drop-target-position={blocks.length}
+        data-drop-target-ancestors=""
         onDragOver={handleDragOver}
         onDrop={handleRootDrop}
       >
@@ -41,6 +45,7 @@ const Workspace = ({ blocks, onDrop, onUpdateBlock }: WorkspaceProps): JSX.Eleme
             block={block}
             path={[]}
             onDrop={onDrop}
+            onTouchDrop={onTouchDrop}
             onUpdateBlock={onUpdateBlock}
           />
         ))}

--- a/src/components/__tests__/SimulationOverlay.test.tsx
+++ b/src/components/__tests__/SimulationOverlay.test.tsx
@@ -22,6 +22,7 @@ describe('SimulationOverlay panels', () => {
     onConfirm: vi.fn(),
     workspace: [] as WorkspaceState,
     onDrop: vi.fn(),
+    onTouchDrop: vi.fn(),
     onUpdateBlock: vi.fn(),
     robotId: 'MF-01',
   } as const;

--- a/src/utils/dropTarget.ts
+++ b/src/utils/dropTarget.ts
@@ -1,0 +1,75 @@
+import type { DropTarget } from '../types/blocks';
+
+const parsePosition = (value: string | undefined): number | undefined => {
+  if (typeof value === 'undefined' || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const parseAncestorIds = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+export const getDropTargetFromElement = (element: Element | null): DropTarget | null => {
+  if (!(element instanceof HTMLElement)) {
+    return null;
+  }
+
+  const dropElement = element.closest<HTMLElement>('[data-drop-target-kind]');
+  if (!dropElement) {
+    return null;
+  }
+
+  const { dataset } = dropElement;
+  const kind = dataset.dropTargetKind;
+  const position = parsePosition(dataset.dropTargetPosition);
+  const ancestorIds = parseAncestorIds(dataset.dropTargetAncestors);
+
+  if (kind === 'workspace') {
+    return { kind: 'workspace', position, ancestorIds };
+  }
+
+  if (kind === 'slot') {
+    const ownerId = dataset.dropTargetOwnerId;
+    const slotName = dataset.dropTargetSlotName;
+
+    if (!ownerId || !slotName) {
+      return null;
+    }
+
+    return { kind: 'slot', ownerId, slotName, position, ancestorIds };
+  }
+
+  return null;
+};
+
+export const getDropTargetFromTouchEvent = (
+  event: Pick<TouchEvent, 'changedTouches'>,
+): DropTarget | null => {
+  if (typeof document === 'undefined' || typeof document.elementFromPoint !== 'function') {
+    return null;
+  }
+
+  const touchList = event.changedTouches;
+  if (!touchList || touchList.length === 0) {
+    return null;
+  }
+
+  const touch = typeof touchList.item === 'function' ? touchList.item(0) : touchList[0];
+  if (!touch) {
+    return null;
+  }
+
+  const targetElement = document.elementFromPoint(touch.clientX, touch.clientY);
+  return getDropTargetFromElement(targetElement);
+};


### PR DESCRIPTION
## Summary
- add a drop target utility so touch events can resolve the correct workspace destination
- wire touch drop handlers through the overlay, palette, workspace, and hook so touch users can drag blocks
- extend unit tests to cover touch-driven drops alongside existing drag-and-drop scenarios

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d16b797750832eb204baffd651855d