### PR TITLE
Add parameter editors and expression drop zones

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -50,6 +50,24 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     },
   },
   {
+    id: 'broadcast-signal',
+    label: 'Broadcast Signal',
+    category: 'action',
+    summary: 'Emit one of the robot signals onto the shared channel.',
+    parameters: {
+      signal: {
+        kind: 'signal',
+        defaultValue: 'status.signal',
+        allowNone: false,
+        options: [
+          { id: 'status.signal', label: 'Status Pulse' },
+          { id: 'alert.signal', label: 'Alert Beacon' },
+          { id: 'ping.signal', label: 'Ping Sweep' },
+        ],
+      },
+    },
+  },
+  {
     id: 'gather-resource',
     label: 'Gather Resource',
     category: 'action',
@@ -142,11 +160,21 @@ export function createBlockInstance(blockType: string): BlockInstance {
             };
             break;
           case 'string':
-          default:
             accumulator[parameterName] = {
               kind: 'string',
               value: parameterDefinition.defaultValue,
             };
+            break;
+          case 'signal':
+            accumulator[parameterName] = {
+              kind: 'signal',
+              value:
+                typeof parameterDefinition.defaultValue === 'string'
+                  ? parameterDefinition.defaultValue
+                  : null,
+            };
+            break;
+          case 'operator':
             break;
         }
         return accumulator;

