### PR TITLE
Improve block sizing and palette layout

### DIFF
--- a/src/components/BlockPalette.tsx
+++ b/src/components/BlockPalette.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useRef, type DragEvent, type TouchEvent as ReactTouchEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent,
+  type TouchEvent as ReactTouchEvent,
+} from 'react';
 import type { BlockDefinition, DragPayload, DropTarget } from '../types/blocks';
 import { getDropTargetFromTouchEvent } from '../utils/dropTarget';
 import styles from '../styles/BlockPalette.module.css';
@@ -11,6 +18,8 @@ interface BlockPaletteProps {
 }
 
 const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element => {
+  const [activeSummaryId, setActiveSummaryId] = useState<string | null>(null);
+  const paletteRef = useRef<HTMLDivElement | null>(null);
   const touchPayloadRef = useRef<DragPayload | null>(null);
 
   const handleDragStart = useCallback((definition: BlockDefinition) => (event: DragEvent<HTMLDivElement>) => {
@@ -70,8 +79,45 @@ const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element =
     touchPayloadRef.current = null;
   }, []);
 
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (!paletteRef.current) {
+        return;
+      }
+
+      if (paletteRef.current.contains(event.target as Node)) {
+        return;
+      }
+
+      setActiveSummaryId(null);
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, []);
+
+  const handlePaletteItemClick = useCallback((definitionId: string) => () => {
+    setActiveSummaryId(definitionId);
+  }, []);
+
+  const handlePaletteItemMouseLeave = useCallback((definitionId: string) => () => {
+    setActiveSummaryId((current) => (current === definitionId ? null : current));
+  }, []);
+
+  const handlePaletteItemBlur = useCallback((definitionId: string) => () => {
+    setActiveSummaryId((current) => (current === definitionId ? null : current));
+  }, []);
+
   return (
-    <div className={styles.blockPalette} role="list" data-testid="block-palette-list">
+    <div
+      className={styles.blockPalette}
+      role="list"
+      data-testid="block-palette-list"
+      ref={paletteRef}
+    >
       {blocks.map((definition) => {
         const paletteItemClasses = [styles.paletteItem];
         switch (definition.category) {
@@ -88,7 +134,12 @@ const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element =
             paletteItemClasses.push(styles.paletteItemAction);
             break;
         }
+        if (definition.summary && activeSummaryId === definition.id) {
+          paletteItemClasses.push(styles.paletteItemActive);
+        }
+
         const paletteItemClass = paletteItemClasses.join(' ');
+        const isSummaryActive = Boolean(definition.summary && activeSummaryId === definition.id);
         return (
           <div
             key={definition.id}
@@ -100,10 +151,24 @@ const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element =
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
             onTouchCancel={handleTouchCancel}
+            onClick={handlePaletteItemClick(definition.id)}
+            onFocus={handlePaletteItemClick(definition.id)}
+            onMouseLeave={handlePaletteItemMouseLeave(definition.id)}
+            onBlur={handlePaletteItemBlur(definition.id)}
+            tabIndex={0}
             data-testid={`palette-${definition.id}`}
           >
             <span className={styles.paletteLabel}>{definition.label}</span>
-            {definition.summary ? <small className={styles.paletteSummary}>{definition.summary}</small> : null}
+            {definition.summary ? (
+              <small
+                className={`${styles.paletteSummary} ${
+                  isSummaryActive ? styles.paletteSummaryVisible : ''
+                }`}
+                aria-hidden={isSummaryActive ? false : true}
+              >
+                {definition.summary}
+              </small>
+            ) : null}
           </div>
         );
       })}

--- a/src/styles/BlockPalette.module.css
+++ b/src/styles/BlockPalette.module.css
@@ -1,6 +1,9 @@
 .blockPalette {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  justify-items: start;
+  align-items: start;
+  grid-auto-rows: max-content;
   gap: var(--space-3);
   flex: 1;
   min-height: 14rem;
@@ -9,6 +12,7 @@
   padding-right: var(--space-2);
   scrollbar-gutter: stable;
   -webkit-overflow-scrolling: touch;
+  align-content: start;
 }
 
 .paletteItem {
@@ -23,12 +27,21 @@
   gap: var(--space-2);
   color: var(--color-text-primary);
   transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+  position: relative;
+  width: fit-content;
+  max-width: min(100%, 22rem);
+  align-self: start;
 }
 
 .paletteItem:active {
   cursor: grabbing;
   transform: scale(0.98);
   box-shadow: 0 12px 32px rgba(2, 6, 18, 0.65);
+}
+
+.paletteItem:focus-visible {
+  outline: 2px solid var(--color-accent-cyan);
+  outline-offset: 2px;
 }
 
 .paletteItemAction {
@@ -57,10 +70,31 @@
 .paletteSummary {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: opacity var(--transition-base), max-height var(--transition-base), margin-top var(--transition-base);
+  margin: 0;
+  pointer-events: none;
+}
+
+.paletteSummaryVisible,
+.paletteItem:hover .paletteSummary,
+.paletteItem:focus-within .paletteSummary {
+  opacity: 1;
+  max-height: 12rem;
+  margin-top: var(--space-2);
+  pointer-events: auto;
+}
+
+.paletteItemActive {
+  border-color: var(--color-accent-cyan);
+  box-shadow: 0 18px 42px rgba(100, 249, 255, 0.2);
 }
 
 @media (max-width: 720px) {
   .blockPalette {
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
     gap: var(--space-2);
     padding-right: 0;
   }
@@ -76,11 +110,13 @@
 
   .paletteSummary {
     font-size: var(--font-size-xs);
+    max-height: 10rem;
   }
 }
 
 @media (max-width: 520px) {
   .blockPalette {
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     gap: var(--space-1);
   }
 
@@ -96,5 +132,6 @@
 
   .paletteSummary {
     font-size: var(--font-size-xs);
+    max-height: 8rem;
   }
 }

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -8,6 +8,9 @@
   flex-direction: column;
   gap: var(--space-3);
   color: var(--color-text-primary);
+  align-self: flex-start;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .blockAction {

--- a/src/styles/Workspace.module.css
+++ b/src/styles/Workspace.module.css
@@ -15,6 +15,7 @@
   flex-direction: column;
   gap: 0;
   box-shadow: inset 0 0 0 1px var(--color-dropzone-inner);
+  align-items: flex-start;
 }
 
 .workspaceDropTarget {


### PR DESCRIPTION
## Summary
- size workspace blocks to their content while keeping the dropzone alignment tidy
- redesign the block palette with a responsive grid and focus styles for compact rows
- reveal palette descriptions on hover or activation and hide them when focus or pointer leaves

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d250f57ed0832e81c891500c366517