### PR TITLE
Add ECS systems for simulation tick flow

### DIFF
--- a/src/simulation/ecs/index.ts
+++ b/src/simulation/ecs/index.ts
@@ -1,1 +1,2 @@
 export * from './world';
+export * from './systems';

--- a/src/simulation/ecs/systems/__tests__/systems.test.ts
+++ b/src/simulation/ecs/systems/__tests__/systems.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Sprite } from 'pixi.js';
+
+import { ECSWorld } from '../../world';
+import { createProgramRunnerSystem, createRobotPhysicsSystem, createSpriteSyncSystem } from '../index';
+import { BlockProgramRunner } from '../../../runtime/blockProgramRunner';
+import { RobotChassis } from '../../../robot';
+import type { TransformComponent } from '../../../runtime/simulationWorld';
+
+const createSpriteStub = (): Sprite => {
+  const position = {
+    x: 0,
+    y: 0,
+    set(x: number, y: number) {
+      this.x = x;
+      this.y = y;
+    },
+  };
+
+  return {
+    rotation: 0,
+    position,
+  } as unknown as Sprite;
+};
+
+describe('simulation systems', () => {
+  it('advances program runners by the provided delta time', () => {
+    const world = new ECSWorld();
+    const ProgramRunner = world.defineComponent<BlockProgramRunner>('ProgramRunner');
+    const entity = world.createEntity();
+    const runner = new BlockProgramRunner(new RobotChassis());
+    const updateSpy = vi.spyOn(runner, 'update');
+
+    ProgramRunner.set(entity, runner);
+    world.addSystem(createProgramRunnerSystem({ ProgramRunner }));
+
+    world.runSystems(0.25);
+
+    expect(updateSpy).toHaveBeenCalledWith(0.25);
+  });
+
+  it('ticks robot cores and copies state into the transform component', () => {
+    const world = new ECSWorld();
+    const Transform = world.defineComponent<TransformComponent>('Transform');
+    const RobotCore = world.defineComponent<RobotChassis>('RobotCore');
+    const entity = world.createEntity();
+    const robot = new RobotChassis();
+
+    robot.state.setLinearVelocity(2, -1);
+    robot.state.setAngularVelocity(Math.PI);
+
+    RobotCore.set(entity, robot);
+    Transform.set(entity, { position: { x: 0, y: 0 }, rotation: 0 });
+
+    world.addSystem(createRobotPhysicsSystem({ RobotCore, Transform }));
+    world.runSystems(0.5);
+
+    const transform = Transform.get(entity);
+    expect(transform).toBeDefined();
+    expect(transform?.position.x).toBeCloseTo(1);
+    expect(transform?.position.y).toBeCloseTo(-0.5);
+    expect(transform?.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('applies transform updates to the sprite component', () => {
+    const world = new ECSWorld();
+    const Transform = world.defineComponent<TransformComponent>('Transform');
+    const SpriteRef = world.defineComponent<Sprite>('SpriteRef');
+    const entity = world.createEntity();
+    const sprite = createSpriteStub();
+
+    Transform.set(entity, {
+      position: { x: -3, y: 7 },
+      rotation: Math.PI / 3,
+    });
+    SpriteRef.set(entity, sprite);
+
+    world.addSystem(createSpriteSyncSystem({ Transform, SpriteRef }));
+    world.runSystems(1);
+
+    expect(sprite.rotation).toBeCloseTo(Math.PI / 3);
+    expect(sprite.position.x).toBeCloseTo(-3);
+    expect(sprite.position.y).toBeCloseTo(7);
+  });
+});

--- a/src/simulation/ecs/systems/index.ts
+++ b/src/simulation/ecs/systems/index.ts
@@ -1,0 +1,3 @@
+export * from './programRunnerSystem';
+export * from './robotPhysicsSystem';
+export * from './spriteSyncSystem';

--- a/src/simulation/ecs/systems/programRunnerSystem.ts
+++ b/src/simulation/ecs/systems/programRunnerSystem.ts
@@ -1,0 +1,19 @@
+import type { BlockProgramRunner } from '../../runtime/blockProgramRunner';
+import type { SimulationWorldComponents } from '../../runtime/simulationWorld';
+import type { ComponentHandle, System } from '../world';
+
+export function createProgramRunnerSystem({
+  ProgramRunner,
+}: Pick<SimulationWorldComponents, 'ProgramRunner'>): System<[
+  ComponentHandle<BlockProgramRunner>,
+]> {
+  return {
+    name: 'ProgramRunnerSystem',
+    components: [ProgramRunner],
+    update: (_world, entities, delta) => {
+      for (const [, runner] of entities) {
+        runner.update(delta);
+      }
+    },
+  };
+}

--- a/src/simulation/ecs/systems/robotPhysicsSystem.ts
+++ b/src/simulation/ecs/systems/robotPhysicsSystem.ts
@@ -1,0 +1,26 @@
+import type { RobotChassis } from '../../robot';
+import type { SimulationWorldComponents, TransformComponent } from '../../runtime/simulationWorld';
+import type { ComponentHandle, System } from '../world';
+
+export function createRobotPhysicsSystem({
+  RobotCore,
+  Transform,
+}: Pick<SimulationWorldComponents, 'RobotCore' | 'Transform'>): System<[
+  ComponentHandle<RobotChassis>,
+  ComponentHandle<TransformComponent>,
+]> {
+  return {
+    name: 'RobotPhysicsSystem',
+    components: [RobotCore, Transform],
+    update: (_world, entities, delta) => {
+      for (const [entity, robot] of entities) {
+        robot.tick(delta);
+        const state = robot.getStateSnapshot();
+        Transform.set(entity, {
+          position: { x: state.position.x, y: state.position.y },
+          rotation: state.orientation,
+        });
+      }
+    },
+  };
+}

--- a/src/simulation/ecs/systems/spriteSyncSystem.ts
+++ b/src/simulation/ecs/systems/spriteSyncSystem.ts
@@ -1,0 +1,22 @@
+import type { Sprite } from 'pixi.js';
+import type { SimulationWorldComponents, TransformComponent } from '../../runtime/simulationWorld';
+import type { ComponentHandle, System } from '../world';
+
+export function createSpriteSyncSystem({
+  Transform,
+  SpriteRef,
+}: Pick<SimulationWorldComponents, 'Transform' | 'SpriteRef'>): System<[
+  ComponentHandle<TransformComponent>,
+  ComponentHandle<Sprite>,
+]> {
+  return {
+    name: 'SpriteSyncSystem',
+    components: [Transform, SpriteRef],
+    update: (_world, entities) => {
+      for (const [, transform, sprite] of entities) {
+        sprite.rotation = transform.rotation;
+        sprite.position.set(transform.position.x, transform.position.y);
+      }
+    },
+  };
+}

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -222,27 +222,7 @@ export class RootScene {
     this.viewport.update(stepSeconds * 60);
 
     const context = this.context;
-    const programRunner = context?.getProgramRunner();
-    if (programRunner) {
-      programRunner.update(stepSeconds);
-    }
-
-    if (context) {
-      const robotCore = context.getRobotCore();
-      if (robotCore) {
-        robotCore.tick(stepSeconds);
-        const state = robotCore.getStateSnapshot();
-        context.setTransform(context.entities.robot, {
-          position: { x: state.position.x, y: state.position.y },
-          rotation: state.orientation,
-        });
-        const sprite = context.getSprite();
-        if (sprite) {
-          sprite.rotation = state.orientation;
-          sprite.position.set(state.position.x, state.position.y);
-        }
-      }
-    }
+    context?.world.runSystems(stepSeconds);
 
     this.updateStatusIndicator();
     this.updateDebugOverlay();

--- a/src/simulation/runtime/simulationWorld.ts
+++ b/src/simulation/runtime/simulationWorld.ts
@@ -1,6 +1,11 @@
 import { Sprite, type Renderer } from 'pixi.js';
 import { assetService } from '../assetService';
 import { ECSWorld, type ComponentHandle, type EntityId } from '../ecs';
+import {
+  createProgramRunnerSystem,
+  createRobotPhysicsSystem,
+  createSpriteSyncSystem,
+} from '../ecs/systems';
 import { RobotChassis } from '../robot';
 import { DEFAULT_MODULE_LOADOUT, createModuleInstance } from '../robot/modules/moduleLibrary';
 import { BlockProgramRunner } from './blockProgramRunner';
@@ -149,6 +154,10 @@ export async function createSimulationWorld({
     selectRobot,
     getSelectedRobot,
   };
+
+  world.addSystem(createProgramRunnerSystem({ ProgramRunner }));
+  world.addSystem(createRobotPhysicsSystem({ RobotCore, Transform }));
+  world.addSystem(createSpriteSyncSystem({ Transform, SpriteRef }));
 
   return context;
 }


### PR DESCRIPTION
## Summary
- add ECS systems for the program runner, robot physics, and sprite synchronisation
- register the new systems in the simulation world and drive ticks via `world.runSystems`
- add unit coverage for the simulation systems

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d25fc69650832e8bd9ed2a29733ace