### PR TITLE
Add telemetry subscription and hook for robot signals

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -57,10 +57,10 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     parameters: {
       signal: {
         kind: 'signal',
-        defaultValue: 'status.signal',
+        defaultValue: 'status.signal.active',
         allowNone: false,
         options: [
-          { id: 'status.signal', label: 'Status Pulse' },
+          { id: 'status.signal.active', label: 'Status Indicator – Active' },
           { id: 'alert.signal', label: 'Alert Beacon' },
           { id: 'ping.signal', label: 'Ping Sweep' },
         ],

--- a/src/components/BlockParameterSignalSelect.tsx
+++ b/src/components/BlockParameterSignalSelect.tsx
@@ -10,6 +10,7 @@ import type {
   BlockParameterDefinition,
   BlockParameterValue,
 } from '../types/blocks';
+import type { RobotTelemetryData } from '../hooks/useRobotTelemetry';
 import styles from '../styles/BlockView.module.css';
 
 interface BlockParameterSignalSelectProps {
@@ -20,6 +21,7 @@ interface BlockParameterSignalSelectProps {
   label: string;
   testId: string;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  telemetry?: RobotTelemetryData;
 }
 
 const stopPropagation = (
@@ -36,8 +38,53 @@ const BlockParameterSignalSelect = ({
   label,
   testId,
   onUpdateBlock,
+  telemetry,
 }: BlockParameterSignalSelectProps): JSX.Element => {
   const selectedValue = value?.kind === 'signal' ? value.value : definition.defaultValue ?? null;
+
+  const seenValues = new Set<string>();
+  const telemetryOptions = (telemetry?.modules ?? [])
+    .filter((module) => module.signals.length > 0)
+    .map((module) => (
+      <optgroup key={`telemetry-${module.moduleId}`} label={module.label}>
+        {module.signals.map((signal) => {
+          seenValues.add(signal.id);
+          return (
+            <option key={signal.id} value={signal.id}>
+              {signal.label}
+            </option>
+          );
+        })}
+      </optgroup>
+    ));
+
+  const fallbackMap = new Map(definition.options?.map((option) => [option.id, option.label]));
+
+  const fallbackOptions = (definition.options ?? [])
+    .filter((option) => !seenValues.has(option.id))
+    .map((option) => {
+      seenValues.add(option.id);
+      return (
+        <option key={`fallback-${option.id}`} value={option.id}>
+          {option.label}
+        </option>
+      );
+    });
+
+  const shouldIncludeSelectedFallback =
+    typeof selectedValue === 'string' &&
+    selectedValue.length > 0 &&
+    !seenValues.has(selectedValue);
+
+  if (shouldIncludeSelectedFallback) {
+    const derivedLabel = fallbackMap.get(selectedValue) ?? formatSignalIdentifier(selectedValue);
+    fallbackOptions.push(
+      <option key={`selected-${selectedValue}`} value={selectedValue}>
+        {derivedLabel}
+      </option>,
+    );
+    seenValues.add(selectedValue);
+  }
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
@@ -75,13 +122,20 @@ const BlockParameterSignalSelect = ({
       {definition.allowNone !== false ? (
         <option value="">None</option>
       ) : null}
-      {definition.options.map((option) => (
-        <option key={option.id} value={option.id}>
-          {option.label}
-        </option>
-      ))}
+      {telemetryOptions}
+      {fallbackOptions}
     </select>
   );
 };
+
+const formatSignalIdentifier = (identifier: string): string =>
+  identifier
+    .split('.')
+    .map((segment) =>
+      segment
+        .replace(/[-_]/g, ' ')
+        .replace(/\b[a-z]/g, (character) => character.toUpperCase()),
+    )
+    .join(' – ');
 
 export default BlockParameterSignalSelect;

--- a/src/components/BlockView.tsx
+++ b/src/components/BlockView.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback, useMemo, useRef, type TouchEvent as ReactTouchEvent } from 'react';
 import { BLOCK_MAP } from '../blocks/library';
+import type { RobotTelemetryData } from '../hooks/useRobotTelemetry';
 import type { BlockInstance, DragPayload, DropTarget } from '../types/blocks';
 import styles from '../styles/BlockView.module.css';
 import { getDropTargetFromTouchEvent } from '../utils/dropTarget';
@@ -22,9 +23,10 @@ interface BlockViewProps {
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  telemetry?: RobotTelemetryData;
 }
 
-const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock }: BlockViewProps): JSX.Element | null => {
+const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock, telemetry }: BlockViewProps): JSX.Element | null => {
   const definition = BLOCK_MAP[block.type];
   if (!definition) {
     return null;
@@ -187,6 +189,7 @@ const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock }: BlockVie
               label={parameterLabel}
               testId={`block-${definition.id}-parameter-${parameterName}`}
               onUpdateBlock={onUpdateBlock}
+              telemetry={telemetry}
             />
           );
         }
