### PR TITLE
Refactor debug overlay and status indicator into ECS systems

### DIFF
--- a/src/simulation/ecs/systems/__tests__/systems.test.ts
+++ b/src/simulation/ecs/systems/__tests__/systems.test.ts
@@ -1,11 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Sprite } from 'pixi.js';
+import type { Container, Graphics, Sprite, Text } from 'pixi.js';
+import type { Viewport } from 'pixi-viewport';
 
 import { ECSWorld } from '../../world';
-import { createProgramRunnerSystem, createRobotPhysicsSystem, createSpriteSyncSystem } from '../index';
-import { BlockProgramRunner } from '../../../runtime/blockProgramRunner';
+import {
+  createDebugOverlaySystem,
+  createProgramRunnerSystem,
+  createRobotPhysicsSystem,
+  createSpriteSyncSystem,
+  createStatusIndicatorSystem,
+} from '../index';
+import {
+  BlockProgramRunner,
+  type ProgramDebugState,
+} from '../../../runtime/blockProgramRunner';
 import { RobotChassis } from '../../../robot';
-import type { TransformComponent } from '../../../runtime/simulationWorld';
+import { STATUS_MODULE_ID } from '../../../robot/modules/statusModule';
+import type {
+  DebugOverlayComponent,
+  StatusIndicatorComponent,
+  TransformComponent,
+} from '../../../runtime/simulationWorld';
+import {
+  DEBUG_CORNER_RADIUS,
+  DEBUG_MAX_WIDTH,
+  DEBUG_MIN_WIDTH,
+  DEBUG_PADDING,
+  DEBUG_VERTICAL_OFFSET,
+} from '../../../runtime/simulationWorld';
+import type { BlockInstruction, CompiledProgram } from '../../../runtime/blockProgram';
 
 const createSpriteStub = (): Sprite => {
   const position = {
@@ -22,6 +45,85 @@ const createSpriteStub = (): Sprite => {
     position,
   } as unknown as Sprite;
 };
+
+const createOverlayLayerStub = (): Container => {
+  const layer: { addChild(child: Container): Container } & Record<string, unknown> = {
+    addChild(child: Container) {
+      (child as unknown as { parent: Container | null }).parent = layer as unknown as Container;
+      return child;
+    },
+  } as Record<string, unknown> as { addChild(child: Container): Container } & Record<string, unknown>;
+
+  return layer as unknown as Container;
+};
+
+const createDebugOverlayComponentStub = () => {
+  const containerStub = {
+    visible: false,
+    destroyed: false,
+    parent: null as Container | null,
+    position: {
+      x: 0,
+      y: 0,
+      set(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      },
+    },
+    scale: {
+      x: 1,
+      y: 1,
+      set(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      },
+    },
+  };
+
+  const backgroundStub = {
+    clear: vi.fn(),
+    roundRect: vi.fn(),
+    fill: vi.fn(),
+    setStrokeStyle: vi.fn(),
+    stroke: vi.fn(),
+  };
+
+  const textStub = {
+    text: '',
+    style: { wordWrap: false, wordWrapWidth: 0 },
+    width: 120,
+    height: 48,
+    anchor: { set: vi.fn() },
+    position: {
+      x: 0,
+      y: 0,
+      set(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      },
+    },
+  };
+
+  const component: DebugOverlayComponent = {
+    container: containerStub as unknown as Container,
+    background: backgroundStub as unknown as Graphics,
+    text: textStub as unknown as Text,
+    lastRenderedText: '',
+  };
+
+  return { component, containerStub, backgroundStub, textStub };
+};
+
+const createValueEntry = (value: unknown, revision = 1) => ({
+  value,
+  metadata: {},
+  revision,
+});
+
+const createActionEntry = (revision = 1) => ({
+  metadata: {},
+  revision,
+});
 
 describe('simulation systems', () => {
   it('advances program runners by the provided delta time', () => {
@@ -81,5 +183,165 @@ describe('simulation systems', () => {
     expect(sprite.rotation).toBeCloseTo(Math.PI / 3);
     expect(sprite.position.x).toBeCloseTo(-3);
     expect(sprite.position.y).toBeCloseTo(7);
+  });
+
+  it('updates status indicators using telemetry from the status module', () => {
+    const world = new ECSWorld();
+    const RobotCore = world.defineComponent<RobotChassis>('RobotCore');
+    const StatusIndicator = world.defineComponent<StatusIndicatorComponent>('StatusIndicator');
+    const entity = world.createEntity();
+
+    const indicatorStub = { visible: false, alpha: 0 } as unknown as Graphics;
+
+    let telemetry: ReturnType<RobotChassis['getTelemetrySnapshot']> = {
+      values: {
+        [STATUS_MODULE_ID]: {
+          active: createValueEntry(true),
+        },
+      },
+      actions: {},
+    };
+
+    const getModule = vi.fn<() => unknown>(() => ({}));
+    const robotCoreStub = {
+      moduleStack: {
+        getModule,
+      },
+      getTelemetrySnapshot: vi.fn(() => telemetry),
+    } as unknown as RobotChassis;
+
+    RobotCore.set(entity, robotCoreStub);
+    StatusIndicator.set(entity, { indicator: indicatorStub } satisfies StatusIndicatorComponent);
+
+    world.addSystem(
+      createStatusIndicatorSystem({ RobotCore, StatusIndicator }, { statusModuleId: STATUS_MODULE_ID }),
+    );
+
+    world.runSystems(0);
+
+    expect(indicatorStub.visible).toBe(true);
+    expect(indicatorStub.alpha).toBeCloseTo(1);
+
+    telemetry = {
+      values: {
+        [STATUS_MODULE_ID]: {
+          active: createValueEntry(false, 2),
+        },
+      },
+      actions: {},
+    };
+
+    world.runSystems(0);
+
+    expect(indicatorStub.visible).toBe(true);
+    expect(indicatorStub.alpha).toBeCloseTo(0.2);
+
+    getModule.mockReturnValue(null);
+    telemetry = { values: {}, actions: {} };
+
+    world.runSystems(0);
+
+    expect(indicatorStub.visible).toBe(false);
+  });
+
+  it('renders debug overlays from program debug state and telemetry', () => {
+    const world = new ECSWorld();
+    const RobotCore = world.defineComponent<RobotChassis>('RobotCore');
+    const ProgramRunner = world.defineComponent<BlockProgramRunner>('ProgramRunner');
+    const SpriteRef = world.defineComponent<Sprite>('SpriteRef');
+    const DebugOverlay = world.defineComponent<DebugOverlayComponent>('DebugOverlay');
+    const entity = world.createEntity();
+
+    const sprite = createSpriteStub();
+    sprite.position.set(12, -5);
+
+    const overlayLayer = createOverlayLayerStub();
+    const { component: overlayComponent, containerStub, backgroundStub, textStub } =
+      createDebugOverlayComponentStub();
+
+    const viewport = { scale: { x: 2, y: 0.5 } } as unknown as Viewport;
+
+    const programInstructions: BlockInstruction[] = [
+      { kind: 'wait', duration: 1 } as BlockInstruction,
+      { kind: 'loop', instructions: [{ kind: 'gather', duration: 2, target: 'auto' } as BlockInstruction] } as BlockInstruction,
+    ];
+
+    let debugState: ProgramDebugState | null = {
+      status: 'running',
+      program: { instructions: programInstructions } as CompiledProgram,
+      currentInstruction: { kind: 'move', speed: 3, duration: 2 } as BlockInstruction,
+      timeRemaining: 1.25,
+      frames: [{ kind: 'sequence', index: 0, length: 2 }],
+    } satisfies ProgramDebugState;
+
+    let telemetry: ReturnType<RobotChassis['getTelemetrySnapshot']> = {
+      values: {
+        moduleA: {
+          active: createValueEntry(true),
+          velocity: createValueEntry(3.14159, 2),
+        },
+      },
+      actions: {
+        moduleA: {
+          ping: createActionEntry(),
+        },
+      },
+    };
+
+    const robotCoreStub = {
+      getTelemetrySnapshot: vi.fn(() => telemetry),
+    } as unknown as RobotChassis;
+
+    const programRunnerStub = {
+      getDebugState: vi.fn(() => debugState),
+    } as unknown as BlockProgramRunner;
+
+    RobotCore.set(entity, robotCoreStub);
+    ProgramRunner.set(entity, programRunnerStub);
+    SpriteRef.set(entity, sprite);
+    DebugOverlay.set(entity, overlayComponent);
+
+    world.addSystem(
+      createDebugOverlaySystem(
+        { RobotCore, ProgramRunner, SpriteRef, DebugOverlay },
+        { overlayLayer, viewport },
+      ),
+    );
+
+    world.runSystems(0);
+
+    expect(containerStub.visible).toBe(true);
+    expect(containerStub.position.x).toBeCloseTo(sprite.position.x);
+    expect(containerStub.position.y).toBeCloseTo(sprite.position.y);
+    expect(containerStub.scale.x).toBeCloseTo(0.5);
+    expect(containerStub.scale.y).toBeCloseTo(2);
+
+    expect(textStub.text).toContain('Program: RUNNING • 3 steps');
+    expect(textStub.text).toContain('Current: move');
+    expect(textStub.text).toContain('ECS telemetry:');
+
+    const expectedWidth = Math.max(
+      Math.min(textStub.width + DEBUG_PADDING * 2, DEBUG_MAX_WIDTH),
+      DEBUG_MIN_WIDTH,
+    );
+    const expectedHeight = textStub.height + DEBUG_PADDING * 2;
+
+    expect(backgroundStub.roundRect).toHaveBeenCalledWith(
+      -expectedWidth / 2,
+      -DEBUG_VERTICAL_OFFSET - expectedHeight,
+      expectedWidth,
+      expectedHeight,
+      DEBUG_CORNER_RADIUS,
+    );
+    expect(textStub.style.wordWrapWidth).toBe(DEBUG_MAX_WIDTH - DEBUG_PADDING * 2);
+
+    debugState = null;
+    telemetry = { values: {}, actions: {} };
+
+    ProgramRunner.remove(entity);
+    world.runSystems(0);
+
+    expect(containerStub.visible).toBe(false);
+    expect(overlayComponent.lastRenderedText).toBe('');
   });
 });

--- a/src/simulation/ecs/systems/debugOverlaySystem.ts
+++ b/src/simulation/ecs/systems/debugOverlaySystem.ts
@@ -1,0 +1,311 @@
+import type { Viewport } from 'pixi-viewport';
+import type { Container, Sprite } from 'pixi.js';
+
+import type {
+  DebugOverlayComponent,
+  SimulationWorldComponents,
+} from '../../runtime/simulationWorld';
+import {
+  DEBUG_BACKGROUND_COLOUR,
+  DEBUG_CORNER_RADIUS,
+  DEBUG_MAX_WIDTH,
+  DEBUG_MIN_WIDTH,
+  DEBUG_PADDING,
+  DEBUG_VERTICAL_OFFSET,
+} from '../../runtime/simulationWorld';
+import type { BlockInstruction } from '../../runtime/blockProgram';
+import type {
+  ProgramDebugFrame,
+  ProgramDebugState,
+} from '../../runtime/blockProgramRunner';
+import type { BlockProgramRunner } from '../../runtime/blockProgramRunner';
+import type { RobotChassis } from '../../robot';
+import type { ComponentHandle, EntityId, System } from '../world';
+
+interface DebugOverlaySystemDependencies
+  extends Pick<
+    SimulationWorldComponents,
+    'RobotCore' | 'ProgramRunner' | 'SpriteRef' | 'DebugOverlay'
+  > {}
+
+interface DebugOverlaySystemOptions {
+  overlayLayer: Container;
+  viewport: Viewport;
+}
+
+type TelemetrySnapshot = ReturnType<RobotChassis['getTelemetrySnapshot']>;
+
+export function createDebugOverlaySystem(
+  { RobotCore, ProgramRunner, SpriteRef, DebugOverlay }: DebugOverlaySystemDependencies,
+  { overlayLayer, viewport }: DebugOverlaySystemOptions,
+): System<[
+  ComponentHandle<RobotChassis>,
+  ComponentHandle<BlockProgramRunner>,
+  ComponentHandle<Sprite>,
+  ComponentHandle<DebugOverlayComponent>,
+]> {
+  return {
+    name: 'DebugOverlaySystem',
+    components: [RobotCore, ProgramRunner, SpriteRef, DebugOverlay],
+    update: (_world, entities) => {
+      const processed = new Set<EntityId>();
+
+      for (const [entity, overlay] of DebugOverlay.entries()) {
+        overlay.container.visible = false;
+        if (!overlay.container.destroyed && overlay.container.parent !== overlayLayer) {
+          overlayLayer.addChild(overlay.container);
+        }
+        processed.add(entity);
+      }
+
+      for (const [entity, robotCore, programRunner, sprite, overlay] of entities) {
+        processed.delete(entity);
+        updateDebugOverlay({
+          overlay,
+          robotCore,
+          programRunner,
+          sprite,
+          viewport,
+        });
+      }
+
+      for (const entity of processed) {
+        const overlay = DebugOverlay.get(entity);
+        if (!overlay) {
+          continue;
+        }
+        overlay.lastRenderedText = '';
+      }
+    },
+  };
+}
+
+interface UpdateDebugOverlayOptions {
+  overlay: DebugOverlayComponent;
+  robotCore: RobotChassis;
+  programRunner: BlockProgramRunner;
+  sprite: Sprite;
+  viewport: Viewport;
+}
+
+function updateDebugOverlay({ overlay, robotCore, programRunner, sprite, viewport }: UpdateDebugOverlayOptions): void {
+  const programDebug = programRunner.getDebugState();
+  const telemetry = robotCore.getTelemetrySnapshot();
+
+  const lines: string[] = [];
+  const programLines = describeProgramDebug(programDebug);
+  if (programLines.length > 0) {
+    lines.push(...programLines);
+  }
+
+  const telemetryLines = describeTelemetry(telemetry);
+  if (telemetryLines.length > 0) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(...telemetryLines);
+  }
+
+  if (lines.length === 0) {
+    overlay.container.visible = false;
+    overlay.lastRenderedText = '';
+    return;
+  }
+
+  const textContent = lines.join('\n');
+  if (textContent !== overlay.lastRenderedText) {
+    overlay.text.text = textContent;
+    overlay.lastRenderedText = textContent;
+  }
+
+  const padding = DEBUG_PADDING;
+  const wordWrapWidth = DEBUG_MAX_WIDTH - DEBUG_PADDING * 2;
+  if (overlay.text.style) {
+    overlay.text.style.wordWrap = true;
+    overlay.text.style.wordWrapWidth = wordWrapWidth;
+  }
+
+  const textWidth = overlay.text.width;
+  const textHeight = overlay.text.height;
+  const backgroundWidth = Math.max(Math.min(textWidth + padding * 2, DEBUG_MAX_WIDTH), DEBUG_MIN_WIDTH);
+  const backgroundHeight = textHeight + padding * 2;
+
+  overlay.background.clear();
+  overlay.background.roundRect(
+    -backgroundWidth / 2,
+    -DEBUG_VERTICAL_OFFSET - backgroundHeight,
+    backgroundWidth,
+    backgroundHeight,
+    DEBUG_CORNER_RADIUS,
+  );
+  overlay.background.fill({ color: DEBUG_BACKGROUND_COLOUR, alpha: 0.9 });
+  overlay.background.setStrokeStyle({ width: 1, color: 0xffffff, alpha: 0.35 });
+  overlay.background.stroke();
+
+  overlay.text.anchor.set(0.5, 0);
+  overlay.text.position.set(0, -DEBUG_VERTICAL_OFFSET - backgroundHeight + padding);
+
+  overlay.container.position.set(sprite.position.x, sprite.position.y);
+
+  const scaleX = viewport.scale.x || 1;
+  const scaleY = viewport.scale.y || 1;
+  overlay.container.scale.set(1 / scaleX, 1 / scaleY);
+  overlay.container.visible = true;
+}
+
+function describeProgramDebug(state: ProgramDebugState | null): string[] {
+  if (!state) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  if (state.program) {
+    const totalSteps = countProgramInstructions(state.program.instructions);
+    const plural = totalSteps === 1 ? 'step' : 'steps';
+    lines.push(`Program: ${state.status.toUpperCase()} • ${totalSteps} ${plural}`);
+  } else {
+    lines.push(`Program: ${state.status.toUpperCase()}`);
+  }
+
+  if (state.currentInstruction) {
+    const description = formatInstruction(state.currentInstruction);
+    const timeRemaining = Math.max(state.timeRemaining, 0).toFixed(1);
+    lines.push(`Current: ${description} • ${timeRemaining}s`);
+  } else {
+    lines.push('Current: —');
+  }
+
+  if (state.frames.length > 0) {
+    const frameDescription = state.frames.map((frame) => formatDebugFrame(frame)).join(' ▸ ');
+    lines.push(`Stack: ${frameDescription}`);
+  } else {
+    lines.push('Stack: —');
+  }
+
+  return lines;
+}
+
+function formatDebugFrame(frame: ProgramDebugFrame): string {
+  if (frame.length <= 0) {
+    return frame.kind === 'sequence' ? 'seq —' : 'loop —';
+  }
+  const label = frame.kind === 'sequence' ? 'seq' : 'loop';
+  const index = Math.min(Math.max(frame.index, 0), frame.length - 1) + 1;
+  return `${label} ${index}/${frame.length}`;
+}
+
+function describeTelemetry(snapshot: TelemetrySnapshot): string[] {
+  const lines: string[] = [];
+  const moduleIds = new Set([
+    ...Object.keys(snapshot.values ?? {}),
+    ...Object.keys(snapshot.actions ?? {}),
+  ]);
+
+  if (moduleIds.size === 0) {
+    lines.push('ECS telemetry: —');
+    return lines;
+  }
+
+  lines.push('ECS telemetry:');
+  for (const moduleId of [...moduleIds].sort()) {
+    lines.push(`- ${moduleId}`);
+    const values = snapshot.values[moduleId] ?? {};
+    const valueKeys = Object.keys(values).sort();
+    if (valueKeys.length > 0) {
+      for (const key of valueKeys) {
+        const entry = values[key];
+        lines.push(`    ${key}: ${formatTelemetryValue(entry.value)}`);
+      }
+    }
+
+    const actions = snapshot.actions[moduleId] ?? {};
+    const actionNames = Object.keys(actions).sort();
+    if (actionNames.length > 0) {
+      lines.push(`    actions: ${actionNames.join(', ')}`);
+    }
+
+    if (valueKeys.length === 0 && actionNames.length === 0) {
+      lines.push('    (no signals)');
+    }
+  }
+
+  return lines;
+}
+
+function formatInstruction(instruction: BlockInstruction): string {
+  switch (instruction.kind) {
+    case 'move':
+      return `move • speed ${instruction.speed.toFixed(0)} • ${instruction.duration.toFixed(1)}s`;
+    case 'turn':
+      return `turn • rate ${(instruction.angularVelocity * (180 / Math.PI)).toFixed(0)}°/s • ${instruction.duration.toFixed(1)}s`;
+    case 'wait':
+      return `wait • ${instruction.duration.toFixed(1)}s`;
+    case 'scan':
+      return `scan${instruction.filter ? ` • ${instruction.filter}` : ''} • ${instruction.duration.toFixed(1)}s`;
+    case 'gather':
+      return `gather • ${instruction.duration.toFixed(1)}s`;
+    case 'deposit':
+      return `deposit • ${instruction.duration.toFixed(1)}s`;
+    case 'status-toggle':
+      return 'status toggle';
+    case 'status-set':
+      return `status set • ${instruction.value ? 'on' : 'off'}`;
+    case 'loop':
+      return `loop • ${instruction.instructions.length} step${instruction.instructions.length === 1 ? '' : 's'}`;
+    default:
+      return (instruction as { kind?: string }).kind ?? 'unknown';
+  }
+}
+
+function formatTelemetryValue(value: unknown): string {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return String(value);
+    }
+    if (Math.abs(value) >= 1000) {
+      return value.toFixed(0);
+    }
+    if (Math.abs(value) >= 1) {
+      return value.toFixed(1);
+    }
+    return value.toFixed(2);
+  }
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((entry) => formatTelemetryValue(entry));
+    const serialised = `[${items.join(', ')}]`;
+    return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
+  }
+  if (value && typeof value === 'object') {
+    try {
+      const serialised = JSON.stringify(value);
+      if (!serialised) {
+        return 'object';
+      }
+      return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
+    } catch (error) {
+      return 'object';
+    }
+  }
+  if (value === null) {
+    return 'null';
+  }
+  return typeof value === 'undefined' ? 'undefined' : String(value);
+}
+
+function countProgramInstructions(instructions: BlockInstruction[] | undefined): number {
+  if (!instructions || instructions.length === 0) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const instruction of instructions) {
+    total += 1;
+    if (instruction.kind === 'loop') {
+      total += countProgramInstructions(instruction.instructions);
+    }
+  }
+  return total;
+}

