### PR TITLE
Seed control block parameters and expression inputs

### DIFF
--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -62,8 +62,13 @@ const DropZone = ({ className, target, onDrop, children }: DropZoneProps): JSX.E
       data-drop-target-kind={target.kind}
       data-drop-target-position={typeof target.position === 'number' ? String(target.position) : ''}
       data-drop-target-ancestors={ancestorIds}
-      data-drop-target-owner-id={target.kind === 'slot' ? target.ownerId : undefined}
+      data-drop-target-owner-id={
+        target.kind === 'slot' || target.kind === 'parameter' ? target.ownerId : undefined
+      }
       data-drop-target-slot-name={target.kind === 'slot' ? target.slotName : undefined}
+      data-drop-target-parameter-name={
+        target.kind === 'parameter' ? target.parameterName : undefined
+      }
       data-dropzone-active={isActive ? 'true' : undefined}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}

--- a/src/hooks/useBlockWorkspace.ts
+++ b/src/hooks/useBlockWorkspace.ts
@@ -34,6 +34,18 @@ const parsePayload = (event: DragEvent<HTMLElement>): DragPayload | null => {
     if (parsed.source === 'workspace' && typeof parsed.instanceId === 'string') {
       return { source: 'workspace', instanceId: parsed.instanceId };
     }
+
+    if (
+      parsed.source === 'parameter'
+      && typeof parsed.ownerId === 'string'
+      && typeof parsed.parameterName === 'string'
+    ) {
+      return {
+        source: 'parameter',
+        ownerId: parsed.ownerId,
+        parameterName: parsed.parameterName,
+      };
+    }
   } catch (error) {
     console.warn('Failed to parse drag payload', error);
   }

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -45,7 +45,9 @@ describe('compileWorkspaceProgram', () => {
     const start = createBlockInstance('start');
     const toggle = createBlockInstance('toggle-status');
     const setStatus = createBlockInstance('set-status');
-    setStatus.state = { value: false };
+    if (setStatus.parameters) {
+      setStatus.parameters.value = { kind: 'boolean', value: false };
+    }
     start.slots!.do = [toggle, setStatus];
 
     const result = compileWorkspaceProgram(buildWorkspace(start));
@@ -84,7 +86,9 @@ describe('compileWorkspaceProgram', () => {
 
     const result = compileWorkspaceProgram(buildWorkspace(start));
     expect(result.program.instructions).toHaveLength(3);
-    expect(result.diagnostics.some((diag) => diag.message.includes('loop three times'))).toBe(true);
+    expect(
+      result.diagnostics.some((diag) => diag.message.includes('configured number of times')),
+    ).toBe(true);
   });
 
   it('runs parallel branches sequentially', () => {

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -81,8 +81,8 @@ const compileBlock = (
     case 'toggle-status':
       return [{ kind: 'status-toggle', duration: 0 }];
     case 'set-status': {
-      const state = (block.state ?? {}) as { value?: unknown };
-      const value = typeof state.value === 'boolean' ? state.value : true;
+      const parameter = block.parameters?.value;
+      const value = parameter?.kind === 'boolean' ? parameter.value : true;
       return [{ kind: 'status-set', duration: 0, value }];
     }
     case 'gather-resource':
@@ -100,12 +100,15 @@ const compileBlock = (
         diagnostics.push({
           severity: 'info',
           message:
-            'Repeat blocks currently loop three times while parameter editing is under construction.',
+            'Repeat blocks currently loop their configured number of times while parameter editing is under construction.',
         });
         context.repeatInfoIssued = true;
       }
+      const countParameter = block.parameters?.count;
+      const rawCount = countParameter?.kind === 'number' ? countParameter.value : DEFAULT_REPEAT_COUNT;
+      const repeatCount = Math.max(0, Math.floor(rawCount));
       const repetitions: BlockInstruction[] = [];
-      for (let index = 0; index < DEFAULT_REPEAT_COUNT; index += 1) {
+      for (let index = 0; index < repeatCount; index += 1) {
         repetitions.push(...inner.map((instruction) => ({ ...instruction })));
       }
       return repetitions;

--- a/src/state/blockUtils.ts
+++ b/src/state/blockUtils.ts
@@ -31,6 +31,8 @@ const removeFromBlocks = (blocks: BlockInstance[], instanceId: string): RemoveRe
       continue;
     }
 
+    let updatedBlock: BlockInstance | null = null;
+
     if (block.slots) {
       const nextSlots: Record<string, BlockInstance[]> = {};
       let slotChanged = false;
@@ -47,13 +49,39 @@ const removeFromBlocks = (blocks: BlockInstance[], instanceId: string): RemoveRe
       }
 
       if (slotChanged) {
-        nextBlocks.push({ ...block, slots: nextSlots });
-        changed = true;
-        continue;
+        updatedBlock = { ...(updatedBlock ?? block), slots: nextSlots };
       }
     }
 
-    nextBlocks.push(block);
+    if (block.expressionInputs) {
+      const nextInputs: Record<string, BlockInstance[]> = {};
+      let inputChanged = false;
+
+      for (const [inputName, inputBlocks] of Object.entries(block.expressionInputs)) {
+        const result = removeFromBlocks(inputBlocks, instanceId);
+        if (result.removed && !removed) {
+          removed = result.removed;
+        }
+        if (result.changed) {
+          inputChanged = true;
+        }
+        nextInputs[inputName] = result.changed ? result.blocks : inputBlocks;
+      }
+
+      if (inputChanged) {
+        updatedBlock = {
+          ...(updatedBlock ?? block),
+          expressionInputs: nextInputs,
+        };
+      }
+    }
+
+    if (updatedBlock) {
+      nextBlocks.push(updatedBlock);
+      changed = true;
+    } else {
+      nextBlocks.push(block);
+    }
   }
 
   return { blocks: nextBlocks, removed, changed };
@@ -97,48 +125,98 @@ const insertIntoBlocks = (
     }
 
     if (block.instanceId === target.ownerId) {
-      const slotBlocks = block.slots?.[target.slotName] ?? [];
-      const insertionIndex = clampIndex(target.position, slotBlocks.length);
-      const updatedSlotBlocks = [...slotBlocks];
-      updatedSlotBlocks.splice(insertionIndex, 0, blockToInsert);
-      const updatedBlock: BlockInstance = {
-        ...block,
-        slots: {
-          ...(block.slots ?? {}),
-          [target.slotName]: updatedSlotBlocks,
-        },
-      };
-      nextBlocks.push(updatedBlock);
-      inserted = true;
-      continue;
-    }
-
-    if (!block.slots) {
-      nextBlocks.push(block);
-      continue;
-    }
-
-    const nextSlots: Record<string, BlockInstance[]> = {};
-    let slotChanged = false;
-
-    for (const [slotName, slotBlocks] of Object.entries(block.slots)) {
-      if (inserted) {
-        nextSlots[slotName] = slotBlocks;
+      if (target.kind === 'slot') {
+        const slotBlocks = block.slots?.[target.slotName] ?? [];
+        const insertionIndex = clampIndex(target.position, slotBlocks.length);
+        const updatedSlotBlocks = [...slotBlocks];
+        updatedSlotBlocks.splice(insertionIndex, 0, blockToInsert);
+        const updatedBlock: BlockInstance = {
+          ...block,
+          slots: {
+            ...(block.slots ?? {}),
+            [target.slotName]: updatedSlotBlocks,
+          },
+        };
+        nextBlocks.push(updatedBlock);
+        inserted = true;
         continue;
       }
 
-      const result = insertIntoBlocks(slotBlocks, target, blockToInsert);
-      if (result.inserted) {
+      if (target.kind === 'parameter') {
+        const inputBlocks = block.expressionInputs?.[target.parameterName] ?? [];
+        const insertionIndex = clampIndex(target.position, inputBlocks.length);
+        const updatedInputBlocks = [...inputBlocks];
+        updatedInputBlocks.splice(insertionIndex, 0, blockToInsert);
+        const updatedBlock: BlockInstance = {
+          ...block,
+          expressionInputs: {
+            ...(block.expressionInputs ?? {}),
+            [target.parameterName]: updatedInputBlocks,
+          },
+        };
+        nextBlocks.push(updatedBlock);
         inserted = true;
-        slotChanged = true;
-        nextSlots[slotName] = result.blocks;
-      } else {
-        nextSlots[slotName] = slotBlocks;
+        continue;
       }
     }
 
-    if (slotChanged) {
-      nextBlocks.push({ ...block, slots: nextSlots });
+    let updatedBlock: BlockInstance | null = null;
+
+    if (block.slots) {
+      const nextSlots: Record<string, BlockInstance[]> = {};
+      let slotChanged = false;
+
+      for (const [slotName, slotBlocks] of Object.entries(block.slots)) {
+        if (inserted) {
+          nextSlots[slotName] = slotBlocks;
+          continue;
+        }
+
+        const result = insertIntoBlocks(slotBlocks, target, blockToInsert);
+        if (result.inserted) {
+          inserted = true;
+          slotChanged = true;
+          nextSlots[slotName] = result.blocks;
+        } else {
+          nextSlots[slotName] = slotBlocks;
+        }
+      }
+
+      if (slotChanged) {
+        updatedBlock = { ...(updatedBlock ?? block), slots: nextSlots };
+      }
+    }
+
+    if (block.expressionInputs) {
+      const nextInputs: Record<string, BlockInstance[]> = {};
+      let inputChanged = false;
+
+      for (const [inputName, inputBlocks] of Object.entries(block.expressionInputs)) {
+        if (inserted) {
+          nextInputs[inputName] = inputBlocks;
+          continue;
+        }
+
+        const result = insertIntoBlocks(inputBlocks, target, blockToInsert);
+        if (result.inserted) {
+          inserted = true;
+          inputChanged = true;
+          nextInputs[inputName] = result.blocks;
+        } else {
+          nextInputs[inputName] = inputBlocks;
+        }
+      }
+
+      if (inputChanged) {
+        updatedBlock = {
+          ...(updatedBlock ?? block),
+          expressionInputs: nextInputs,
+        };
+      }
+    }
+
+    if (updatedBlock) {
+      nextBlocks.push(updatedBlock);
     } else {
       nextBlocks.push(block);
     }
@@ -179,31 +257,55 @@ const updateBlocks = (
       return updater(block);
     }
 
-    if (!block.slots) {
-      return block;
-    }
+    let updatedBlock: BlockInstance | null = null;
 
-    const nextSlots: Record<string, BlockInstance[]> = {};
-    let slotChanged = false;
-    for (const [slotName, slotBlocks] of Object.entries(block.slots)) {
-      const result = updateBlocks(slotBlocks, instanceId, updater);
-      if (result.changed) {
-        slotChanged = true;
-        nextSlots[slotName] = result.blocks;
-      } else {
-        nextSlots[slotName] = slotBlocks;
+    if (block.slots) {
+      const nextSlots: Record<string, BlockInstance[]> = {};
+      let slotChanged = false;
+
+      for (const [slotName, slotBlocks] of Object.entries(block.slots)) {
+        const result = updateBlocks(slotBlocks, instanceId, updater);
+        if (result.changed) {
+          slotChanged = true;
+          nextSlots[slotName] = result.blocks;
+        } else {
+          nextSlots[slotName] = slotBlocks;
+        }
+      }
+
+      if (slotChanged) {
+        updatedBlock = { ...(updatedBlock ?? block), slots: nextSlots };
       }
     }
 
-    if (!slotChanged) {
+    if (block.expressionInputs) {
+      const nextInputs: Record<string, BlockInstance[]> = {};
+      let inputChanged = false;
+
+      for (const [inputName, inputBlocks] of Object.entries(block.expressionInputs)) {
+        const result = updateBlocks(inputBlocks, instanceId, updater);
+        if (result.changed) {
+          inputChanged = true;
+          nextInputs[inputName] = result.blocks;
+        } else {
+          nextInputs[inputName] = inputBlocks;
+        }
+      }
+
+      if (inputChanged) {
+        updatedBlock = {
+          ...(updatedBlock ?? block),
+          expressionInputs: nextInputs,
+        };
+      }
+    }
+
+    if (!updatedBlock) {
       return block;
     }
 
     changed = true;
-    return {
-      ...block,
-      slots: nextSlots,
-    };
+    return updatedBlock;
   });
 
   return { blocks: changed ? nextBlocks : blocks, changed };

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -54,6 +54,12 @@
   color: var(--color-text-secondary);
 }
 
+.blockControlValue {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
 .blockToggle {
   border: 1px solid var(--color-border-subtle);
   background: var(--color-surface-raised);

--- a/src/types/blocks.ts
+++ b/src/types/blocks.ts
@@ -1,17 +1,33 @@
 export type BlockCategory = 'event' | 'action' | 'c' | string;
 
+export type BlockParameterKind = 'boolean' | 'number' | 'string';
+
+export type BlockParameterDefinition =
+  | { kind: 'boolean'; defaultValue: boolean }
+  | { kind: 'number'; defaultValue: number }
+  | { kind: 'string'; defaultValue: string };
+
+export type BlockParameterValue =
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string };
+
 export interface BlockDefinition {
   id: string;
   label: string;
   category: BlockCategory;
   summary?: string;
   slots?: string[];
+  parameters?: Record<string, BlockParameterDefinition>;
+  expressionInputs?: string[];
 }
 
 export interface BlockInstance {
   instanceId: string;
   type: string;
   slots?: Record<string, BlockInstance[]>;
+  parameters?: Record<string, BlockParameterValue>;
+  expressionInputs?: Record<string, BlockInstance[]>;
   state?: Record<string, unknown>;
 }
 
@@ -31,8 +47,17 @@ export interface SlotDropTarget {
   ancestorIds: string[];
 }
 
-export type DropTarget = WorkspaceDropTarget | SlotDropTarget;
+export interface ParameterDropTarget {
+  kind: 'parameter';
+  ownerId: string;
+  parameterName: string;
+  position?: number;
+  ancestorIds: string[];
+}
+
+export type DropTarget = WorkspaceDropTarget | SlotDropTarget | ParameterDropTarget;
 
 export type DragPayload =
   | { source: 'palette'; blockType: string }
-  | { source: 'workspace'; instanceId: string };
+  | { source: 'workspace'; instanceId: string }
+  | { source: 'parameter'; ownerId: string; parameterName: string };

--- a/src/utils/dropTarget.test.ts
+++ b/src/utils/dropTarget.test.ts
@@ -62,11 +62,42 @@ describe('getDropTargetFromElement', () => {
     });
   });
 
+  it('parses parameter drop targets when metadata exists', () => {
+    const dropElement = document.createElement('div');
+    dropElement.dataset.dropTargetKind = 'parameter';
+    dropElement.dataset.dropTargetOwnerId = 'owner-2';
+    dropElement.dataset.dropTargetParameterName = 'condition';
+    dropElement.dataset.dropTargetPosition = '1';
+    dropElement.dataset.dropTargetAncestors = 'root,owner-1';
+
+    const child = document.createElement('span');
+    dropElement.appendChild(child);
+    document.body.appendChild(dropElement);
+
+    const result = getDropTargetFromElement(child);
+    expect(result).toEqual({
+      kind: 'parameter',
+      ownerId: 'owner-2',
+      parameterName: 'condition',
+      position: 1,
+      ancestorIds: ['root', 'owner-1'],
+    });
+  });
+
   it('returns null when slot metadata is incomplete', () => {
     const element = document.createElement('div');
     element.dataset.dropTargetKind = 'slot';
     element.dataset.dropTargetOwnerId = '';
     element.dataset.dropTargetSlotName = '';
+
+    expect(getDropTargetFromElement(element)).toBeNull();
+  });
+
+  it('returns null when parameter metadata is incomplete', () => {
+    const element = document.createElement('div');
+    element.dataset.dropTargetKind = 'parameter';
+    element.dataset.dropTargetOwnerId = 'owner-3';
+    element.dataset.dropTargetParameterName = '';
 
     expect(getDropTargetFromElement(element)).toBeNull();
   });

--- a/src/utils/dropTarget.ts
+++ b/src/utils/dropTarget.ts
@@ -50,6 +50,17 @@ export const getDropTargetFromElement = (element: Element | null): DropTarget | 
     return { kind: 'slot', ownerId, slotName, position, ancestorIds };
   }
 
+  if (kind === 'parameter') {
+    const ownerId = dataset.dropTargetOwnerId;
+    const parameterName = dataset.dropTargetParameterName;
+
+    if (!ownerId || !parameterName) {
+      return null;
+    }
+
+    return { kind: 'parameter', ownerId, parameterName, position, ancestorIds };
+  }
+
   return null;
 };
 


### PR DESCRIPTION
## Summary
- add a repeat count expression container and default conditional parameter metadata to the block library
- extend the block utilities test suite to confirm control blocks seed defaults and nested inputs

## Testing
- npm run typecheck
- npm test
- npx playwright test


------
https://chatgpt.com/codex/tasks/task_e_68d27b66ec6c832eba86ff5a67d4d106