### PR TITLE
Add runtime debug overlay for simulation shell

### DIFF
--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -1,11 +1,16 @@
-import { Application, Container, Graphics, Sprite, Ticker } from 'pixi.js';
+import { Application, Container, Graphics, Sprite, Text, Ticker } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { assetService } from './assetService';
 import { RobotChassis } from './robot';
 import { DEFAULT_MODULE_LOADOUT, createModuleInstance } from './robot/modules/moduleLibrary';
 import { STATUS_MODULE_ID } from './robot/modules/statusModule';
-import type { CompiledProgram } from './runtime/blockProgram';
-import { BlockProgramRunner, type ProgramRunnerStatus } from './runtime/blockProgramRunner';
+import type { BlockInstruction, CompiledProgram } from './runtime/blockProgram';
+import {
+  BlockProgramRunner,
+  type ProgramDebugFrame,
+  type ProgramDebugState,
+  type ProgramRunnerStatus,
+} from './runtime/blockProgramRunner';
 import type { InventorySnapshot } from './robot/inventory';
 import { ResourceLayer } from './resourceLayer';
 
@@ -17,8 +22,16 @@ const STEP_MS = 1000 / 60;
 const GRID_EXTENT = 2000;
 const GRID_SPACING = 80;
 const DEFAULT_ROBOT_ID = 'MF-01';
+const DEBUG_PADDING = 8;
+const DEBUG_VERTICAL_OFFSET = 72;
+const DEBUG_CORNER_RADIUS = 8;
+const DEBUG_MAX_WIDTH = 280;
+const DEBUG_MIN_WIDTH = 180;
+const DEBUG_BACKGROUND_COLOUR = 0x0b1623;
 
 type RobotSelectionListener = (robotId: string | null) => void;