--- a/src/simulation/ecs/systems/index.ts
+++ b/src/simulation/ecs/systems/index.ts
@@ -1,3 +1,5 @@
 export * from './programRunnerSystem';
 export * from './robotPhysicsSystem';
 export * from './spriteSyncSystem';
+export * from './statusIndicatorSystem';
+export * from './debugOverlaySystem';

--- a/src/simulation/ecs/systems/statusIndicatorSystem.ts
+++ b/src/simulation/ecs/systems/statusIndicatorSystem.ts
@@ -1,0 +1,41 @@
+import type { SimulationWorldComponents, StatusIndicatorComponent } from '../../runtime/simulationWorld';
+import type { RobotChassis } from '../../robot';
+import type { ComponentHandle, System } from '../world';
+
+interface StatusIndicatorSystemDependencies
+  extends Pick<SimulationWorldComponents, 'RobotCore' | 'StatusIndicator'> {}
+
+interface StatusIndicatorSystemOptions {
+  statusModuleId: string;
+}
+
+export function createStatusIndicatorSystem(
+  { RobotCore, StatusIndicator }: StatusIndicatorSystemDependencies,
+  { statusModuleId }: StatusIndicatorSystemOptions,
+): System<[
+  ComponentHandle<RobotChassis>,
+  ComponentHandle<StatusIndicatorComponent>,
+]> {
+  return {
+    name: 'StatusIndicatorSystem',
+    components: [RobotCore, StatusIndicator],
+    update: (_world, entities) => {
+      for (const [, robotCore, { indicator }] of entities) {
+        const hasStatusModule = Boolean(robotCore.moduleStack.getModule(statusModuleId));
+
+        if (!hasStatusModule) {
+          indicator.visible = false;
+          continue;
+        }
+
+        const telemetry = robotCore.getTelemetrySnapshot();
+        const statusTelemetry = telemetry.values?.[statusModuleId];
+        const activeEntry = statusTelemetry?.active;
+        const isActive = typeof activeEntry?.value === 'boolean' ? activeEntry.value : false;
+
+        indicator.alpha = isActive ? 1 : 0.2;
+        indicator.visible = true;
+      }
+    },
+  };
+}

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -1,10 +1,8 @@
-import { Application, Container, Graphics, Text, Ticker } from 'pixi.js';
+import { Application, Container, Graphics, Ticker } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { assetService } from './assetService';
-import type { RobotChassis } from './robot';
-import { STATUS_MODULE_ID } from './robot/modules/statusModule';
-import type { BlockInstruction, CompiledProgram } from './runtime/blockProgram';
-import { type ProgramDebugFrame, type ProgramDebugState, type ProgramRunnerStatus } from './runtime/blockProgramRunner';
+import type { CompiledProgram } from './runtime/blockProgram';
+import { type ProgramRunnerStatus } from './runtime/blockProgramRunner';
 import { createSimulationWorld, type SimulationWorldContext } from './runtime/simulationWorld';
 import type { InventorySnapshot } from './robot/inventory';
 import { ResourceLayer } from './resourceLayer';
