### PR TITLE
Render resource nodes with change notifications

### DIFF
--- a/src/simulation/assetService.ts
+++ b/src/simulation/assetService.ts
@@ -75,3 +75,80 @@ assetService.defineVectorAsset('robot/chassis', ({ radius = 28, fill = 0x4ecdc4,
 
   return graphic;
 });
+
+const drawShard = (graphic: Graphics, points: Array<[number, number]>, fill: number, stroke: number, alpha = 0.9): void => {
+  graphic.beginPath();
+  graphic.moveTo(points[0][0], points[0][1]);
+  for (let i = 1; i < points.length; i += 1) {
+    graphic.lineTo(points[i][0], points[i][1]);
+  }
+  graphic.closePath();
+  graphic.fill({ color: fill, alpha });
+  graphic.setStrokeStyle({ width: 2, color: stroke, alpha: 0.95 });
+  graphic.stroke();
+};
+
+assetService.defineVectorAsset('resource/default', () => {
+  const graphic = new Graphics();
+  graphic.circle(0, 0, 16);
+  graphic.fill({ color: 0xb0bec5, alpha: 0.85 });
+  graphic.setStrokeStyle({ width: 3, color: 0x455a64, alpha: 0.95 });
+  graphic.stroke();
+  return graphic;
+});
+
+assetService.defineVectorAsset('resource/ferrous-ore', () => {
+  const graphic = new Graphics();
+  const points: Array<[number, number]> = [
+    [0, -18],
+    [14, -8],
+    [16, 10],
+    [2, 18],
+    [-14, 8],
+    [-12, -10],
+  ];
+  drawShard(graphic, points, 0x6c5b7b, 0x2c3e50);
+  graphic.circle(-4, -2, 4);
+  graphic.fill({ color: 0xdcd6f7, alpha: 0.75 });
+  return graphic;
+});
+
+assetService.defineVectorAsset('resource/silicate-crystal', () => {
+  const graphic = new Graphics();
+  const shard: Array<[number, number]> = [
+    [0, -20],
+    [10, -2],
+    [6, 20],
+    [-8, 8],
+  ];
+  drawShard(graphic, shard, 0x74d2ff, 0x2a9d8f, 0.85);
+  const innerShard: Array<[number, number]> = [
+    [-6, -10],
+    [2, -4],
+    [4, 10],
+    [-6, 2],
+  ];
+  drawShard(graphic, innerShard, 0xc0f5ff, 0x2a9d8f, 0.75);
+  return graphic;
+});
+
+assetService.defineVectorAsset('resource/biotic-spore', () => {
+  const graphic = new Graphics();
+  graphic.circle(0, 0, 18);
+  graphic.fill({ color: 0xff8c94, alpha: 0.78 });
+  graphic.setStrokeStyle({ width: 3, color: 0xff2e63, alpha: 0.95 });
+  graphic.stroke();
+
+  graphic.circle(-6, -4, 6);
+  graphic.fill({ color: 0xffffff, alpha: 0.65 });
+  graphic.circle(7, 6, 4);
+  graphic.fill({ color: 0xfff0f5, alpha: 0.8 });
+  return graphic;
+});
+
+export const RESOURCE_TEXTURE_IDS: Record<string, string> = {
+  default: 'resource/default',
+  'ferrous-ore': 'resource/ferrous-ore',
+  'silicate-crystal': 'resource/silicate-crystal',
+  'biotic-spore': 'resource/biotic-spore',
+};

--- a/src/simulation/resourceLayer.ts
+++ b/src/simulation/resourceLayer.ts
@@ -1,0 +1,153 @@
+import { Container, Renderer, Sprite } from 'pixi.js';
+import { assetService, RESOURCE_TEXTURE_IDS } from './assetService';
+import type {
+  ResourceField,
+  ResourceFieldEvent,
+  ResourceNode,
+} from './resources/resourceField';
+
+interface ResourceSpriteEntry {
+  sprite: Sprite;
+  maxQuantity: number;
+}
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+export class ResourceLayer {
+  private readonly container: Container;
+  private readonly spriteEntries = new Map<string, ResourceSpriteEntry>();
+  private readonly pendingLoads = new Map<string, Promise<void>>();
+  private readonly unsubscribe: () => void;
+  private destroyed = false;
+
+  constructor(private readonly renderer: Renderer, private readonly resourceField: ResourceField) {
+    this.container = new Container();
+    this.container.sortableChildren = false;
+
+    for (const node of this.resourceField.list()) {
+      this.ensureSprite(node);
+    }
+
+    this.unsubscribe = this.resourceField.subscribe((event) => {
+      this.handleEvent(event);
+    });
+  }
+
+  get view(): Container {
+    return this.container;
+  }
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.unsubscribe();
+    for (const [nodeId, entry] of this.spriteEntries.entries()) {
+      this.disposeSprite(nodeId, entry);
+    }
+    this.spriteEntries.clear();
+    this.container.destroy({ children: true });
+  }
+
+  private handleEvent(event: ResourceFieldEvent): void {
+    if (this.destroyed) {
+      return;
+    }
+    switch (event.type) {
+      case 'added':
+        this.ensureSprite(event.node);
+        break;
+      case 'updated':
+        this.updateSprite(event.node);
+        break;
+      case 'restored':
+        this.ensureSprite(event.node);
+        break;
+      case 'depleted':
+        this.updateSprite(event.node);
+        this.removeSprite(event.node.id);
+        break;
+      case 'removed':
+        this.removeSprite(event.nodeId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private ensureSprite(node: ResourceNode): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    if (this.spriteEntries.has(node.id)) {
+      this.updateSprite(node);
+      return;
+    }
+
+    if (this.pendingLoads.has(node.id)) {
+      return;
+    }
+
+    const loadPromise = this.createSprite(node).finally(() => {
+      this.pendingLoads.delete(node.id);
+    });
+    this.pendingLoads.set(node.id, loadPromise);
+  }
+
+  private async createSprite(node: ResourceNode): Promise<void> {
+    const textureId = RESOURCE_TEXTURE_IDS[node.type] ?? RESOURCE_TEXTURE_IDS.default;
+    const texture = await assetService.loadTexture(textureId, this.renderer, { resourceType: node.type });
+    if (this.destroyed) {
+      return;
+    }
+
+    if (this.spriteEntries.has(node.id)) {
+      this.updateSprite(node);
+      return;
+    }
+
+    const sprite = new Sprite(texture);
+    sprite.anchor.set(0.5);
+    sprite.position.set(node.position.x, node.position.y);
+
+    this.container.addChild(sprite);
+    this.spriteEntries.set(node.id, {
+      sprite,
+      maxQuantity: Math.max(node.quantity, 1),
+    });
+
+    this.updateSprite(node);
+  }
+
+  private updateSprite(node: ResourceNode): void {
+    const entry = this.spriteEntries.get(node.id);
+    if (!entry) {
+      this.ensureSprite(node);
+      return;
+    }
+
+    entry.sprite.position.set(node.position.x, node.position.y);
+    entry.maxQuantity = Math.max(entry.maxQuantity, Math.max(node.quantity, 1));
+    const ratio = entry.maxQuantity > 0 ? clamp(node.quantity / entry.maxQuantity, 0, 1) : 0;
+    const alpha = node.quantity > 0 ? 0.35 + ratio * 0.65 : 0;
+    entry.sprite.alpha = alpha;
+    const scale = 0.8 + ratio * 0.4;
+    entry.sprite.scale.set(scale);
+  }
+
+  private removeSprite(nodeId: string): void {
+    const entry = this.spriteEntries.get(nodeId);
+    if (!entry) {
+      return;
+    }
+    this.disposeSprite(nodeId, entry);
+  }
+
+  private disposeSprite(nodeId: string, entry: ResourceSpriteEntry): void {
+    this.container.removeChild(entry.sprite);
+    entry.sprite.destroy({ children: true, texture: false });
+    this.spriteEntries.delete(nodeId);
+  }
+}

--- a/src/simulation/resources/__tests__/resourceField.test.ts
+++ b/src/simulation/resources/__tests__/resourceField.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ResourceField,
+  type ResourceFieldEvent,
+  type ResourceNode,
+} from '../resourceField';
+
+const origin = { x: 0, y: 0 };
+
+const createField = (nodes: ResourceNode[]): ResourceField => new ResourceField(nodes);
+
+describe('ResourceField subscriptions', () => {
+  const baseNode: ResourceNode = {
+    id: 'test-node',
+    type: 'test-resource',
+    position: { x: 0, y: 0 },
+    quantity: 10,
+  };
+
+  it('notifies listeners when harvesting reduces quantity', () => {
+    const field = createField([baseNode]);
+    const events: ResourceFieldEvent[] = [];
+    field.subscribe((event) => events.push(event));
+
+    const result = field.harvest({ nodeId: baseNode.id, origin, amount: 3, maxDistance: 10 });
+
+    expect(result.status).toBe('ok');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'updated', node: { id: baseNode.id, quantity: 7 } });
+  });
+
+  it('notifies depletion when harvesting consumes the final resources', () => {
+    const field = createField([baseNode]);
+    const events: ResourceFieldEvent[] = [];
+    field.subscribe((event) => events.push(event));
+
+    const result = field.harvest({ nodeId: baseNode.id, origin, amount: 15, maxDistance: 10 });
+
+    expect(result.status).toBe('depleted');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'depleted', node: { id: baseNode.id, quantity: 0 } });
+  });
+
+  it('emits restored when refilling a depleted node', () => {
+    const field = createField([{ ...baseNode, quantity: 0 }]);
+    const listener = vi.fn();
+    field.subscribe(listener);
+
+    field.restore(baseNode.id, 5);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'restored', node: expect.objectContaining({ id: baseNode.id, quantity: 5 }) }),
+    );
+  });
+
+  it('stops notifying once a listener unsubscribes', () => {
+    const field = createField([baseNode]);
+    const listener = vi.fn();
+    const unsubscribe = field.subscribe(listener);
+
+    field.harvest({ nodeId: baseNode.id, origin, amount: 2, maxDistance: 10 });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    field.restore(baseNode.id, 2);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add subscription API to `ResourceField` so callers are notified when nodes change, deplete, restore, or are removed
- register vector textures for resource node types and introduce a `ResourceLayer` that renders and updates sprites from field events
- hook the new layer into `RootScene` and cover the subscription mechanics with unit tests

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: missing Playwright browser binaries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16f2db374832eb3bd4cc416bb2ba1