+
+type TelemetrySnapshot = ReturnType<RobotChassis['getTelemetrySnapshot']>;
 
 export class RootScene {
   private readonly app: Application;
@@ -37,6 +50,10 @@ export class RootScene {
   private selectedRobotId: string | null;
   private statusIndicator: Graphics | null;
   private resourceLayer: ResourceLayer | null;
+  private debugOverlay: Container | null;
+  private debugBackground: Graphics | null;
+  private debugText: Text | null;
+  private lastDebugText: string;
 
   constructor(app: Application) {
     this.app = app;
@@ -73,6 +90,7 @@ export class RootScene {
     this.viewport.addChild(this.backgroundLayer);
 
     this.rootLayer = new Container();
+    this.rootLayer.sortableChildren = true;
     this.viewport.addChild(this.rootLayer);
 
     this.robotCore = new RobotChassis();
@@ -83,6 +101,10 @@ export class RootScene {
 
     this.resourceLayer = null;
     this.robot = null;
+    this.debugOverlay = null;
+    this.debugBackground = null;
+    this.debugText = null;
+    this.lastDebugText = '';
     this.tickHandler = this.tick.bind(this);
     app.ticker.add(this.tickHandler as (ticker: Ticker) => void);
 
@@ -111,6 +133,7 @@ export class RootScene {
     robot.eventMode = 'static';
     robot.interactive = true;
     robot.cursor = 'pointer';
+    robot.zIndex = 10;
     robot.on('pointerdown', () => {
       this.notifyRobotSelected(DEFAULT_ROBOT_ID);
     });
@@ -120,7 +143,9 @@ export class RootScene {
     this.rootLayer.addChild(robot);
 
     this.robot = robot;
+    this.ensureDebugOverlay();
     this.updateStatusIndicator();
+    this.updateDebugOverlay();
 
     if (!this.hasPlayerPanned) {
       this.viewport.moveCenter(robot.position.x, robot.position.y);
@@ -184,6 +209,7 @@ export class RootScene {
     }
 
     this.updateStatusIndicator();
+    this.updateDebugOverlay();
   }
 
   resize(width: number, height: number): void {
@@ -251,6 +277,283 @@ export class RootScene {
     return this.selectedRobotId;
   }
 
+  private ensureDebugOverlay(): void {
+    if (this.debugOverlay) {
+      return;
+    }
+
+    const container = new Container();
+    container.visible = false;
+    container.zIndex = 1000;
+    container.eventMode = 'none';
+
+    const background = new Graphics();
+    container.addChild(background);
+
+    const text = new Text({
+      text: '',
+      style: {
+        fill: 0xffffff,
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 12,
+        lineHeight: 18,
+        wordWrap: true,
+        wordWrapWidth: DEBUG_MAX_WIDTH - DEBUG_PADDING * 2,
+      },
+    });
+    text.anchor.set(0.5, 0);
+    container.addChild(text);
+
+    this.rootLayer.addChild(container);
+    this.debugOverlay = container;
+    this.debugBackground = background;
+    this.debugText = text;
+    this.lastDebugText = '';
+  }
+
+  private updateDebugOverlay(): void {
+    if (!this.robotCore || !this.robot || !this.programRunner) {
+      this.hideDebugOverlay();
+      return;
+    }
+
+    this.ensureDebugOverlay();
+
+    if (!this.debugOverlay || !this.debugBackground || !this.debugText) {
+      return;
+    }
+
+    const programDebug = this.programRunner.getDebugState();
+    const telemetry = this.robotCore.getTelemetrySnapshot();
+
+    const lines: string[] = [];
+    const programLines = this.describeProgramDebug(programDebug);
+    if (programLines.length > 0) {
+      lines.push(...programLines);
+    }
+    const telemetryLines = this.describeTelemetry(telemetry);
+    if (telemetryLines.length > 0) {
+      if (lines.length > 0) {
+        lines.push('');
+      }
+      lines.push(...telemetryLines);
+    }
+
+    if (lines.length === 0) {
+      this.hideDebugOverlay();
+      return;
+    }
+
+    const textContent = lines.join('\n');
+    if (textContent !== this.lastDebugText) {
+      this.debugText.text = textContent;
+      this.lastDebugText = textContent;
+    }
+
+    const padding = DEBUG_PADDING;
+    const textWidth = this.debugText.width;
+    const textHeight = this.debugText.height;
+    const backgroundWidth = Math.max(Math.min(textWidth + padding * 2, DEBUG_MAX_WIDTH), DEBUG_MIN_WIDTH);
+    const backgroundHeight = textHeight + padding * 2;
+
+    this.debugBackground.clear();
+    this.debugBackground.roundRect(
+      -backgroundWidth / 2,
+      -DEBUG_VERTICAL_OFFSET - backgroundHeight,
+      backgroundWidth,
+      backgroundHeight,
+      DEBUG_CORNER_RADIUS,
+    );
+    this.debugBackground.fill({ color: DEBUG_BACKGROUND_COLOUR, alpha: 0.9 });
+    this.debugBackground.setStrokeStyle({ width: 1, color: 0xffffff, alpha: 0.35 });
+    this.debugBackground.stroke();
+
+    this.debugText.anchor.set(0.5, 0);
+    this.debugText.position.set(0, -DEBUG_VERTICAL_OFFSET - backgroundHeight + padding);
+
+    const targetX = this.robot.position.x;
+    const targetY = this.robot.position.y;
+    this.debugOverlay.position.set(targetX, targetY);
+
+    const scaleX = this.viewport.scale.x || 1;
+    const scaleY = this.viewport.scale.y || 1;
+    this.debugOverlay.scale.set(1 / scaleX, 1 / scaleY);
+    this.debugOverlay.visible = true;
+  }
+
+  private hideDebugOverlay(): void {
+    if (this.debugOverlay) {
+      this.debugOverlay.visible = false;
+    }
+    this.lastDebugText = '';
+  }
+
+  private describeProgramDebug(state: ProgramDebugState | null): string[] {
+    if (!state) {
+      return [];
+    }
+
+    const lines: string[] = [];
+    if (state.program) {
+      const totalSteps = this.countProgramInstructions(state.program);
+      const plural = totalSteps === 1 ? 'step' : 'steps';
+      lines.push(`Program: ${state.status.toUpperCase()} • ${totalSteps} ${plural}`);
+    } else {
+      lines.push(`Program: ${state.status.toUpperCase()}`);
+    }
+
+    if (state.currentInstruction) {
+      const description = this.formatInstruction(state.currentInstruction);
+      const timeRemaining = Math.max(state.timeRemaining, 0).toFixed(1);
+      lines.push(`Current: ${description} • ${timeRemaining}s`);
+    } else {
+      lines.push('Current: —');
+    }
+
+    if (state.frames.length > 0) {
+      const frameDescription = state.frames
+        .map((frame) => this.formatDebugFrame(frame))
+        .join(' ▸ ');
+      lines.push(`Stack: ${frameDescription}`);
+    } else {
+      lines.push('Stack: —');
+    }
+
+    return lines;
+  }
+
+  private formatDebugFrame(frame: ProgramDebugFrame): string {
+    if (frame.length <= 0) {
+      return frame.kind === 'sequence' ? 'seq —' : 'loop —';
+    }
+    const label = frame.kind === 'sequence' ? 'seq' : 'loop';
+    const index = Math.min(Math.max(frame.index, 0), frame.length - 1) + 1;
+    return `${label} ${index}/${frame.length}`;
+  }
+
+  private describeTelemetry(snapshot: TelemetrySnapshot): string[] {
+    const lines: string[] = [];
+    const moduleIds = new Set([
+      ...Object.keys(snapshot.values ?? {}),
+      ...Object.keys(snapshot.actions ?? {}),
+    ]);
+
+    if (moduleIds.size === 0) {
+      lines.push('ECS telemetry: —');
+      return lines;
+    }
+
+    lines.push('ECS telemetry:');
+    for (const moduleId of [...moduleIds].sort()) {
+      lines.push(`- ${moduleId}`);
+      const values = snapshot.values[moduleId] ?? {};
+      const valueKeys = Object.keys(values).sort();
+      if (valueKeys.length > 0) {
+        for (const key of valueKeys) {
+          const entry = values[key];
+          lines.push(`    ${key}: ${this.formatTelemetryValue(entry.value)}`);
+        }
+      }
+
+      const actions = snapshot.actions[moduleId] ?? {};
+      const actionNames = Object.keys(actions).sort();
+      if (actionNames.length > 0) {
+        lines.push(`    actions: ${actionNames.join(', ')}`);
+      }
+
+      if (valueKeys.length === 0 && actionNames.length === 0) {
+        lines.push('    (no signals)');
+      }
+    }
+
+    return lines;
+  }
+
+  private formatInstruction(instruction: BlockInstruction): string {
+    switch (instruction.kind) {
+      case 'move':
+        return `move • speed ${instruction.speed.toFixed(0)} • ${instruction.duration.toFixed(1)}s`;
+      case 'turn':
+        return `turn • rate ${(instruction.angularVelocity * (180 / Math.PI)).toFixed(0)}°/s • ${instruction.duration.toFixed(1)}s`;
+      case 'wait':
+        return `wait • ${instruction.duration.toFixed(1)}s`;
+      case 'scan':
+        return `scan${instruction.filter ? ` • ${instruction.filter}` : ''} • ${instruction.duration.toFixed(1)}s`;
+      case 'gather':
+        return `gather • ${instruction.duration.toFixed(1)}s`;
+      case 'deposit':
+        return `deposit • ${instruction.duration.toFixed(1)}s`;
+      case 'status-toggle':
+        return 'status toggle';
+      case 'status-set':
+        return `status set • ${instruction.value ? 'on' : 'off'}`;
+      case 'loop':
+        return `loop • ${instruction.instructions.length} step${instruction.instructions.length === 1 ? '' : 's'}`;
+      default:
+        return (instruction as { kind?: string }).kind ?? 'unknown';
+    }
+  }
+
+  private formatTelemetryValue(value: unknown): string {
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        return String(value);
+      }
+      if (Math.abs(value) >= 1000) {
+        return value.toFixed(0);
+      }
+      if (Math.abs(value) >= 1) {
+        return value.toFixed(1);
+      }
+      return value.toFixed(2);
+    }
+    if (typeof value === 'string' || typeof value === 'boolean') {
+      return String(value);
+    }
+    if (Array.isArray(value)) {
+      const items = value.map((entry) => this.formatTelemetryValue(entry));
+      const serialised = `[${items.join(', ')}]`;
+      return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
+    }
+    if (value && typeof value === 'object') {
+      try {
+        const serialised = JSON.stringify(value);
+        if (!serialised) {
+          return 'object';
+        }
+        return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
+      } catch (error) {
+        return 'object';
+      }
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value === 'undefined' ? 'undefined' : String(value);
+  }
+
+  private countProgramInstructions(program: CompiledProgram | null): number {
+    if (!program) {
+      return 0;
+    }
+    return this.countInstructions(program.instructions);
+  }
+
+  private countInstructions(instructions: BlockInstruction[] | undefined): number {
+    if (!instructions || instructions.length === 0) {
+      return 0;
+    }
+
+    let total = 0;
+    for (const instruction of instructions) {
+      total += 1;
+      if (instruction.kind === 'loop') {
+        total += this.countInstructions(instruction.instructions);
+      }
+    }
+    return total;
+  }
+
   destroy(): void {
     this.app.ticker.remove(this.tickHandler as (ticker: Ticker) => void);
     this.viewport.destroy({ children: true, texture: false });
@@ -260,6 +563,13 @@ export class RootScene {
     this.programStatus = 'idle';
     this.notifyRobotSelected(null);
     this.selectionListeners.clear();
+    if (this.debugOverlay) {
+      this.debugOverlay.destroy({ children: true });
+      this.debugOverlay = null;
+      this.debugBackground = null;
+      this.debugText = null;
+    }
+    this.lastDebugText = '';
     if (this.resourceLayer) {
       this.rootLayer.removeChild(this.resourceLayer.view);
       this.resourceLayer.destroy();


### PR DESCRIPTION
## Summary
- add a Pixi debug overlay in the simulation root scene that displays the active program, current instruction, and module telemetry above the robot
- expose structured debug information from the block program runner so visual overlays can track the execution stack
- extend the runtime unit tests to exercise the new debug state reporting

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d244e37938832ebcadc075aa604c22