### PR TITLE
feat: add ECS systems for resource views and selection

### DIFF
--- a/src/simulation/ecs/systems/index.ts
+++ b/src/simulation/ecs/systems/index.ts
@@ -1,5 +1,7 @@
 export * from './programRunnerSystem';
 export * from './robotPhysicsSystem';
+export * from './resourceFieldViewSystem';
+export * from './selectableSystem';
 export * from './spriteSyncSystem';
 export * from './statusIndicatorSystem';
 export * from './debugOverlaySystem';

--- a/src/simulation/ecs/systems/resourceFieldViewSystem.ts
+++ b/src/simulation/ecs/systems/resourceFieldViewSystem.ts
@@ -1,0 +1,78 @@
+import type { Container, Renderer } from 'pixi.js';
+import { ResourceLayer } from '../../resourceLayer';
+import type {
+  ResourceFieldViewComponent,
+  SimulationWorldComponents,
+} from '../../runtime/simulationWorld';
+import type { ComponentHandle, EntityId, System } from '../world';
+
+interface ResourceFieldViewSystemDependencies
+  extends Pick<SimulationWorldComponents, 'ResourceFieldView'> {}
+
+interface ResourceFieldViewSystemOptions {
+  renderer: Renderer;
+  container: Container;
+}
+
+export function createResourceFieldViewSystem(
+  { ResourceFieldView }: ResourceFieldViewSystemDependencies,
+  { renderer, container }: ResourceFieldViewSystemOptions,
+): System<[ComponentHandle<ResourceFieldViewComponent>]> {
+  const layers = new Map<EntityId, ResourceLayer>();
+
+  return {
+    name: 'ResourceFieldViewSystem',
+    components: [ResourceFieldView],
+    update: (world, entities) => {
+      const activeEntities = new Set<EntityId>();
+
+      for (const [entity, view] of entities) {
+        activeEntities.add(entity);
+
+        let layer = layers.get(entity);
+
+        if (!layer) {
+          layer = view.layer ?? new ResourceLayer(renderer, view.resourceField);
+          layers.set(entity, layer);
+        } else if (view.layer && view.layer !== layer) {
+          layers.set(entity, view.layer);
+          if (layer !== view.layer) {
+            if (layer.view.parent) {
+              layer.view.parent.removeChild(layer.view);
+            }
+            layer.dispose();
+          }
+          layer = view.layer;
+        }
+
+        if (view.layer !== layer) {
+          view.layer = layer;
+        }
+
+        if (layer.view.parent !== container) {
+          container.addChild(layer.view);
+        }
+
+        layer.view.zIndex = Math.min(layer.view.zIndex ?? 0, -10);
+      }
+
+      for (const [entity, layer] of layers.entries()) {
+        if (activeEntities.has(entity) && world.hasEntity(entity) && ResourceFieldView.has(entity)) {
+          continue;
+        }
+
+        if (layer.view.parent === container) {
+          container.removeChild(layer.view);
+        }
+
+        layer.dispose();
+        layers.delete(entity);
+
+        const component = ResourceFieldView.get(entity);
+        if (component) {
+          component.layer = null;
+        }
+      }
+    },
+  };
+}

--- a/src/simulation/ecs/systems/selectableSystem.ts
+++ b/src/simulation/ecs/systems/selectableSystem.ts
@@ -1,0 +1,92 @@
+import type { Sprite } from 'pixi.js';
+import type {
+  SelectableComponent,
+  SimulationWorldComponents,
+} from '../../runtime/simulationWorld';
+import type { ComponentHandle, EntityId, System } from '../world';
+
+interface SelectableSystemDependencies
+  extends Pick<SimulationWorldComponents, 'Selectable' | 'SpriteRef'> {}
+
+type PointerEventName = 'pointerdown' | 'pointertap';
+
+interface ListenerEntry {
+  sprite: Sprite;
+  handler: () => void;
+}
+
+const POINTER_EVENTS: PointerEventName[] = ['pointerdown', 'pointertap'];
+
+const attachListeners = (sprite: Sprite, handler: () => void): void => {
+  for (const eventName of POINTER_EVENTS) {
+    sprite.on(eventName, handler);
+  }
+};
+
+const detachListeners = (sprite: Sprite, handler: () => void): void => {
+  for (const eventName of POINTER_EVENTS) {
+    sprite.off(eventName, handler);
+  }
+};
+
+export function createSelectableSystem({
+  Selectable,
+  SpriteRef,
+}: SelectableSystemDependencies): System<[
+  ComponentHandle<SelectableComponent>,
+  ComponentHandle<Sprite>,
+]> {
+  const listeners = new Map<EntityId, ListenerEntry>();
+
+  return {
+    name: 'SelectableSystem',
+    components: [Selectable, SpriteRef],
+    update: (world, entities) => {
+      const active = new Set<EntityId>();
+
+      for (const [entity, _selectable, sprite] of entities) {
+        active.add(entity);
+
+        const existing = listeners.get(entity);
+
+        if (existing && existing.sprite !== sprite) {
+          detachListeners(existing.sprite, existing.handler);
+          listeners.delete(entity);
+        }
+
+        let entry = listeners.get(entity);
+
+        if (!entry) {
+          const handler = () => {
+            const current = Selectable.get(entity);
+            if (!current?.onSelected) {
+              return;
+            }
+            current.onSelected(current.id);
+          };
+
+          sprite.eventMode = 'static';
+          (sprite as { interactive?: boolean }).interactive = true;
+          sprite.cursor = 'pointer';
+
+          attachListeners(sprite, handler);
+          listeners.set(entity, { sprite, handler });
+          entry = listeners.get(entity);
+        } else {
+          entry.sprite.eventMode = 'static';
+          (entry.sprite as { interactive?: boolean }).interactive = true;
+          entry.sprite.cursor = 'pointer';
+        }
+      }
+
+      for (const [entity, entry] of listeners.entries()) {
+        if (active.has(entity) && world.hasEntity(entity) && Selectable.has(entity) && SpriteRef.has(entity)) {
+          continue;
+        }
+
+        detachListeners(entry.sprite, entry.handler);
+        listeners.delete(entity);
+      }
+    },
+  };
+}

--- a/src/simulation/resourceLayer.ts
+++ b/src/simulation/resourceLayer.ts
@@ -37,7 +37,7 @@ export class ResourceLayer {
     return this.container;
   }
 
-  destroy(): void {
+  dispose(): void {
     if (this.destroyed) {
       return;
     }
@@ -48,6 +48,10 @@ export class ResourceLayer {
     }
     this.spriteEntries.clear();
     this.container.destroy({ children: true });
+  }
+
+  destroy(): void {
+    this.dispose();
   }
 
   private handleEvent(event: ResourceFieldEvent): void {


### PR DESCRIPTION
## Summary
- add ResourceFieldView and Selectable components to the simulation world and register them with new ECS systems
- create systems that manage ResourceLayer lifecycle and selection listeners, replacing manual wiring in the scene
- update RootScene and ResourceLayer to work with the systems and extend tests for the new behaviour

## Testing
- npm run typecheck
- npm test
- npx playwright test *(fails: browsers not installed, run `npx playwright install` to download)*

------
https://chatgpt.com/codex/tasks/task_e_68d269b26730832e9e17e4f4c7e9facb