--- a/src/components/BlockParameterField.tsx
+++ b/src/components/BlockParameterField.tsx
@@ -1,0 +1,223 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type TouchEvent as ReactTouchEvent,
+} from 'react';
+import type {
+  BlockInstance,
+  BlockParameterDefinition,
+  BlockParameterValue,
+} from '../types/blocks';
+import styles from '../styles/BlockView.module.css';
+
+interface BlockParameterFieldProps {
+  block: BlockInstance;
+  parameterName: string;
+  definition: Extract<BlockParameterDefinition, { kind: 'boolean' | 'number' | 'string' }>;
+  value: BlockParameterValue | undefined;
+  label: string;
+  testId: string;
+  onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+}
+
+const stopPropagation = (
+  event: MouseEvent<HTMLElement> | ReactTouchEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+): void => {
+  event.stopPropagation();
+};
+
+const PARTIAL_NUMBER_PATTERN = /^-?\d*(\.\d*)?$/;
+
+const BlockParameterField = ({
+  block,
+  parameterName,
+  definition,
+  value,
+  label,
+  testId,
+  onUpdateBlock,
+}: BlockParameterFieldProps): JSX.Element => {
+  const [numberDraft, setNumberDraft] = useState<string>(() => {
+    if (definition.kind === 'number') {
+      const initialValue = value?.kind === 'number' ? value.value : definition.defaultValue;
+      return Number.isFinite(initialValue) ? String(initialValue) : '';
+    }
+
+    return '';
+  });
+
+  const resolvedValue = useMemo(() => {
+    switch (definition.kind) {
+      case 'boolean':
+        return value?.kind === 'boolean' ? value.value : definition.defaultValue;
+      case 'number':
+        return value?.kind === 'number' ? value.value : definition.defaultValue;
+      case 'string':
+      default:
+        return value?.kind === 'string' ? value.value : definition.defaultValue;
+    }
+  }, [definition, value]);
+
+  useEffect(() => {
+    if (definition.kind !== 'number') {
+      return;
+    }
+
+    const nextValue = value?.kind === 'number' ? value.value : definition.defaultValue;
+    setNumberDraft(Number.isFinite(nextValue) ? String(nextValue) : '');
+  }, [definition, value]);
+
+  const updateParameter = useCallback(
+    (nextValue: BlockParameterValue): void => {
+      if (!onUpdateBlock) {
+        return;
+      }
+
+      onUpdateBlock(block.instanceId, (current) => {
+        const currentParameters = { ...(current.parameters ?? {}) };
+        return {
+          ...current,
+          parameters: {
+            ...currentParameters,
+            [parameterName]: nextValue,
+          },
+        };
+      });
+    },
+    [block.instanceId, onUpdateBlock, parameterName],
+  );
+
+  const handleBooleanClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      const defaultValue = definition.kind === 'boolean' ? definition.defaultValue : false;
+      const currentValue = value?.kind === 'boolean' ? value.value : defaultValue;
+      updateParameter({ kind: 'boolean', value: !currentValue });
+    },
+    [definition, updateParameter, value],
+  );
+
+  const handleNumberChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.value;
+      if (!PARTIAL_NUMBER_PATTERN.test(nextValue)) {
+        return;
+      }
+
+      setNumberDraft(nextValue);
+
+      if (
+        nextValue === ''
+        || nextValue === '-'
+        || nextValue === '.'
+        || nextValue === '-.'
+        || nextValue.endsWith('.')
+      ) {
+        return;
+      }
+
+      const parsed = Number(nextValue);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+
+      updateParameter({ kind: 'number', value: parsed });
+    },
+    [updateParameter],
+  );
+
+  const handleNumberBlur = useCallback(() => {
+    if (definition.kind !== 'number') {
+      return;
+    }
+
+    const trimmed = numberDraft.trim();
+    if (trimmed === '' || trimmed === '-' || trimmed === '.' || trimmed === '-.') {
+      const fallback = definition.defaultValue;
+      setNumberDraft(String(fallback));
+      updateParameter({ kind: 'number', value: fallback });
+      return;
+    }
+
+    const parsed = Number(trimmed);
+    if (Number.isNaN(parsed)) {
+      const fallback = definition.defaultValue;
+      setNumberDraft(String(fallback));
+      updateParameter({ kind: 'number', value: fallback });
+      return;
+    }
+
+    setNumberDraft(String(parsed));
+    updateParameter({ kind: 'number', value: parsed });
+  }, [definition, numberDraft, updateParameter]);
+
+  const handleStringChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      updateParameter({ kind: 'string', value: event.target.value });
+    },
+    [updateParameter],
+  );
+
+  if (definition.kind === 'boolean') {
+    const isActive = Boolean(resolvedValue);
+    return (
+      <button
+        type="button"
+        className={styles.blockToggle}
+        onMouseDown={stopPropagation}
+        onTouchStart={stopPropagation}
+        onKeyDown={stopPropagation}
+        onClick={handleBooleanClick}
+        disabled={!onUpdateBlock}
+        data-testid={testId}
+        aria-label={`${label} toggle`}
+      >
+        {isActive ? 'true' : 'false'}
+      </button>
+    );
+  }
+
+  if (definition.kind === 'number') {
+    return (
+      <input
+        type="number"
+        className={styles.blockInput}
+        value={numberDraft}
+        min={definition.min}
+        max={definition.max}
+        step={definition.step ?? 'any'}
+        readOnly={!onUpdateBlock}
+        onChange={handleNumberChange}
+        onMouseDown={stopPropagation}
+        onTouchStart={stopPropagation}
+        onKeyDown={stopPropagation}
+        onBlur={handleNumberBlur}
+        data-testid={testId}
+        aria-label={`${label} value`}
+        inputMode="decimal"
+      />
+    );
+  }
+
+  return (
+    <input
+      type="text"
+      className={styles.blockInput}
+      value={typeof resolvedValue === 'string' ? resolvedValue : ''}
+      readOnly={!onUpdateBlock}
+      onChange={handleStringChange}
+      onMouseDown={stopPropagation}
+      onTouchStart={stopPropagation}
+      onKeyDown={stopPropagation}
+      data-testid={testId}
+      aria-label={`${label} value`}
+    />
+  );
+};
+
+export default BlockParameterField;