@@ -213,6 +216,7 @@ const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock }: BlockVie
                       onDrop={onDrop}
                       onTouchDrop={onTouchDrop}
                       onUpdateBlock={onUpdateBlock}
+                      telemetry={telemetry}
                     />
                   )}
                 />
@@ -245,6 +249,7 @@ const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock }: BlockVie
                     onDrop={onDrop}
                     onTouchDrop={onTouchDrop}
                     onUpdateBlock={onUpdateBlock}
+                    telemetry={telemetry}
                   />
                 )}
               />
@@ -264,6 +269,7 @@ const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock }: BlockVie
               onDrop={onDrop}
               onTouchDrop={onTouchDrop}
               onUpdateBlock={onUpdateBlock}
+              telemetry={telemetry}
             />
           ))}
         </div>
@@ -280,9 +286,10 @@ interface SlotViewProps {
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  telemetry?: RobotTelemetryData;
 }
 
-const SlotView = ({ owner, slotName, blocks, path, onDrop, onTouchDrop, onUpdateBlock }: SlotViewProps): JSX.Element => {
+const SlotView = ({ owner, slotName, blocks, path, onDrop, onTouchDrop, onUpdateBlock, telemetry }: SlotViewProps): JSX.Element => {
   const handleDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
       onDrop(event, {
@@ -359,6 +366,7 @@ const SlotView = ({ owner, slotName, blocks, path, onDrop, onTouchDrop, onUpdate
                     onDrop={onDrop}
                     onTouchDrop={onTouchDrop}
                     onUpdateBlock={onUpdateBlock}
+                    telemetry={telemetry}
                   />
                   <DropZone
                     className={dropTargetClassName}

--- a/src/components/RobotProgrammingPanel.tsx
+++ b/src/components/RobotProgrammingPanel.tsx
@@ -5,6 +5,7 @@ import RuntimeControls from './RuntimeControls';
 import { BLOCK_LIBRARY } from '../blocks/library';
 import type { WorkspaceState, DropTarget, BlockInstance, DragPayload } from '../types/blocks';
 import styles from '../styles/RobotProgrammingPanel.module.css';
+import useRobotTelemetry from '../hooks/useRobotTelemetry';
 
 interface RobotProgrammingPanelProps {
   workspace: WorkspaceState;
@@ -26,6 +27,7 @@ const RobotProgrammingPanel = ({
   robotId,
 }: RobotProgrammingPanelProps): JSX.Element => {
   const paletteRef = useRef<HTMLDivElement | null>(null);
+  const telemetry = useRobotTelemetry();
   const handleConfirm = useCallback(() => {
     onConfirm();
   }, [onConfirm]);
@@ -59,6 +61,7 @@ const RobotProgrammingPanel = ({
             onDrop={onDrop}
             onTouchDrop={onTouchDrop}
             onUpdateBlock={onUpdateBlock}
+            telemetry={telemetry}
           />
         </section>
       </div>

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback } from 'react';
 import BlockView from './BlockView';
 import DropZone from './DropZone';
+import type { RobotTelemetryData } from '../hooks/useRobotTelemetry';
 import type { BlockInstance, DropTarget, DragPayload } from '../types/blocks';
 import styles from '../styles/Workspace.module.css';
 
@@ -9,9 +10,10 @@ interface WorkspaceProps {
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  telemetry?: RobotTelemetryData;
 }
 
-const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock }: WorkspaceProps): JSX.Element => {
+const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock, telemetry }: WorkspaceProps): JSX.Element => {
   const workspaceTarget = (position: number): DropTarget => ({
     kind: 'workspace',
     position,
@@ -67,6 +69,7 @@ const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock }: WorkspaceProp
                     onDrop={onDrop}
                     onTouchDrop={onTouchDrop}
                     onUpdateBlock={onUpdateBlock}
+                    telemetry={telemetry}
                   />
                   <DropZone
                     className={dropTargetClassName}

--- a/src/components/__tests__/BlockParameterEditors.test.tsx
+++ b/src/components/__tests__/BlockParameterEditors.test.tsx
@@ -1,11 +1,16 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within, act, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import BlockView from '../BlockView';
-import { createBlockInstance } from '../../blocks/library';
+import BlockParameterSignalSelect from '../BlockParameterSignalSelect';
+import { BLOCK_MAP, createBlockInstance } from '../../blocks/library';
 import type { BlockInstance } from '../../types/blocks';
+import useRobotTelemetry from '../../hooks/useRobotTelemetry';
+import { simulationRuntime } from '../../state/simulationRuntime';
+import type { SimulationTelemetrySnapshot } from '../../simulation/runtime/ecsBlackboard';
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('Block parameter editors', () => {
@@ -96,6 +101,82 @@ describe('Block parameter editors', () => {
       parameterName: 'count',
       position: 0,
       ancestorIds: [block.instanceId],
+    });
+  });
+
+  it('refreshes signal options when telemetry snapshots change', async () => {
+    const block = createBlockInstance('broadcast-signal');
+    const definition = BLOCK_MAP['broadcast-signal'].parameters?.signal;
+    if (!definition || definition.kind !== 'signal') {
+      throw new Error('Signal parameter definition not found.');
+    }
+
+    const initialSnapshot: SimulationTelemetrySnapshot = {
+      values: {
+        'status.signal': {
+          active: {
+            value: true,
+            metadata: { label: 'Indicator active' },
+            revision: 1,
+          },
+        },
+      },
+      actions: {},
+    };
+
+    const updatedSnapshot: SimulationTelemetrySnapshot = {
+      values: {
+        'status.signal': {
+          active: {
+            value: false,
+            metadata: { label: 'Indicator engaged' },
+            revision: 2,
+          },
+        },
+      },
+      actions: {},
+    };
+
+    let telemetryListener: ((snapshot: SimulationTelemetrySnapshot, robotId: string | null) => void) | null = null;
+
+    vi.spyOn(simulationRuntime, 'getSelectedRobot').mockReturnValue('MF-01');
+    vi.spyOn(simulationRuntime, 'getTelemetrySnapshot').mockReturnValue(initialSnapshot);
+    vi.spyOn(simulationRuntime, 'subscribeTelemetry').mockImplementation((listener) => {
+      telemetryListener = listener;
+      listener(initialSnapshot, 'MF-01');
+      return () => {};
+    });
+
+    const Harness = () => {
+      const telemetry = useRobotTelemetry();
+      return (
+        <BlockParameterSignalSelect
+          block={block}
+          parameterName="signal"
+          definition={definition}
+          value={block.parameters?.signal}
+          label="Signal"
+          testId="block-broadcast-signal-parameter-signal"
+          onUpdateBlock={vi.fn()}
+          telemetry={telemetry}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    const select = screen.getByTestId('block-broadcast-signal-parameter-signal') as HTMLSelectElement;
+    const optionLabels = () => Array.from(select.options).map((option) => option.textContent);
+
+    expect(optionLabels()).toContain('Indicator active');
+    expect(telemetryListener).not.toBeNull();
+
+    act(() => {
+      telemetryListener?.(updatedSnapshot, 'MF-01');
+    });
+
+    await waitFor(() => {
+      expect(optionLabels()).toContain('Indicator engaged');
     });
   });
 });

--- a/src/hooks/useRobotTelemetry.ts
+++ b/src/hooks/useRobotTelemetry.ts
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { SimulationTelemetrySnapshot } from '../simulation/runtime/ecsBlackboard';
+import { MODULE_LIBRARY } from '../simulation/robot/modules/moduleLibrary';
+import { simulationRuntime } from '../state/simulationRuntime';
+
+interface TelemetryValueMetadata {
+  label?: string;
+  description?: string;
+}
+
+export interface RobotTelemetrySignal {
+  id: string;
+  key: string;
+  moduleId: string;
+  label: string;
+  value: unknown;
+  description?: string;
+}
+
+export interface RobotTelemetryModuleGroup {
+  moduleId: string;
+  label: string;
+  signals: RobotTelemetrySignal[];
+}
+
+export interface RobotTelemetryData {
+  robotId: string | null;
+  snapshot: SimulationTelemetrySnapshot;
+  modules: RobotTelemetryModuleGroup[];
+}
+
+const MODULE_BLUEPRINT_MAP = MODULE_LIBRARY.reduce<Record<string, (typeof MODULE_LIBRARY)[number]>>(
+  (accumulator, blueprint) => {
+    accumulator[blueprint.id] = blueprint;
+    return accumulator;
+  },
+  {},
+);
+
+const formatTitleCase = (value: string): string =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_.]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/(^|\s)([a-z])/g, (match) => match.toUpperCase());
+
+const buildModuleLabel = (moduleId: string): string => {
+  const blueprint = MODULE_BLUEPRINT_MAP[moduleId];
+  if (blueprint?.title) {
+    return blueprint.title;
+  }
+  return formatTitleCase(moduleId);
+};
+
+const buildSignalLabel = (key: string, metadata: TelemetryValueMetadata | undefined): string => {
+  if (metadata?.label) {
+    return metadata.label;
+  }
+  return formatTitleCase(key);
+};
+
+const buildSignalDescription = (
+  metadata: TelemetryValueMetadata | undefined,
+): string | undefined => {
+  if (metadata?.description && typeof metadata.description === 'string') {
+    return metadata.description;
+  }
+  return undefined;
+};
+
+const extractModules = (snapshot: SimulationTelemetrySnapshot): RobotTelemetryModuleGroup[] => {
+  const moduleIds = new Set<string>();
+  for (const moduleId of Object.keys(snapshot.values ?? {})) {
+    moduleIds.add(moduleId);
+  }
+  for (const moduleId of Object.keys(snapshot.actions ?? {})) {
+    moduleIds.add(moduleId);
+  }
+
+  const sortedModuleIds = Array.from(moduleIds).sort((a, b) => buildModuleLabel(a).localeCompare(buildModuleLabel(b)));
+
+  return sortedModuleIds.map((moduleId) => {
+    const label = buildModuleLabel(moduleId);
+    const values = snapshot.values?.[moduleId] ?? {};
+    const signals = Object.entries(values)
+      .map(([key, entry]) => {
+        const metadata = (entry?.metadata ?? {}) as TelemetryValueMetadata;
+        return {
+          id: `${moduleId}.${key}`,
+          key,
+          moduleId,
+          label: buildSignalLabel(key, metadata),
+          description: buildSignalDescription(metadata),
+          value: entry?.value,
+        } satisfies RobotTelemetrySignal;
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    return {
+      moduleId,
+      label,
+      signals,
+    } satisfies RobotTelemetryModuleGroup;
+  });
+};
+
+const EMPTY_TELEMETRY: SimulationTelemetrySnapshot = { values: {}, actions: {} };
+
+export const useRobotTelemetry = (): RobotTelemetryData => {
+  const [state, setState] = useState<{ robotId: string | null; snapshot: SimulationTelemetrySnapshot }>(() => {
+    const robotId = simulationRuntime.getSelectedRobot();
+    const snapshot = simulationRuntime.getTelemetrySnapshot(robotId ?? null);
+    return { robotId, snapshot };
+  });
+
+  useEffect(
+    () =>
+      simulationRuntime.subscribeTelemetry((snapshot, robotId) => {
+        setState((current) => ({ robotId: robotId ?? current.robotId ?? null, snapshot }));
+      }),
+    [],
+  );
+
+  const modules = useMemo(() => extractModules(state.snapshot), [state.snapshot]);
+
+  return {
+    robotId: state.robotId,
+    snapshot: state.snapshot ?? EMPTY_TELEMETRY,
+    modules,
+  };
+};
+
+export default useRobotTelemetry;

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -17,6 +17,9 @@ const createSceneStub = () => {
     stopProgram: vi.fn(),
     getInventorySnapshot: vi.fn(() => ({ capacity: 0, used: 0, available: 0, entries: [] })),
     subscribeInventory: vi.fn(() => () => {}),
+    subscribeTelemetry: vi.fn(() => () => {}),
+    getTelemetrySnapshot: vi.fn(() => ({ values: {}, actions: {} })),
+    getSelectedRobot: vi.fn(() => null),
     selectRobot: vi.fn(),
     clearRobotSelection: vi.fn(),
     triggerStatus: (status: Parameters<NonNullable<typeof subscriptions.status>>[0]) => {

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -2,11 +2,16 @@ import type { RootScene } from '../simulation/rootScene';
 import type { CompiledProgram } from '../simulation/runtime/blockProgram';
 import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
 import { DEFAULT_STARTUP_PROGRAM } from '../simulation/runtime/defaultProgram';
+import type { SimulationTelemetrySnapshot } from '../simulation/runtime/ecsBlackboard';
 import type { InventorySnapshot } from '../simulation/robot/inventory';
 
 type StatusListener = (status: ProgramRunnerStatus) => void;
 type InventoryListener = (snapshot: InventorySnapshot) => void;
 type SelectionListener = (selectedRobotId: string | null) => void;
+type TelemetryListener = (
+  snapshot: SimulationTelemetrySnapshot,
+  robotId: string | null,
+) => void;
 
 const EMPTY_INVENTORY_SNAPSHOT: InventorySnapshot = {
   capacity: 0,
@@ -15,16 +20,26 @@ const EMPTY_INVENTORY_SNAPSHOT: InventorySnapshot = {
   entries: [],
 };
 
+const EMPTY_TELEMETRY_SNAPSHOT: SimulationTelemetrySnapshot = {
+  values: {},
+  actions: {},
+};
+
 class SimulationRuntime {
   private scene: RootScene | null = null;
   private pendingProgram: CompiledProgram | null = null;
   private readonly listeners = new Set<StatusListener>();
   private readonly inventoryListeners = new Set<InventoryListener>();
   private readonly selectionListeners = new Set<SelectionListener>();
+  private readonly telemetryListeners = new Set<TelemetryListener>();
   private unsubscribeScene: (() => void) | null = null;
   private sceneInventoryUnsubscribe: (() => void) | null = null;
+  private sceneTelemetryUnsubscribe: (() => void) | null = null;
   private status: ProgramRunnerStatus = 'idle';
   private inventorySnapshot: InventorySnapshot = EMPTY_INVENTORY_SNAPSHOT;
+  private telemetrySnapshot: SimulationTelemetrySnapshot = EMPTY_TELEMETRY_SNAPSHOT;
+  private telemetryRobotId: string | null = null;
+  private readonly telemetrySnapshots = new Map<string, SimulationTelemetrySnapshot>();
   private selectedRobotId: string | null = null;
   private hasAutoStarted = false;
 
@@ -35,6 +50,8 @@ class SimulationRuntime {
 
     this.unsubscribeScene?.();
     this.teardownInventorySubscription();
+    this.sceneTelemetryUnsubscribe?.();
+    this.telemetrySnapshots.clear();
     this.scene = scene;
     this.unsubscribeScene = scene.subscribeProgramStatus((nextStatus) => {
       this.updateStatus(nextStatus);
@@ -42,6 +59,10 @@ class SimulationRuntime {
     this.updateStatus(scene.getProgramStatus());
     this.updateInventorySnapshot(scene.getInventorySnapshot());
     this.ensureInventorySubscription();
+    this.sceneTelemetryUnsubscribe = scene.subscribeTelemetry((snapshot, robotId) => {
+      this.handleSceneTelemetry(snapshot, robotId);
+    });
+    this.handleSceneTelemetry(scene.getTelemetrySnapshot(), scene.getSelectedRobot());
     if (this.selectedRobotId !== null) {
       scene.selectRobot(this.selectedRobotId);
     }
@@ -65,10 +86,14 @@ class SimulationRuntime {
     this.unsubscribeScene?.();
     this.unsubscribeScene = null;
     this.teardownInventorySubscription();
+    this.sceneTelemetryUnsubscribe?.();
+    this.sceneTelemetryUnsubscribe = null;
     this.scene = null;
     this.pendingProgram = null;
     this.updateStatus('idle');
     this.updateInventorySnapshot(EMPTY_INVENTORY_SNAPSHOT);
+    this.updateTelemetrySnapshot(EMPTY_TELEMETRY_SNAPSHOT, null);
+    this.telemetrySnapshots.clear();
     this.updateSelectedRobot(null);
     this.hasAutoStarted = false;
   }
@@ -118,6 +143,24 @@ class SimulationRuntime {
     return this.inventorySnapshot;
   }
 
+  subscribeTelemetry(listener: TelemetryListener): () => void {
+    this.telemetryListeners.add(listener);
+    listener(this.telemetrySnapshot, this.telemetryRobotId);
+    return () => {
+      this.telemetryListeners.delete(listener);
+    };
+  }
+
+  getTelemetrySnapshot(robotId: string | null = this.selectedRobotId): SimulationTelemetrySnapshot {
+    if (robotId) {
+      if (robotId === this.telemetryRobotId) {
+        return this.telemetrySnapshot;
+      }
+      return this.telemetrySnapshots.get(robotId) ?? EMPTY_TELEMETRY_SNAPSHOT;
+    }
+    return this.telemetrySnapshot;
+  }
+
   subscribeSelectedRobot(listener: SelectionListener): () => void {
     this.selectionListeners.add(listener);
     listener(this.selectedRobotId);
@@ -133,11 +176,13 @@ class SimulationRuntime {
   setSelectedRobot(robotId: string): void {
     this.scene?.selectRobot(robotId);
     this.updateSelectedRobot(robotId);
+    this.applyTelemetryForSelection(robotId);
   }
 
   clearSelectedRobot(): void {
     this.scene?.clearRobotSelection();
     this.updateSelectedRobot(null);
+    this.applyTelemetryForSelection(null);
   }
 
   private updateStatus(status: ProgramRunnerStatus): void {
@@ -180,6 +225,54 @@ class SimulationRuntime {
     this.selectedRobotId = selectedRobotId;
     for (const listener of this.selectionListeners) {
       listener(selectedRobotId);
+    }
+  }
+
+  private handleSceneTelemetry(
+    snapshot: SimulationTelemetrySnapshot,
+    robotId: string | null,
+  ): void {
+    if (robotId) {
+      this.telemetrySnapshots.set(robotId, snapshot);
+    }
+    const effectiveRobotId = robotId ?? this.selectedRobotId;
+    if (effectiveRobotId === this.selectedRobotId) {
+      this.updateTelemetrySnapshot(snapshot, effectiveRobotId ?? null);
+    }
+  }
+
+  private applyTelemetryForSelection(robotId: string | null): void {
+    if (robotId) {
+      const cached = this.telemetrySnapshots.get(robotId);
+      if (cached) {
+        this.updateTelemetrySnapshot(cached, robotId);
+        return;
+      }
+      if (this.scene) {
+        this.updateTelemetrySnapshot(this.scene.getTelemetrySnapshot(), robotId);
+        return;
+      }
+      this.updateTelemetrySnapshot(EMPTY_TELEMETRY_SNAPSHOT, robotId);
+      return;
+    }
+    this.updateTelemetrySnapshot(EMPTY_TELEMETRY_SNAPSHOT, null);
+  }
+
+  private updateTelemetrySnapshot(
+    snapshot: SimulationTelemetrySnapshot,
+    robotId: string | null,
+  ): void {
+    this.telemetrySnapshot = snapshot;
+    this.telemetryRobotId = robotId;
+    if (robotId) {
+      this.telemetrySnapshots.set(robotId, snapshot);
+    }
+    this.notifyTelemetryListeners();
+  }
+
+  private notifyTelemetryListeners(): void {
+    for (const listener of this.telemetryListeners) {
+      listener(this.telemetrySnapshot, this.telemetryRobotId);
     }
   }
 }


### PR DESCRIPTION
## Summary
- stream telemetry from RootScene into SimulationRuntime and cache per robot
- add a useRobotTelemetry hook and thread telemetry through the programming panel
- refresh signal selector options from live telemetry with updated unit coverage

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2969762f4832eb397f2bb7be3ae54