### PR TITLE
Enable reordering and reparenting of workspace blocks

### DIFF
--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useState, type ReactNode } from 'react';
+import type { DropTarget } from '../types/blocks';
+import styles from '../styles/DropZone.module.css';
+
+interface DropZoneProps {
+  className?: string;
+  target: DropTarget;
+  onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
+  children?: ReactNode;
+}
+
+const joinClassNames = (classNames: Array<string | undefined>): string =>
+  classNames.filter(Boolean).join(' ');
+
+const DropZone = ({ className, target, onDrop, children }: DropZoneProps): JSX.Element => {
+  const [isActive, setIsActive] = useState(false);
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const handleDragEnter = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+
+    setIsActive(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+
+    setIsActive(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsActive(false);
+      onDrop(event, target);
+    },
+    [onDrop, target],
+  );
+
+  const classNames = joinClassNames([styles.dropZone, className]);
+  const ancestorIds = target.ancestorIds.join(',');
+
+  return (
+    <div
+      className={classNames}
+      data-drop-target-kind={target.kind}
+      data-drop-target-position={typeof target.position === 'number' ? String(target.position) : ''}
+      data-drop-target-ancestors={ancestorIds}
+      data-drop-target-owner-id={target.kind === 'slot' ? target.ownerId : undefined}
+      data-drop-target-slot-name={target.kind === 'slot' ? target.slotName : undefined}
+      data-dropzone-active={isActive ? 'true' : undefined}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DropZone;

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from 'react';
+import { Fragment, useCallback } from 'react';
 import BlockView from './BlockView';
-import type { BlockInstance, DragPayload, DropTarget } from '../types/blocks';
+import DropZone from './DropZone';
+import type { BlockInstance, DropTarget, DragPayload } from '../types/blocks';
 import styles from '../styles/Workspace.module.css';
 
 interface WorkspaceProps {
@@ -11,18 +12,20 @@ interface WorkspaceProps {
 }
 
 const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock }: WorkspaceProps): JSX.Element => {
-  const handleRootDrop = useCallback(
+  const workspaceTarget = (position: number): DropTarget => ({
+    kind: 'workspace',
+    position,
+    ancestorIds: [],
+  });
+
+  const handleContainerDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
-      onDrop(event, {
-        kind: 'workspace',
-        position: blocks.length,
-        ancestorIds: [],
-      });
+      onDrop(event, workspaceTarget(blocks.length));
     },
     [blocks.length, onDrop],
   );
 
-  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+  const handleContainerDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
   }, []);
@@ -35,20 +38,46 @@ const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock }: WorkspaceProp
         data-drop-target-kind="workspace"
         data-drop-target-position={blocks.length}
         data-drop-target-ancestors=""
-        onDragOver={handleDragOver}
-        onDrop={handleRootDrop}
+        onDrop={handleContainerDrop}
+        onDragOver={handleContainerDragOver}
       >
