### PR TITLE
feat: load selected robot program into workspace

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import App from './App';
 import { simulationRuntime } from './state/simulationRuntime';
 
@@ -199,6 +199,74 @@ describe('block workspace drag and drop', () => {
     const repeatBlocks = within(workspaceAfter).getAllByTestId('block-repeat');
     expect(repeatBlocks).toHaveLength(1);
     expect(within(repeatBlocks[0]).getByTestId('block-move')).toBeInTheDocument();
+  });
+
+  it('restores saved workspaces when switching between robots', async () => {
+    renderAppWithOverlay();
+
+    const [startPaletteItem] = screen.getAllByTestId('palette-start');
+    const initialDropzone = getWorkspaceDropzone();
+    const startTransfer = createDataTransfer();
+
+    fireEvent.dragStart(startPaletteItem, { dataTransfer: startTransfer });
+    fireEvent.dragOver(initialDropzone, { dataTransfer: startTransfer });
+    fireEvent.drop(initialDropzone, { dataTransfer: startTransfer });
+
+    let workspace = getWorkspaceDropzone();
+    let startBlock = within(workspace).getByTestId('block-start');
+    let doSlotDropzone = within(startBlock).getByTestId('slot-do-dropzone');
+    const [movePaletteItem] = screen.getAllByTestId('palette-move');
+    const moveTransfer = createDataTransfer();
+
+    fireEvent.dragStart(movePaletteItem, { dataTransfer: moveTransfer });
+    fireEvent.dragOver(doSlotDropzone, { dataTransfer: moveTransfer });
+    fireEvent.drop(doSlotDropzone, { dataTransfer: moveTransfer });
+
+    expect(within(startBlock).getByTestId('block-move')).toBeInTheDocument();
+
+    act(() => {
+      simulationRuntime.setSelectedRobot('MF-02');
+    });
+
+    await waitFor(() => {
+      const switchedWorkspace = getWorkspaceDropzone();
+      expect(within(switchedWorkspace).queryByTestId('block-start')).toBeNull();
+    });
+
+    const [secondStartPaletteItem] = screen.getAllByTestId('palette-start');
+    const secondDropzone = getWorkspaceDropzone();
+    const secondStartTransfer = createDataTransfer();
+
+    fireEvent.dragStart(secondStartPaletteItem, { dataTransfer: secondStartTransfer });
+    fireEvent.dragOver(secondDropzone, { dataTransfer: secondStartTransfer });
+    fireEvent.drop(secondDropzone, { dataTransfer: secondStartTransfer });
+
+    workspace = getWorkspaceDropzone();
+    startBlock = within(workspace).getByTestId('block-start');
+    doSlotDropzone = within(startBlock).getByTestId('slot-do-dropzone');
+    const [turnPaletteItem] = screen.getAllByTestId('palette-turn');
+    const turnTransfer = createDataTransfer();
+
+    fireEvent.dragStart(turnPaletteItem, { dataTransfer: turnTransfer });
+    fireEvent.dragOver(doSlotDropzone, { dataTransfer: turnTransfer });
+    fireEvent.drop(doSlotDropzone, { dataTransfer: turnTransfer });
+
+    expect(within(startBlock).getByTestId('block-turn')).toBeInTheDocument();
+
+    act(() => {
+      simulationRuntime.setSelectedRobot('MF-01');
+    });
+
+    await waitFor(() => {
+      const restoredWorkspace = getWorkspaceDropzone();
+      const restoredStart = within(restoredWorkspace).getByTestId('block-start');
+      expect(within(restoredStart).getByTestId('block-move')).toBeInTheDocument();
+      expect(within(restoredStart).queryByTestId('block-turn')).toBeNull();
+    });
+
+    act(() => {
+      simulationRuntime.clearSelectedRobot();
+    });
   });
 
   it('compiles and reports a routine when Run Program is pressed', () => {


### PR DESCRIPTION
## Summary
- track workspace programmes per robot id so selecting a robot restores its saved routine
- clear the workspace when switching to a chassis without a stored programme and keep updates isolated per robot
- add a regression test that covers switching between multiple robots and preserving their individual block layouts

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d170c754c0832ea24f0ec39d1ddcd8