--- a/src/components/BlockParameterSignalSelect.tsx
+++ b/src/components/BlockParameterSignalSelect.tsx
@@ -1,0 +1,87 @@
+import {
+  useCallback,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type TouchEvent as ReactTouchEvent,
+} from 'react';
+import type {
+  BlockInstance,
+  BlockParameterDefinition,
+  BlockParameterValue,
+} from '../types/blocks';
+import styles from '../styles/BlockView.module.css';
+
+interface BlockParameterSignalSelectProps {
+  block: BlockInstance;
+  parameterName: string;
+  definition: Extract<BlockParameterDefinition, { kind: 'signal' }>;
+  value: BlockParameterValue | undefined;
+  label: string;
+  testId: string;
+  onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+}
+
+const stopPropagation = (
+  event: MouseEvent<HTMLElement> | ReactTouchEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+): void => {
+  event.stopPropagation();
+};
+
+const BlockParameterSignalSelect = ({
+  block,
+  parameterName,
+  definition,
+  value,
+  label,
+  testId,
+  onUpdateBlock,
+}: BlockParameterSignalSelectProps): JSX.Element => {
+  const selectedValue = value?.kind === 'signal' ? value.value : definition.defaultValue ?? null;
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      if (!onUpdateBlock) {
+        return;
+      }
+
+      const nextValue = event.target.value === '' ? null : event.target.value;
+      onUpdateBlock(block.instanceId, (current) => {
+        const currentParameters = { ...(current.parameters ?? {}) };
+        return {
+          ...current,
+          parameters: {
+            ...currentParameters,
+            [parameterName]: { kind: 'signal', value: nextValue },
+          },
+        };
+      });
+    },
+    [block.instanceId, onUpdateBlock, parameterName],
+  );
+
+  return (
+    <select
+      className={styles.blockSelect}
+      value={selectedValue ?? ''}
+      onChange={handleChange}
+      onMouseDown={stopPropagation}
+      onTouchStart={stopPropagation}
+      onKeyDown={stopPropagation}
+      disabled={!onUpdateBlock}
+      data-testid={testId}
+      aria-label={`${label} signal`}
+    >
+      {definition.allowNone !== false ? (
+        <option value="">None</option>
+      ) : null}
+      {definition.options.map((option) => (
+        <option key={option.id} value={option.id}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default BlockParameterSignalSelect;

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -7,12 +7,13 @@ interface DropZoneProps {
   target: DropTarget;
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
   children?: ReactNode;
+  testId?: string;
 }
 
 const joinClassNames = (classNames: Array<string | undefined>): string =>
   classNames.filter(Boolean).join(' ');
 
-const DropZone = ({ className, target, onDrop, children }: DropZoneProps): JSX.Element => {
+const DropZone = ({ className, target, onDrop, children, testId }: DropZoneProps): JSX.Element => {
   const [isActive, setIsActive] = useState(false);
 
   const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -63,13 +64,18 @@ const DropZone = ({ className, target, onDrop, children }: DropZoneProps): JSX.E
       data-drop-target-position={typeof target.position === 'number' ? String(target.position) : ''}
       data-drop-target-ancestors={ancestorIds}
       data-drop-target-owner-id={
-        target.kind === 'slot' || target.kind === 'parameter' ? target.ownerId : undefined
+        target.kind === 'slot' || target.kind === 'parameter' || target.kind === 'parameter-expression'
+          ? target.ownerId
+          : undefined
       }
       data-drop-target-slot-name={target.kind === 'slot' ? target.slotName : undefined}
       data-drop-target-parameter-name={
-        target.kind === 'parameter' ? target.parameterName : undefined
+        target.kind === 'parameter' || target.kind === 'parameter-expression'
+          ? target.parameterName
+          : undefined
       }
       data-dropzone-active={isActive ? 'true' : undefined}
+      data-testid={testId}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}

--- a/src/components/ValueInputDropZone.tsx
+++ b/src/components/ValueInputDropZone.tsx
@@ -1,0 +1,88 @@
+import { Fragment, useCallback, type MouseEvent, type TouchEvent as ReactTouchEvent } from 'react';
+import type { BlockInstance, DropTarget } from '../types/blocks';
+import DropZone from './DropZone';
+import styles from '../styles/BlockView.module.css';
+
+interface ValueInputDropZoneProps {
+  owner: BlockInstance;
+  parameterName: string;
+  blocks: BlockInstance[];
+  path: string[];
+  placeholder?: string;
+  testId: string;
+  onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
+  renderBlock: (block: BlockInstance) => JSX.Element;
+}
+
+const ValueInputDropZone = ({
+  owner,
+  parameterName,
+  blocks,
+  path,
+  placeholder = 'Drop value blocks here',
+  testId,
+  onDrop,
+  renderBlock,
+}: ValueInputDropZoneProps): JSX.Element => {
+  const stopPropagation = useCallback((event: MouseEvent<HTMLDivElement> | ReactTouchEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  const createTarget = useCallback(
+    (position: number): DropTarget => ({
+      kind: 'parameter-expression',
+      ownerId: owner.instanceId,
+      parameterName,
+      position,
+      ancestorIds: path,
+    }),
+    [owner.instanceId, parameterName, path],
+  );
+
+  return (
+    <div
+      className={styles.valueInputContainer}
+      data-testid={testId}
+      onMouseDown={stopPropagation}
+      onTouchStart={stopPropagation}
+    >
+      {blocks.length === 0 ? (
+        <DropZone
+          className={styles.valueInputDropZoneEmpty}
+          target={createTarget(0)}
+          onDrop={onDrop}
+          testId={`${testId}-dropzone`}
+        >
+          <span className={styles.valueInputPlaceholder}>{placeholder}</span>
+        </DropZone>
+      ) : (
+        <div className={styles.valueInputFilled}>
+          <DropZone
+            className={`${styles.valueInputDropTarget} ${styles.valueInputDropTargetLeading}`}
+            target={createTarget(0)}
+            onDrop={onDrop}
+            testId={`${testId}-dropzone`}
+          />
+          {blocks.map((childBlock, index) => {
+            const trailingClassName =
+              index === blocks.length - 1 ? styles.valueInputDropTargetTrailing : undefined;
+            const dropClassName = [styles.valueInputDropTarget, trailingClassName].filter(Boolean).join(' ');
+
+            return (
+              <Fragment key={childBlock.instanceId}>
+                {renderBlock(childBlock)}
+                <DropZone
+                  className={dropClassName}
+                  target={createTarget(index + 1)}
+                  onDrop={onDrop}
+                />
+              </Fragment>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ValueInputDropZone;

--- a/src/components/__tests__/BlockParameterEditors.test.tsx
+++ b/src/components/__tests__/BlockParameterEditors.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import BlockView from '../BlockView';
+import { createBlockInstance } from '../../blocks/library';
+import type { BlockInstance } from '../../types/blocks';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Block parameter editors', () => {
+  const renderBlockView = (block: BlockInstance, options: { onDrop?: ReturnType<typeof vi.fn>; onUpdateBlock?: ReturnType<typeof vi.fn> } = {}) => {
+    const onDrop = options.onDrop ?? vi.fn();
+    const onUpdateBlock = options.onUpdateBlock ?? vi.fn();
+
+    render(
+      <BlockView
+        block={block}
+        path={[]}
+        onDrop={onDrop}
+        onUpdateBlock={onUpdateBlock}
+      />,
+    );
+
+    return { onDrop, onUpdateBlock };
+  };
+
+  it('updates numeric parameters when editing the field value', () => {
+    const block = createBlockInstance('repeat');
+    const { onUpdateBlock } = renderBlockView(block);
+
+    const input = screen.getByTestId('block-repeat-parameter-count') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '6' } });
+
+    expect(onUpdateBlock).toHaveBeenCalledTimes(1);
+    const updater = onUpdateBlock.mock.calls[0][1];
+    const updated = updater(block);
+    expect(updated.parameters?.count).toEqual({ kind: 'number', value: 6 });
+  });
+
+  it('allows partial numeric entry before committing decimals or negatives', () => {
+    const block = createBlockInstance('repeat');
+    let currentBlock = block;
+    const { onUpdateBlock } = renderBlockView(block);
+
+    const input = screen.getByTestId('block-repeat-parameter-count') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '-' } });
+    expect(onUpdateBlock).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: '-2' } });
+    expect(onUpdateBlock).toHaveBeenCalledTimes(1);
+    let updater = onUpdateBlock.mock.calls[0][1];
+    currentBlock = updater(currentBlock);
+    expect(currentBlock.parameters?.count).toEqual({ kind: 'number', value: -2 });
+
+    onUpdateBlock.mockClear();
+
+    fireEvent.change(input, { target: { value: '0.' } });
+    expect(onUpdateBlock).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: '0.75' } });
+    expect(onUpdateBlock).toHaveBeenCalledTimes(1);
+    updater = onUpdateBlock.mock.calls[0][1];
+    currentBlock = updater(currentBlock);
+    expect(currentBlock.parameters?.count).toEqual({ kind: 'number', value: 0.75 });
+  });
+
+  it('allows selecting a signal option for signal parameters', () => {
+    const block = createBlockInstance('broadcast-signal');
+    const { onUpdateBlock } = renderBlockView(block);
+
+    const select = screen.getByTestId('block-broadcast-signal-parameter-signal') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'alert.signal' } });
+
+    expect(onUpdateBlock).toHaveBeenCalledTimes(1);
+    const updater = onUpdateBlock.mock.calls[0][1];
+    const updated = updater(block);
+    expect(updated.parameters?.signal).toEqual({ kind: 'signal', value: 'alert.signal' });
+  });
+
+  it('emits a parameter expression drop target when dropping into the value zone', () => {
+    const block = createBlockInstance('repeat');
+    const { onDrop } = renderBlockView(block);
+
+    const container = screen.getByTestId('block-repeat-parameter-count-expression');
+    const dropZone = within(container).getByTestId('block-repeat-parameter-count-expression-dropzone');
+
+    fireEvent.drop(dropZone);
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const [, target] = onDrop.mock.calls[0];
+    expect(target).toEqual({
+      kind: 'parameter-expression',
+      ownerId: block.instanceId,
+      parameterName: 'count',
+      position: 0,
+      ancestorIds: [block.instanceId],
+    });
+  });
+});

