### PR TITLE
Add robot deposit instruction and resource drop handling

### DIFF
--- a/src/simulation/robot/modules/__tests__/manipulationModule.test.ts
+++ b/src/simulation/robot/modules/__tests__/manipulationModule.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { RobotChassis } from '../../RobotChassis';
+import { CargoHoldModule } from '../cargoHoldModule';
+import { ManipulationModule } from '../manipulationModule';
+
+const createChassis = (): RobotChassis => {
+  const robot = new RobotChassis();
+  robot.attachModule(new CargoHoldModule({ capacity: 200 }));
+  robot.attachModule(new ManipulationModule());
+  return robot;
+};
+
+describe('ManipulationModule dropResource', () => {
+  it('drops all inventory stacks and updates telemetry', () => {
+    const robot = createChassis();
+    robot.inventory.store('ferrous-ore', 10);
+    robot.inventory.store('silicate-crystal', 5);
+
+    const result = robot.invokeAction('arm.manipulator', 'dropResource', {}) as {
+      status: string;
+      totalDropped: number;
+      resources: Array<{ resource: string; dropped: number; remaining: number }>;
+    };
+
+    expect(result.status).toBe('dropped');
+    expect(result.totalDropped).toBe(15);
+    expect(result.resources).toHaveLength(2);
+
+    const inventoryAfter = robot.getInventorySnapshot();
+    expect(inventoryAfter.used).toBe(0);
+
+    const telemetry = robot.getTelemetrySnapshot().values['arm.manipulator'];
+    expect(telemetry?.totalDeposited.value).toBe(15);
+    expect(telemetry?.operationsCompleted.value).toBe(1);
+    const lastDrop = telemetry?.lastDrop.value as { status: string; totalDropped: number } | null;
+    expect(lastDrop?.status).toBe('dropped');
+    expect(lastDrop?.totalDropped).toBe(15);
+
+    const nodes = robot.resourceField.list();
+    const nearOrigin = nodes.filter((node) => Math.hypot(node.position.x, node.position.y) <= 1);
+    expect(nearOrigin.length).toBeGreaterThanOrEqual(2);
+    expect(
+      nearOrigin.some((node) => node.type === 'ferrous-ore' && node.quantity >= 10),
+    ).toBe(true);
+    expect(
+      nearOrigin.some((node) => node.type === 'silicate-crystal' && node.quantity >= 5),
+    ).toBe(true);
+  });
+
+  it('supports targeted partial drops', () => {
+    const robot = createChassis();
+    robot.inventory.store('ferrous-ore', 10);
+
+    const result = robot.invokeAction('arm.manipulator', 'dropResource', {
+      resource: 'ferrous-ore',
+      amount: 4,
+    }) as {
+      status: string;
+      totalDropped: number;
+      resources: Array<{ remaining: number; dropped: number }>;
+    };
+
+    expect(result.status).toBe('partial');
+    expect(result.totalDropped).toBe(4);
+    expect(result.resources).toHaveLength(1);
+    expect(result.resources[0].remaining).toBe(6);
+
+    const inventoryAfter = robot.getInventorySnapshot();
+    expect(inventoryAfter.used).toBe(6);
+
+    const telemetry = robot.getTelemetrySnapshot().values['arm.manipulator'];
+    expect(telemetry?.totalDeposited.value).toBe(4);
+    const lastDrop = telemetry?.lastDrop.value as {
+      status: string;
+      totalDropped: number;
+      resources: Array<{ remaining: number }>;
+    } | null;
+    expect(lastDrop?.status).toBe('partial');
+    expect(lastDrop?.totalDropped).toBe(4);
+    expect(lastDrop?.resources[0].remaining).toBe(6);
+  });
+});

--- a/src/simulation/robot/modules/moduleLibrary.ts
+++ b/src/simulation/robot/modules/moduleLibrary.ts
@@ -117,6 +117,11 @@ export const MODULE_LIBRARY: ModuleBlueprint[] = [
         label: 'Gather resource',
         description: 'Harvest a surveyed node and transfer it into cargo storage.',
       },
+      {
+        name: 'dropResource',
+        label: 'Drop resource',
+        description: 'Release stored resources to create or expand nearby ground piles.',
+      },
     ],
     telemetry: [
       {
@@ -145,9 +150,19 @@ export const MODULE_LIBRARY: ModuleBlueprint[] = [
         description: 'Total resource units transferred into inventory.',
       },
       {
+        key: 'totalDeposited',
+        label: 'Total deposited',
+        description: 'Total resource units released back into the field.',
+      },
+      {
         key: 'lastGather',
         label: 'Last gather',
         description: 'Result payload from the most recent harvesting attempt.',
+      },
+      {
+        key: 'lastDrop',
+        label: 'Last drop',
+        description: 'Summary of the most recent drop operation.',
       },
     ],
     instantiate: () => new ManipulationModule(),

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -13,6 +13,7 @@ export type BlockInstruction =
   | { kind: 'wait'; duration: number }
   | { kind: 'scan'; duration: number; filter: string | null }
   | { kind: 'gather'; duration: number; target: 'auto' }
+  | { kind: 'deposit'; duration: number }
   | { kind: 'status-toggle'; duration: number }
   | { kind: 'status-set'; duration: number; value: boolean }
   | { kind: 'loop'; instructions: BlockInstruction[] };
@@ -89,7 +90,7 @@ const compileBlock = (
     case 'return-home':
       return [{ kind: 'move', duration: 1, speed: MOVE_SPEED }];
     case 'deposit-cargo':
-      return [{ kind: 'wait', duration: WAIT_DURATION }];
+      return [{ kind: 'deposit', duration: WAIT_DURATION }];
     case 'repeat': {
       const inner = compileSequence(block.slots?.do, diagnostics, context);
       if (inner.length === 0) {

--- a/src/simulation/runtime/blockProgramRunner.ts
+++ b/src/simulation/runtime/blockProgramRunner.ts
@@ -200,6 +200,12 @@ export class BlockProgramRunner {
         this.executeGather();
         break;
       }
+      case 'deposit': {
+        this.applyLinearVelocity(0, 0);
+        this.applyAngularVelocity(0);
+        this.executeDeposit();
+        break;
+      }
       case 'status-toggle': {
         this.applyLinearVelocity(0, 0);
         this.applyAngularVelocity(0);
@@ -303,6 +309,14 @@ export class BlockProgramRunner {
 
     const result = this.robot.invokeAction(MANIPULATOR_MODULE_ID, 'gatherResource', { nodeId });
     this.updateScanMemoryAfterGather(result);
+  }
+
+  private executeDeposit(): void {
+    if (!this.robot.moduleStack.getModule(MANIPULATOR_MODULE_ID)) {
+      return;
+    }
+
+    this.robot.invokeAction(MANIPULATOR_MODULE_ID, 'dropResource', {});
   }
 
   private resolveGatherTarget(): string | null {


### PR DESCRIPTION
## Summary
- add an upsert helper for ResourceField that reuses nearby nodes and generates ids for new piles
- extend the manipulator module with a dropResource action, telemetry, and inventory updates used by deposit instructions
- compile and run the new deposit block and cover the behaviour with unit tests

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d1758bb9ac832eab3d5cd66f7cf915