-        {blocks.length === 0 ? <p className={styles.workspaceEmpty}>Drag blocks here to start building</p> : null}
-        {blocks.map((block) => (
-          <BlockView
-            key={block.instanceId}
-            block={block}
-            path={[]}
-            onDrop={onDrop}
-            onTouchDrop={onTouchDrop}
-            onUpdateBlock={onUpdateBlock}
-          />
-        ))}
+        {blocks.length === 0 ? (
+          <DropZone className={styles.workspaceDropTargetEmpty} target={workspaceTarget(0)} onDrop={onDrop}>
+            <p className={styles.workspaceEmpty}>Drag blocks here to start building</p>
+          </DropZone>
+        ) : (
+          <>
+            <DropZone
+              className={`${styles.workspaceDropTarget} ${styles.workspaceDropTargetLeading}`}
+              target={workspaceTarget(0)}
+              onDrop={onDrop}
+            />
+            {blocks.map((block, index) => {
+              const trailingClassName =
+                index === blocks.length - 1 ? styles.workspaceDropTargetTrailing : undefined;
+              const dropTargetClassName = [styles.workspaceDropTarget, trailingClassName]
+                .filter(Boolean)
+                .join(' ');
+
+              return (
+                <Fragment key={block.instanceId}>
+                  <BlockView
+                    block={block}
+                    path={[]}
+                    onDrop={onDrop}
+                    onTouchDrop={onTouchDrop}
+                    onUpdateBlock={onUpdateBlock}
+                  />
+                  <DropZone
+                    className={dropTargetClassName}
+                    target={workspaceTarget(index + 1)}
+                    onDrop={onDrop}
+                  />
+                </Fragment>
+              );
+            })}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/state/__tests__/blockUtils.test.ts
+++ b/src/state/__tests__/blockUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { insertBlock, removeBlock } from '../blockUtils';
+import type { BlockInstance, DropTarget } from '../../types/blocks';
+
+const createBlock = (instanceId: string, slots?: Record<string, BlockInstance[]>): BlockInstance => ({
+  instanceId,
+  type: 'mock-block',
+  ...(slots ? { slots } : {}),
+});
+
+describe('blockUtils', () => {
+  it('inserts a block into the workspace at the requested position', () => {
+    const blocks = [createBlock('a'), createBlock('b')];
+    const blockToInsert = createBlock('c');
+    const target: DropTarget = { kind: 'workspace', position: 1, ancestorIds: [] };
+
+    const result = insertBlock(blocks, target, blockToInsert);
+
+    expect(result.inserted).toBe(true);
+    expect(result.blocks.map((block) => block.instanceId)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('reorders an existing workspace block when reinserting at a different position', () => {
+    const blocks = [createBlock('a'), createBlock('b'), createBlock('c')];
+
+    const removal = removeBlock(blocks, 'b');
+    expect(removal.removed?.instanceId).toBe('b');
+
+    const target: DropTarget = { kind: 'workspace', position: 2, ancestorIds: [] };
+    const insertion = insertBlock(removal.blocks, target, removal.removed!);
+
+    expect(insertion.inserted).toBe(true);
+    expect(insertion.blocks.map((block) => block.instanceId)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('moves a block with its children into a new slot', () => {
+    const grandchild = createBlock('grandchild');
+    const child = createBlock('child', { chain: [grandchild] });
+    const sourceParent = createBlock('source-parent', { actions: [child] });
+    const destinationParent = createBlock('destination-parent', { actions: [] });
+    const workspace = [sourceParent, destinationParent];
+
+    const removal = removeBlock(workspace, 'child');
+    expect(removal.removed?.instanceId).toBe('child');
+    expect(removal.removed?.slots?.chain?.[0]?.instanceId).toBe('grandchild');
+
+    const target: DropTarget = {
+      kind: 'slot',
+      ownerId: 'destination-parent',
+      slotName: 'actions',
+      position: 0,
+      ancestorIds: ['destination-parent'],
+    };
+
+    const insertion = insertBlock(removal.blocks, target, removal.removed!);
+
+    expect(insertion.inserted).toBe(true);
+    const destinationSlot = insertion.blocks[1]?.slots?.actions ?? [];
+    expect(destinationSlot.map((block) => block.instanceId)).toEqual(['child']);
+    expect(destinationSlot[0]?.slots?.chain?.[0]?.instanceId).toBe('grandchild');
+    const sourceSlot = insertion.blocks[0]?.slots?.actions ?? [];
+    expect(sourceSlot).toHaveLength(0);
+  });
+});

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -99,7 +99,44 @@
   min-height: 2.75rem;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 0;
+}
+
+.slotDropTarget {
+  min-height: 0.75rem;
+  margin: var(--space-2) 0;
+}
+
+.slotDropTarget::after {
+  content: '';
+  position: absolute;
+  left: var(--space-2);
+  right: var(--space-2);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: rgba(100, 249, 255, 0.18);
+  opacity: 0;
+  transition: opacity var(--transition-base), background var(--transition-base);
+}
+
+.slotDropTarget[data-dropzone-active='true']::after {
+  opacity: 1;
+  background: var(--color-accent-cyan);
+}
+
+.slotDropTargetLeading {
+  margin-top: 0;
+}
+
+.slotDropTargetTrailing {
+  margin-bottom: 0;
+}
+
+.slotDropTargetEmpty {
+  min-height: 3.5rem;
+  margin: var(--space-2) 0;
+  border-color: var(--color-slot-border);
+  background: rgba(155, 107, 255, 0.12);
 }
 
 .slotPlaceholder {
@@ -134,7 +171,7 @@
   }
 
   .slotBody {
-    gap: var(--space-2);
+    gap: 0;
   }
 
   .slotPlaceholder {

--- a/src/styles/DropZone.module.css
+++ b/src/styles/DropZone.module.css
@@ -1,0 +1,18 @@
+.dropZone {
+  position: relative;
+  width: 100%;
+  min-height: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px dashed transparent;
+  transition: background var(--transition-base), border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.dropZone[data-dropzone-active='true'] {
+  border-color: rgba(100, 249, 255, 0.5);
+  background: rgba(100, 249, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(100, 249, 255, 0.24);
+}

--- a/src/styles/Workspace.module.css
+++ b/src/styles/Workspace.module.css
@@ -13,8 +13,47 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 0;
   box-shadow: inset 0 0 0 1px var(--color-dropzone-inner);
+}
+
+.workspaceDropTarget {
+  min-height: 0.85rem;
+  margin: var(--space-3) 0;
+}
+
+.workspaceDropTarget::after {
+  content: '';
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: rgba(100, 249, 255, 0.2);
+  opacity: 0;
+  transition: opacity var(--transition-base), background var(--transition-base);
+}
+
+.workspaceDropTarget[data-dropzone-active='true']::after {
+  opacity: 1;
+  background: var(--color-accent-cyan);
+}
+
+.workspaceDropTargetLeading {
+  margin-top: 0;
+}
+
+.workspaceDropTargetTrailing {
+  margin-bottom: 0;
+}
+
+.workspaceDropTargetEmpty {
+  min-height: 8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-color: var(--color-dropzone-border);
+  background: rgba(12, 26, 54, 0.35);
 }
 
 .workspaceEmpty {


### PR DESCRIPTION
## Summary
- add a dedicated DropZone component that advertises drop targets with visual feedback
- allow workspace and slot containers to expose positional drop zones so blocks can be reordered or reparented while dragging
- cover block insertion and movement logic with new unit tests to ensure children move along with their parents

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d247506d64832e9b9e63473bd6410d