--- a/src/state/__tests__/blockUtils.test.ts
+++ b/src/state/__tests__/blockUtils.test.ts
@@ -77,7 +77,7 @@ describe('blockUtils', () => {
     const workspace = [owner];
 
     const target: DropTarget = {
-      kind: 'parameter',
+      kind: 'parameter-expression',
       ownerId: 'owner',
       parameterName: 'condition',
       position: 0,

--- a/src/state/blockUtils.ts
+++ b/src/state/blockUtils.ts
@@ -142,7 +142,7 @@ const insertIntoBlocks = (
         continue;
       }
 
-      if (target.kind === 'parameter') {
+      if (target.kind === 'parameter' || target.kind === 'parameter-expression') {
         const inputBlocks = block.expressionInputs?.[target.parameterName] ?? [];
         const insertionIndex = clampIndex(target.position, inputBlocks.length);
         const updatedInputBlocks = [...inputBlocks];

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -44,7 +44,7 @@
 
 .blockControlRow {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
 }
@@ -52,12 +52,15 @@
 .blockControlLabel {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+  flex: 1 1 auto;
 }
 
-.blockControlValue {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
+.blockControlInputs {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 .blockToggle {
@@ -77,6 +80,31 @@
   border-color: var(--color-accent-cyan);
   background: var(--color-surface-overlay);
   outline: none;
+}
+
+.blockInput,
+.blockSelect {
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-raised);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-sm);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  min-width: 4rem;
+}
+
+.blockInput:focus,
+.blockInput:focus-visible,
+.blockSelect:focus,
+.blockSelect:focus-visible {
+  outline: none;
+  border-color: var(--color-accent-cyan);
+  box-shadow: 0 0 0 1px rgba(100, 249, 255, 0.35);
+}
+
+.blockSelect {
+  padding-right: var(--space-4);
 }
 
 .blockSlots {
@@ -156,6 +184,81 @@
   font-size: var(--font-size-sm);
 }
 
+.valueInputContainer {
+  display: flex;
+  align-items: stretch;
+  min-height: 2.25rem;
+}
+
+.valueInputDropZoneEmpty {
+  min-width: 6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-2);
+  border: 1px dashed var(--color-slot-border);
+  border-radius: var(--radius-sm);
+  background: rgba(155, 107, 255, 0.12);
+  color: var(--color-slot-text);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.valueInputDropZoneEmpty[data-dropzone-active='true'] {
+  border-color: var(--color-accent-cyan);
+  background: rgba(100, 249, 255, 0.12);
+  color: var(--color-text-primary);
+}
+
+.valueInputPlaceholder {
+  pointer-events: none;
+}
+
+.valueInputFilled {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.valueInputFilled .block {
+  margin: 0;
+}
+
+.valueInputDropTarget {
+  width: 0.5rem;
+  min-width: 0.5rem;
+  min-height: 2rem;
+  position: relative;
+}
+
+.valueInputDropTarget::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 25%;
+  bottom: 25%;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: rgba(100, 249, 255, 0.18);
+  opacity: 0;
+  transform: translateX(-50%);
+  transition: opacity var(--transition-base), background var(--transition-base);
+}
+
+.valueInputDropTarget[data-dropzone-active='true']::after {
+  opacity: 1;
+  background: var(--color-accent-cyan);
+}
+
+.valueInputDropTargetLeading {
+  margin-left: 0;
+}
+
+.valueInputDropTargetTrailing {
+  margin-right: 0;
+}
+
 @media (max-width: 720px) {
   .block {
     padding: var(--space-2) var(--space-3);
@@ -168,6 +271,10 @@
 
   .blockSummary {
     font-size: var(--font-size-xs);
+  }
+
+  .blockControlInputs {
+    gap: var(--space-1);
   }
 
   .blockSlots {
@@ -186,6 +293,15 @@
   .slotPlaceholder {
     font-size: var(--font-size-xs);
     padding: var(--space-2);
+  }
+
+  .valueInputContainer {
+    min-height: 2rem;
+  }
+
+  .valueInputDropZoneEmpty {
+    min-width: 5rem;
+    font-size: var(--font-size-xxs);
   }
 }
 
@@ -226,5 +342,13 @@
   .slotPlaceholder {
     font-size: var(--font-size-xs);
     padding: var(--space-1) var(--space-2);
+  }
+
+  .valueInputContainer {
+    min-height: 1.75rem;
+  }
+
+  .valueInputDropZoneEmpty {
+    min-width: 4.5rem;
   }
 }

--- a/src/types/blocks.ts
+++ b/src/types/blocks.ts
@@ -1,16 +1,30 @@
 export type BlockCategory = 'event' | 'action' | 'c' | string;
 
-export type BlockParameterKind = 'boolean' | 'number' | 'string';
+export type BlockParameterKind = 'boolean' | 'number' | 'string' | 'signal' | 'operator';
+
+export interface BlockParameterSignalOption {
+  id: string;
+  label: string;
+  description?: string;
+}
 
 export type BlockParameterDefinition =
   | { kind: 'boolean'; defaultValue: boolean }
-  | { kind: 'number'; defaultValue: number }
-  | { kind: 'string'; defaultValue: string };
+  | { kind: 'number'; defaultValue: number; min?: number; max?: number; step?: number }
+  | { kind: 'string'; defaultValue: string }
+  | {
+      kind: 'signal';
+      defaultValue: string | null;
+      allowNone?: boolean;
+      options: BlockParameterSignalOption[];
+    }
+  | { kind: 'operator'; valueType: 'boolean' | 'number'; label?: string };
 
 export type BlockParameterValue =
   | { kind: 'boolean'; value: boolean }
   | { kind: 'number'; value: number }
-  | { kind: 'string'; value: string };
+  | { kind: 'string'; value: string }
+  | { kind: 'signal'; value: string | null };
 
 export interface BlockDefinition {
   id: string;
@@ -55,7 +69,19 @@ export interface ParameterDropTarget {
   ancestorIds: string[];
 }
 
-export type DropTarget = WorkspaceDropTarget | SlotDropTarget | ParameterDropTarget;
+export interface ParameterExpressionDropTarget {
+  kind: 'parameter-expression';
+  ownerId: string;
+  parameterName: string;
+  position?: number;
+  ancestorIds: string[];
+}
+
+export type DropTarget =
+  | WorkspaceDropTarget
+  | SlotDropTarget
+  | ParameterDropTarget
+  | ParameterExpressionDropTarget;
 
 export type DragPayload =
   | { source: 'palette'; blockType: string }

--- a/src/utils/dropTarget.test.ts
+++ b/src/utils/dropTarget.test.ts
@@ -84,6 +84,28 @@ describe('getDropTargetFromElement', () => {
     });
   });
 
+  it('parses parameter expression drop targets when metadata exists', () => {
+    const dropElement = document.createElement('div');
+    dropElement.dataset.dropTargetKind = 'parameter-expression';
+    dropElement.dataset.dropTargetOwnerId = 'owner-5';
+    dropElement.dataset.dropTargetParameterName = 'count';
+    dropElement.dataset.dropTargetPosition = '2';
+    dropElement.dataset.dropTargetAncestors = 'root,owner-3';
+
+    const child = document.createElement('span');
+    dropElement.appendChild(child);
+    document.body.appendChild(dropElement);
+
+    const result = getDropTargetFromElement(child);
+    expect(result).toEqual({
+      kind: 'parameter-expression',
+      ownerId: 'owner-5',
+      parameterName: 'count',
+      position: 2,
+      ancestorIds: ['root', 'owner-3'],
+    });
+  });
+
   it('returns null when slot metadata is incomplete', () => {
     const element = document.createElement('div');
     element.dataset.dropTargetKind = 'slot';
@@ -97,6 +119,15 @@ describe('getDropTargetFromElement', () => {
     const element = document.createElement('div');
     element.dataset.dropTargetKind = 'parameter';
     element.dataset.dropTargetOwnerId = 'owner-3';
+    element.dataset.dropTargetParameterName = '';
+
+    expect(getDropTargetFromElement(element)).toBeNull();
+  });
+
+  it('returns null when parameter expression metadata is incomplete', () => {
+    const element = document.createElement('div');
+    element.dataset.dropTargetKind = 'parameter-expression';
+    element.dataset.dropTargetOwnerId = 'owner-6';
     element.dataset.dropTargetParameterName = '';
 
     expect(getDropTargetFromElement(element)).toBeNull();

--- a/src/utils/dropTarget.ts
+++ b/src/utils/dropTarget.ts
@@ -61,6 +61,23 @@ export const getDropTargetFromElement = (element: Element | null): DropTarget | 
     return { kind: 'parameter', ownerId, parameterName, position, ancestorIds };
   }
 
+  if (kind === 'parameter-expression') {
+    const ownerId = dataset.dropTargetOwnerId;
+    const parameterName = dataset.dropTargetParameterName;
+
+    if (!ownerId || !parameterName) {
+      return null;
+    }
+
+    return {
+      kind: 'parameter-expression',
+      ownerId,
+      parameterName,
+      position,
+      ancestorIds,
+    };
+  }
+
   return null;
 };
 


### PR DESCRIPTION
## Summary
- add dedicated parameter editor components for literals, signal selection, and expression drop zones
- teach BlockView to render parameters through the new components and support the new parameter-expression drop target
- extend drop target handling, block utilities, styling, and tests; introduce a sample signal broadcast block for exercising the new editors
- preserve partial numeric editing states in the parameter field so decimals and negatives can be entered smoothly, and cover the behaviour with focused tests

## Testing
- npm run typecheck
- npm test
- npx playwright test *(fails: browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d287628918832e826f105a931dc118