@@ -16,16 +14,7 @@ interface TickPayload {
 const STEP_MS = 1000 / 60;
 const GRID_EXTENT = 2000;
 const GRID_SPACING = 80;
-const DEBUG_PADDING = 8;
-const DEBUG_VERTICAL_OFFSET = 72;
-const DEBUG_CORNER_RADIUS = 8;
-const DEBUG_MAX_WIDTH = 280;
-const DEBUG_MIN_WIDTH = 180;
-const DEBUG_BACKGROUND_COLOUR = 0x0b1623;
-
 type RobotSelectionListener = (robotId: string | null) => void;
-
-type TelemetrySnapshot = ReturnType<RobotChassis['getTelemetrySnapshot']>;
 
 export class RootScene {
   private readonly app: Application;
@@ -41,12 +30,7 @@ export class RootScene {
   private readonly programListeners: Set<(status: ProgramRunnerStatus) => void>;
   private readonly selectionListeners: Set<RobotSelectionListener>;
   private pendingSelection: string | null;
-  private statusIndicator: Graphics | null;
   private resourceLayer: ResourceLayer | null;
-  private debugOverlay: Container | null;
-  private debugBackground: Graphics | null;
-  private debugText: Text | null;
-  private lastDebugText: string;
 
   constructor(app: Application) {
     this.app = app;
@@ -89,17 +73,12 @@ export class RootScene {
     this.context = null;
     this.pendingContextCallbacks = [];
     this.resourceLayer = null;
-    this.debugOverlay = null;
-    this.debugBackground = null;
-    this.debugText = null;
-    this.lastDebugText = '';
     this.tickHandler = this.tick.bind(this);
     app.ticker.add(this.tickHandler as (ticker: Ticker) => void);
 
     this.programListeners = new Set();
     this.selectionListeners = new Set();
     this.pendingSelection = null;
-    this.statusIndicator = null;
     this.programStatus = 'idle';
 
     void this.initialiseSimulationWorld();
@@ -109,6 +88,8 @@ export class RootScene {
     const context = await createSimulationWorld({
       renderer: this.app.renderer,
       onRobotSelected: (robotId) => this.notifyRobotSelected(robotId),
+      overlayLayer: this.rootLayer,
+      viewport: this.viewport,
     });
 
     this.context = context;
@@ -152,8 +133,7 @@ export class RootScene {
       this.viewport.moveCenter(sprite.position.x, sprite.position.y);
     }
 
-    this.updateStatusIndicator();
-    this.updateDebugOverlay();
+    // Presentation systems are responsible for updating overlay components.
   }
 
   private flushPendingContextCallbacks(context: SimulationWorldContext): void {
@@ -224,8 +204,6 @@ export class RootScene {
     const context = this.context;
     context?.world.runSystems(stepSeconds);
 
-    this.updateStatusIndicator();
-    this.updateDebugOverlay();
   }
 
   resize(width: number, height: number): void {
@@ -326,292 +304,6 @@ export class RootScene {
     return this.pendingSelection;
   }
 
-  private ensureDebugOverlay(): void {
-    if (this.debugOverlay) {
-      return;
-    }
-
-    const container = new Container();
-    container.visible = false;
-    container.zIndex = 1000;
-    container.eventMode = 'none';
-
-    const background = new Graphics();
-    container.addChild(background);
-
-    const text = new Text({
-      text: '',
-      style: {
-        fill: 0xffffff,
-        fontFamily: 'JetBrains Mono, monospace',
-        fontSize: 12,
-        lineHeight: 18,
-        wordWrap: true,
-        wordWrapWidth: DEBUG_MAX_WIDTH - DEBUG_PADDING * 2,
-      },
-    });
-    text.anchor.set(0.5, 0);
-    container.addChild(text);
-
-    this.rootLayer.addChild(container);
-    this.debugOverlay = container;
-    this.debugBackground = background;
-    this.debugText = text;
-    this.lastDebugText = '';
-  }
-
-  private updateDebugOverlay(): void {
-    const context = this.context;
-    if (!context) {
-      this.hideDebugOverlay();
-      return;
-    }
-
-    const robotCore = context.getRobotCore();
-    const sprite = context.getSprite();
-    const programRunner = context.getProgramRunner();
-    if (!robotCore || !sprite || !programRunner) {
-      this.hideDebugOverlay();
-      return;
-    }
-
-    this.ensureDebugOverlay();
-
-    if (!this.debugOverlay || !this.debugBackground || !this.debugText) {
-      return;
-    }
-
-    const programDebug = programRunner.getDebugState();
-    const telemetry = robotCore.getTelemetrySnapshot();
-
-    const lines: string[] = [];
-    const programLines = this.describeProgramDebug(programDebug);
-    if (programLines.length > 0) {
-      lines.push(...programLines);
-    }
-    const telemetryLines = this.describeTelemetry(telemetry);
-    if (telemetryLines.length > 0) {
-      if (lines.length > 0) {
-        lines.push('');
-      }
-      lines.push(...telemetryLines);
-    }
-
-    if (lines.length === 0) {
-      this.hideDebugOverlay();
-      return;
-    }
-
-    const textContent = lines.join('\n');
-    if (textContent !== this.lastDebugText) {
-      this.debugText.text = textContent;
-      this.lastDebugText = textContent;
-    }
-
-    const padding = DEBUG_PADDING;
-    const textWidth = this.debugText.width;
-    const textHeight = this.debugText.height;
-    const backgroundWidth = Math.max(Math.min(textWidth + padding * 2, DEBUG_MAX_WIDTH), DEBUG_MIN_WIDTH);
-    const backgroundHeight = textHeight + padding * 2;
-
-    this.debugBackground.clear();
-    this.debugBackground.roundRect(
-      -backgroundWidth / 2,
-      -DEBUG_VERTICAL_OFFSET - backgroundHeight,
-      backgroundWidth,
-      backgroundHeight,
-      DEBUG_CORNER_RADIUS,
-    );
-    this.debugBackground.fill({ color: DEBUG_BACKGROUND_COLOUR, alpha: 0.9 });
-    this.debugBackground.setStrokeStyle({ width: 1, color: 0xffffff, alpha: 0.35 });
-    this.debugBackground.stroke();
-
-    this.debugText.anchor.set(0.5, 0);
-    this.debugText.position.set(0, -DEBUG_VERTICAL_OFFSET - backgroundHeight + padding);
-
-    const targetX = sprite.position.x;
-    const targetY = sprite.position.y;
-    this.debugOverlay.position.set(targetX, targetY);
-
-    const scaleX = this.viewport.scale.x || 1;
-    const scaleY = this.viewport.scale.y || 1;
-    this.debugOverlay.scale.set(1 / scaleX, 1 / scaleY);
-    this.debugOverlay.visible = true;
-  }
-
-  private hideDebugOverlay(): void {
-    if (this.debugOverlay) {
-      this.debugOverlay.visible = false;
-    }
-    this.lastDebugText = '';
-  }
-
-  private describeProgramDebug(state: ProgramDebugState | null): string[] {
-    if (!state) {
-      return [];
-    }
-
-    const lines: string[] = [];
-    if (state.program) {
-      const totalSteps = this.countProgramInstructions(state.program);
-      const plural = totalSteps === 1 ? 'step' : 'steps';
-      lines.push(`Program: ${state.status.toUpperCase()} • ${totalSteps} ${plural}`);
-    } else {
-      lines.push(`Program: ${state.status.toUpperCase()}`);
-    }
-
-    if (state.currentInstruction) {
-      const description = this.formatInstruction(state.currentInstruction);
-      const timeRemaining = Math.max(state.timeRemaining, 0).toFixed(1);
-      lines.push(`Current: ${description} • ${timeRemaining}s`);
-    } else {
-      lines.push('Current: —');
-    }
-
-    if (state.frames.length > 0) {
-      const frameDescription = state.frames
-        .map((frame) => this.formatDebugFrame(frame))
-        .join(' ▸ ');
-      lines.push(`Stack: ${frameDescription}`);
-    } else {
-      lines.push('Stack: —');
-    }
-
-    return lines;
-  }
-
-  private formatDebugFrame(frame: ProgramDebugFrame): string {
-    if (frame.length <= 0) {
-      return frame.kind === 'sequence' ? 'seq —' : 'loop —';
-    }
-    const label = frame.kind === 'sequence' ? 'seq' : 'loop';
-    const index = Math.min(Math.max(frame.index, 0), frame.length - 1) + 1;
-    return `${label} ${index}/${frame.length}`;
-  }
-
-  private describeTelemetry(snapshot: TelemetrySnapshot): string[] {
-    const lines: string[] = [];
-    const moduleIds = new Set([
-      ...Object.keys(snapshot.values ?? {}),
-      ...Object.keys(snapshot.actions ?? {}),
-    ]);
-
-    if (moduleIds.size === 0) {
-      lines.push('ECS telemetry: —');
-      return lines;
-    }
-
-    lines.push('ECS telemetry:');
-    for (const moduleId of [...moduleIds].sort()) {
-      lines.push(`- ${moduleId}`);
-      const values = snapshot.values[moduleId] ?? {};
-      const valueKeys = Object.keys(values).sort();
-      if (valueKeys.length > 0) {
-        for (const key of valueKeys) {
-          const entry = values[key];
-          lines.push(`    ${key}: ${this.formatTelemetryValue(entry.value)}`);
-        }
-      }
-
-      const actions = snapshot.actions[moduleId] ?? {};
-      const actionNames = Object.keys(actions).sort();
-      if (actionNames.length > 0) {
-        lines.push(`    actions: ${actionNames.join(', ')}`);
-      }
-
-      if (valueKeys.length === 0 && actionNames.length === 0) {
-        lines.push('    (no signals)');
-      }
-    }
-
-    return lines;
-  }
-
-  private formatInstruction(instruction: BlockInstruction): string {
-    switch (instruction.kind) {
-      case 'move':
-        return `move • speed ${instruction.speed.toFixed(0)} • ${instruction.duration.toFixed(1)}s`;
-      case 'turn':
-        return `turn • rate ${(instruction.angularVelocity * (180 / Math.PI)).toFixed(0)}°/s • ${instruction.duration.toFixed(1)}s`;
-      case 'wait':
-        return `wait • ${instruction.duration.toFixed(1)}s`;
-      case 'scan':
-        return `scan${instruction.filter ? ` • ${instruction.filter}` : ''} • ${instruction.duration.toFixed(1)}s`;
-      case 'gather':
-        return `gather • ${instruction.duration.toFixed(1)}s`;
-      case 'deposit':
-        return `deposit • ${instruction.duration.toFixed(1)}s`;
-      case 'status-toggle':
-        return 'status toggle';
-      case 'status-set':
-        return `status set • ${instruction.value ? 'on' : 'off'}`;
-      case 'loop':
-        return `loop • ${instruction.instructions.length} step${instruction.instructions.length === 1 ? '' : 's'}`;
-      default:
-        return (instruction as { kind?: string }).kind ?? 'unknown';
-    }
-  }
-
-  private formatTelemetryValue(value: unknown): string {
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value)) {
-        return String(value);
-      }
-      if (Math.abs(value) >= 1000) {
-        return value.toFixed(0);
-      }
-      if (Math.abs(value) >= 1) {
-        return value.toFixed(1);
-      }
-      return value.toFixed(2);
-    }
-    if (typeof value === 'string' || typeof value === 'boolean') {
-      return String(value);
-    }
-    if (Array.isArray(value)) {
-      const items = value.map((entry) => this.formatTelemetryValue(entry));
-      const serialised = `[${items.join(', ')}]`;
-      return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
-    }
-    if (value && typeof value === 'object') {
-      try {
-        const serialised = JSON.stringify(value);
-        if (!serialised) {
-          return 'object';
-        }
-        return serialised.length > 60 ? `${serialised.slice(0, 57)}…` : serialised;
-      } catch (error) {
-        return 'object';
-      }
-    }
-    if (value === null) {
-      return 'null';
-    }
-    return typeof value === 'undefined' ? 'undefined' : String(value);
-  }
-
-  private countProgramInstructions(program: CompiledProgram | null): number {
-    if (!program) {
-      return 0;
-    }
-    return this.countInstructions(program.instructions);
-  }
-
-  private countInstructions(instructions: BlockInstruction[] | undefined): number {
-    if (!instructions || instructions.length === 0) {
-      return 0;
-    }
-
-    let total = 0;
-    for (const instruction of instructions) {
-      total += 1;
-      if (instruction.kind === 'loop') {
-        total += this.countInstructions(instruction.instructions);
-      }
-    }
-    return total;
-  }
-
   destroy(): void {
     this.app.ticker.remove(this.tickHandler as (ticker: Ticker) => void);
     this.viewport.destroy({ children: true, texture: false });
@@ -620,13 +312,6 @@ export class RootScene {
     this.notifyRobotSelected(null);
     this.selectionListeners.clear();
     this.pendingContextCallbacks.length = 0;
-    if (this.debugOverlay) {
-      this.debugOverlay.destroy({ children: true });
-      this.debugOverlay = null;
-      this.debugBackground = null;
-      this.debugText = null;
-    }
-    this.lastDebugText = '';
     if (this.resourceLayer) {
       this.rootLayer.removeChild(this.resourceLayer.view);
       this.resourceLayer.destroy();
@@ -651,8 +336,6 @@ export class RootScene {
       context.world.destroyEntity(context.entities.selection);
       this.context = null;
     }
-    this.statusIndicator?.destroy();
-    this.statusIndicator = null;
     assetService.disposeAll();
   }
 
@@ -679,44 +362,4 @@ export class RootScene {
     }
   }
 
-  private updateStatusIndicator(): void {
-    const context = this.context;
-    const robotCore = context?.getRobotCore();
-    const sprite = context?.getSprite();
-    if (!robotCore || !sprite) {
-      if (this.statusIndicator) {
-        this.statusIndicator.destroy();
-        this.statusIndicator = null;
-      }
-      return;
-    }
-
-    const hasStatusModule = Boolean(robotCore.moduleStack.getModule(STATUS_MODULE_ID));
-    if (!hasStatusModule) {
-      if (this.statusIndicator) {
-        this.statusIndicator.destroy();
-        this.statusIndicator = null;
-      }
-      return;
-    }
-
-    if (!this.statusIndicator) {
-      const indicator = new Graphics();
-      indicator.circle(0, -36, 6);
-      indicator.fill({ color: 0xff6b6b, alpha: 0.95 });
-      indicator.setStrokeStyle({ width: 2, color: 0xffffff, alpha: 0.85 });
-      indicator.stroke();
-      indicator.position.set(0, 0);
-      sprite.addChild(indicator);
-      this.statusIndicator = indicator;
-    }
-
-    const telemetry = robotCore.getTelemetrySnapshot();
-    const statusTelemetry = telemetry.values[STATUS_MODULE_ID];
-    const activeEntry = statusTelemetry?.active;
-    const isActive = typeof activeEntry?.value === 'boolean' ? activeEntry.value : false;
-
-    this.statusIndicator.alpha = isActive ? 1 : 0.2;
-    this.statusIndicator.visible = true;
-  }
 }

--- a/src/simulation/runtime/simulationWorld.ts
+++ b/src/simulation/runtime/simulationWorld.ts
@@ -1,14 +1,25 @@
-import { Sprite, type Renderer } from 'pixi.js';
+import { Container, Graphics, Sprite, Text, type Renderer } from 'pixi.js';
+import type { Viewport } from 'pixi-viewport';
 import { assetService } from '../assetService';
 import { ECSWorld, type ComponentHandle, type EntityId } from '../ecs';
 import {
+  createDebugOverlaySystem,
   createProgramRunnerSystem,
   createRobotPhysicsSystem,
   createSpriteSyncSystem,
+  createStatusIndicatorSystem,
 } from '../ecs/systems';
 import { RobotChassis } from '../robot';
 import { DEFAULT_MODULE_LOADOUT, createModuleInstance } from '../robot/modules/moduleLibrary';
 import { BlockProgramRunner } from './blockProgramRunner';
+import { STATUS_MODULE_ID } from '../robot/modules/statusModule';
+
+export const DEBUG_PADDING = 8;
+export const DEBUG_VERTICAL_OFFSET = 72;
+export const DEBUG_CORNER_RADIUS = 8;
+export const DEBUG_MAX_WIDTH = 280;
+export const DEBUG_MIN_WIDTH = 180;
+export const DEBUG_BACKGROUND_COLOUR = 0x0b1623;
 
 export const DEFAULT_ROBOT_ID = 'MF-01';
 
@@ -34,6 +45,8 @@ export interface SimulationWorldComponents {
   ViewportTarget: ComponentHandle<ViewportTargetComponent>;
   SelectionState: ComponentHandle<SelectionStateComponent>;
   RobotId: ComponentHandle<string>;
+  DebugOverlay: ComponentHandle<DebugOverlayComponent>;
+  StatusIndicator: ComponentHandle<StatusIndicatorComponent>;
 }
 
 export interface SimulationWorldEntities {
@@ -60,12 +73,27 @@ interface CreateSimulationWorldOptions {
   renderer: Renderer;
   defaultRobotId?: string;
   onRobotSelected?: (robotId: string) => void;
+  overlayLayer: Container;
+  viewport: Viewport;
+}
+
+export interface DebugOverlayComponent {
+  container: Container;
+  background: Graphics;
+  text: Text;
+  lastRenderedText: string;
+}
+
+export interface StatusIndicatorComponent {
+  indicator: Graphics;
 }
 
 export async function createSimulationWorld({
   renderer,
   defaultRobotId = DEFAULT_ROBOT_ID,
   onRobotSelected,
+  overlayLayer,
+  viewport,
 }: CreateSimulationWorldOptions): Promise<SimulationWorldContext> {
   const world = new ECSWorld();
 
@@ -76,6 +104,8 @@ export async function createSimulationWorld({
   const ViewportTarget = world.defineComponent<ViewportTargetComponent>('ViewportTarget');
   const SelectionState = world.defineComponent<SelectionStateComponent>('SelectionState');
   const RobotId = world.defineComponent<string>('RobotId');
+  const DebugOverlay = world.defineComponent<DebugOverlayComponent>('DebugOverlay');
+  const StatusIndicator = world.defineComponent<StatusIndicatorComponent>('StatusIndicator');
 
   const selectionEntity = world.createEntity();
   SelectionState.set(selectionEntity, { robotId: null });
@@ -112,6 +142,45 @@ export async function createSimulationWorld({
   sprite.on('pointertap', () => onRobotSelected?.(defaultRobotId));
   SpriteRef.set(robotEntity, sprite);
 
+  const statusIndicator = new Graphics();
+  statusIndicator.circle(0, -36, 6);
+  statusIndicator.fill({ color: 0xff6b6b, alpha: 0.95 });
+  statusIndicator.setStrokeStyle({ width: 2, color: 0xffffff, alpha: 0.85 });
+  statusIndicator.stroke();
+  statusIndicator.visible = false;
+  sprite.addChild(statusIndicator);
+  StatusIndicator.set(robotEntity, { indicator: statusIndicator });
+
+  const debugOverlayContainer = new Container();
+  debugOverlayContainer.visible = false;
+  debugOverlayContainer.zIndex = 1000;
+  debugOverlayContainer.eventMode = 'none';
+
+  const debugOverlayBackground = new Graphics();
+  debugOverlayContainer.addChild(debugOverlayBackground);
+
+  const debugOverlayText = new Text({
+    text: '',
+    style: {
+      fill: 0xffffff,
+      fontFamily: 'JetBrains Mono, monospace',
+      fontSize: 12,
+      lineHeight: 18,
+      wordWrap: true,
+      wordWrapWidth: DEBUG_MAX_WIDTH - DEBUG_PADDING * 2,
+    },
+  });
+  debugOverlayText.anchor.set(0.5, 0);
+  debugOverlayContainer.addChild(debugOverlayText);
+  overlayLayer.addChild(debugOverlayContainer);
+
+  DebugOverlay.set(robotEntity, {
+    container: debugOverlayContainer,
+    background: debugOverlayBackground,
+    text: debugOverlayText,
+    lastRenderedText: '',
+  });
+
   const selectRobot = (robotId: string | null): void => {
     SelectionState.set(selectionEntity, { robotId });
   };
@@ -130,6 +199,8 @@ export async function createSimulationWorld({
       ViewportTarget,
       SelectionState,
       RobotId,
+      DebugOverlay,
+      StatusIndicator,
     },
     entities: {
       robot: robotEntity,
@@ -158,6 +229,15 @@ export async function createSimulationWorld({
   world.addSystem(createProgramRunnerSystem({ ProgramRunner }));
   world.addSystem(createRobotPhysicsSystem({ RobotCore, Transform }));
   world.addSystem(createSpriteSyncSystem({ Transform, SpriteRef }));
+  world.addSystem(
+    createStatusIndicatorSystem({ RobotCore, StatusIndicator }, { statusModuleId: STATUS_MODULE_ID }),
+  );
+  world.addSystem(
+    createDebugOverlaySystem(
+      { RobotCore, ProgramRunner, SpriteRef, DebugOverlay },
+      { overlayLayer, viewport },
+    ),
+  );
 
   return context;
 }


### PR DESCRIPTION
## Summary
- add DebugOverlay and StatusIndicator component handles to the simulation world and instantiate their PIXI nodes during world setup
- move overlay and indicator rendering into new ECS systems so RootScene no longer manages these helpers directly
- expand the systems test suite with coverage for the new presentation systems

## Testing
- npm run typecheck
- npm test
- npx playwright test *(fails: missing Playwright browsers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d26321eedc832e814558e9f3c6370b