### PR TITLE
Add value blocks, palette grouping, and tests

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -2,43 +2,55 @@ import type { BlockDefinition, BlockInstance } from '../types/blocks';
 
 let blockCounter = 0;
 
+const SIGNAL_OPTIONS = [
+  { id: 'status.signal.active', label: 'Status Indicator – Active' },
+  { id: 'alert.signal', label: 'Alert Beacon' },
+  { id: 'ping.signal', label: 'Ping Sweep' },
+];
+
 export const BLOCK_LIBRARY: BlockDefinition[] = [
   {
     id: 'start',
     label: 'When Started',
     category: 'event',
     slots: ['do'],
-    summary: 'Entry point that fires once when the scene begins.'
+    summary: 'Entry point that fires once when the scene begins.',
+    paletteGroup: 'Events',
   },
   {
     id: 'move',
     label: 'Move Forward',
     category: 'action',
-    summary: 'Move the actor forward by one unit.'
+    summary: 'Move the actor forward by one unit.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'turn',
     label: 'Turn Left',
     category: 'action',
-    summary: 'Rotate the actor 90° counter-clockwise.'
+    summary: 'Rotate the actor 90° counter-clockwise.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'wait',
     label: 'Wait',
     category: 'action',
-    summary: 'Pause the routine for a single beat.'
+    summary: 'Pause the routine for a single beat.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'scan-resources',
     label: 'Scan Area',
     category: 'action',
-    summary: 'Trigger the survey scanner to look for nearby resource nodes.'
+    summary: 'Trigger the survey scanner to look for nearby resource nodes.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'toggle-status',
     label: 'Toggle Status',
     category: 'action',
-    summary: 'Flip the status indicator between on and off states.'
+    summary: 'Flip the status indicator between on and off states.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'set-status',
@@ -48,6 +60,11 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     parameters: {
       value: { kind: 'boolean', defaultValue: true },
     },
+    expressionInputs: ['value'],
+    expressionInputDefaults: {
+      value: ['literal-boolean'],
+    },
+    paletteGroup: 'Actions',
   },
   {
     id: 'broadcast-signal',
@@ -59,31 +76,31 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
         kind: 'signal',
         defaultValue: 'status.signal.active',
         allowNone: false,
-        options: [
-          { id: 'status.signal.active', label: 'Status Indicator – Active' },
-          { id: 'alert.signal', label: 'Alert Beacon' },
-          { id: 'ping.signal', label: 'Ping Sweep' },
-        ],
+        options: SIGNAL_OPTIONS,
       },
     },
+    paletteGroup: 'Actions',
   },
   {
     id: 'gather-resource',
     label: 'Gather Resource',
     category: 'action',
-    summary: 'Harvest the closest detected resource node and store it in cargo.'
+    summary: 'Harvest the closest detected resource node and store it in cargo.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'return-home',
     label: 'Return to Core',
     category: 'action',
-    summary: 'Navigate back to the Mind Fragment to offload gathered scrap.'
+    summary: 'Navigate back to the Mind Fragment to offload gathered scrap.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'deposit-cargo',
     label: 'Deposit Cargo',
     category: 'action',
-    summary: 'Transfer stored resources into the assembler reserves.'
+    summary: 'Transfer stored resources into the assembler reserves.',
+    paletteGroup: 'Actions',
   },
   {
     id: 'repeat',
@@ -95,20 +112,25 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
       count: { kind: 'number', defaultValue: 3 },
     },
     expressionInputs: ['count'],
+    paletteGroup: 'Control',
+    paletteTags: ['loop'],
   },
   {
     id: 'forever',
     label: 'Forever',
     category: 'c',
     slots: ['do'],
-    summary: 'Loop the enclosed blocks without end.'
+    summary: 'Loop the enclosed blocks without end.',
+    paletteGroup: 'Control',
+    paletteTags: ['loop'],
   },
   {
     id: 'parallel',
     label: 'Parallel',
     category: 'c',
     slots: ['branchA', 'branchB'],
-    summary: 'Execute the A and B branches side by side.'
+    summary: 'Execute the A and B branches side by side.',
+    paletteGroup: 'Control',
   },
   {
     id: 'if',
@@ -120,7 +142,89 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
       condition: { kind: 'boolean', defaultValue: true },
     },
     expressionInputs: ['condition'],
-  }
+    expressionInputDefaults: {
+      condition: ['literal-boolean'],
+    },
+    paletteGroup: 'Control',
+    paletteTags: ['logic'],
+  },
+  {
+    id: 'literal-number',
+    label: 'Number Literal',
+    category: 'value',
+    summary: 'Outputs the configured numeric value for use in expressions.',
+    parameters: {
+      value: { kind: 'number', defaultValue: 0 },
+    },
+    paletteGroup: 'Values & Signals',
+    paletteTags: ['value', 'number', 'literal', 'constant'],
+  },
+  {
+    id: 'literal-boolean',
+    label: 'Boolean Literal',
+    category: 'value',
+    summary: 'Outputs a fixed true or false value for conditionals.',
+    parameters: {
+      value: { kind: 'boolean', defaultValue: true },
+    },
+    paletteGroup: 'Values & Signals',
+    paletteTags: ['value', 'boolean', 'literal', 'logic'],
+  },
+  {
+    id: 'read-signal',
+    label: 'Read Signal',
+    category: 'value',
+    summary: 'Returns the most recent value reported by a selected robot signal.',
+    parameters: {
+      signal: {
+        kind: 'signal',
+        defaultValue: 'status.signal.active',
+        allowNone: false,
+        options: SIGNAL_OPTIONS,
+      },
+    },
+    paletteGroup: 'Values & Signals',
+    paletteTags: ['value', 'signal', 'sensor', 'status'],
+  },
+  {
+    id: 'operator-add',
+    label: 'Add Numbers',
+    category: 'operator',
+    summary: 'Outputs the sum of two number inputs.',
+    expressionInputs: ['firstValue', 'secondValue'],
+    expressionInputDefaults: {
+      firstValue: ['literal-number'],
+      secondValue: ['literal-number'],
+    },
+    paletteGroup: 'Operators',
+    paletteTags: ['operator', 'math', 'arithmetic'],
+  },
+  {
+    id: 'operator-greater-than',
+    label: 'Greater Than',
+    category: 'operator',
+    summary: 'Returns true when the first number is greater than the second.',
+    expressionInputs: ['firstValue', 'secondValue'],
+    expressionInputDefaults: {
+      firstValue: ['literal-number'],
+      secondValue: ['literal-number'],
+    },
+    paletteGroup: 'Operators',
+    paletteTags: ['operator', 'comparison', 'logic'],
+  },
+  {
+    id: 'operator-and',
+    label: 'Logical AND',
+    category: 'operator',
+    summary: 'Outputs true only when both boolean inputs evaluate to true.',
+    expressionInputs: ['firstValue', 'secondValue'],
+    expressionInputDefaults: {
+      firstValue: ['literal-boolean'],
+      secondValue: ['literal-boolean'],
+    },
+    paletteGroup: 'Operators',
+    paletteTags: ['operator', 'logic', 'boolean'],
+  },
 ];
 
 export const BLOCK_MAP: Record<string, BlockDefinition> = BLOCK_LIBRARY.reduce(
@@ -165,15 +269,20 @@ export function createBlockInstance(blockType: string): BlockInstance {
               value: parameterDefinition.defaultValue,
             };
             break;
-          case 'signal':
+          case 'signal': {
+            const fallbackValue =
+              typeof parameterDefinition.defaultValue === 'string'
+                ? parameterDefinition.defaultValue
+                : parameterDefinition.allowNone === false && parameterDefinition.options.length > 0
+                  ? parameterDefinition.options[0]?.id ?? null
+                  : null;
+
             accumulator[parameterName] = {
               kind: 'signal',
-              value:
-                typeof parameterDefinition.defaultValue === 'string'
-                  ? parameterDefinition.defaultValue
-                  : null,
+              value: fallbackValue,
             };
             break;
+          }
           case 'operator':
             break;
         }
@@ -201,6 +310,23 @@ export function createBlockInstance(blockType: string): BlockInstance {
       },
       {},
     );
+  }
+
+  if (definition.expressionInputDefaults && instance.expressionInputs) {
+    for (const [inputName, defaultBlockTypes] of Object.entries(definition.expressionInputDefaults)) {
+      const target = instance.expressionInputs[inputName];
+      if (!target) {
+        continue;
+      }
+
+      for (const blockType of defaultBlockTypes) {
+        if (!BLOCK_MAP[blockType]) {
+          continue;
+        }
+
+        target.push(createBlockInstance(blockType));
+      }
+    }
   }
 
   return instance;

--- a/src/components/BlockPalette.tsx
+++ b/src/components/BlockPalette.tsx
@@ -1,8 +1,10 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type DragEvent,
   type TouchEvent as ReactTouchEvent,
 } from 'react';
@@ -12,20 +14,89 @@ import styles from '../styles/BlockPalette.module.css';
 
 const PAYLOAD_MIME = 'application/json';
 
+const CATEGORY_GROUP_LABELS: Record<string, string> = {
+  event: 'Events',
+  action: 'Actions',
+  c: 'Control',
+  value: 'Values & Signals',
+  operator: 'Operators',
+};
+
+const getGroupLabel = (definition: BlockDefinition): string =>
+  definition.paletteGroup ?? CATEGORY_GROUP_LABELS[definition.category] ?? 'Other';
+
+const getBadgeLabel = (definition: BlockDefinition): string | null => {
+  switch (definition.category) {
+    case 'value':
+      return 'Value';
+    case 'operator':
+      return 'Operator';
+    default:
+      return null;
+  }
+};
+
 interface BlockPaletteProps {
   blocks: BlockDefinition[];
   onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
 }
 
+interface PaletteGroup {
+  key: string;
+  label: string;
+  blocks: BlockDefinition[];
+}
+
 const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element => {
   const [activeSummaryId, setActiveSummaryId] = useState<string | null>(null);
+  const [filterQuery, setFilterQuery] = useState('');
   const paletteRef = useRef<HTMLDivElement | null>(null);
   const touchPayloadRef = useRef<DragPayload | null>(null);
+
+  const { groups, filteredBlockIds } = useMemo(() => {
+    const query = filterQuery.trim().toLowerCase();
+    const groupsList: PaletteGroup[] = [];
+    const groupMap = new Map<string, PaletteGroup>();
+    const blockIds = new Set<string>();
+
+    blocks.forEach((definition) => {
+      const searchableParts = [
+        definition.label,
+        definition.summary ?? '',
+        ...(definition.paletteTags ?? []),
+      ];
+
+      const matches =
+        query.length === 0
+        || searchableParts.some((part) => part.toLowerCase().includes(query));
+
+      if (!matches) {
+        return;
+      }
+
+      const groupLabel = getGroupLabel(definition);
+      let group = groupMap.get(groupLabel);
+      if (!group) {
+        group = { key: groupLabel, label: groupLabel, blocks: [] };
+        groupMap.set(groupLabel, group);
+        groupsList.push(group);
+      }
+
+      group.blocks.push(definition);
+      blockIds.add(definition.id);
+    });
+
+    return { groups: groupsList, filteredBlockIds: blockIds };
+  }, [blocks, filterQuery]);
+
+  const handleFilterChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setFilterQuery(event.target.value);
+  }, []);
 
   const handleDragStart = useCallback((definition: BlockDefinition) => (event: DragEvent<HTMLDivElement>) => {
     const payload = {
       source: 'palette',
-      blockType: definition.id
+      blockType: definition.id,
     };
 
     event.dataTransfer.effectAllowed = 'copyMove';
@@ -80,6 +151,12 @@ const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element =
   }, []);
 
   useEffect(() => {
+    if (activeSummaryId && !filteredBlockIds.has(activeSummaryId)) {
+      setActiveSummaryId(null);
+    }
+  }, [activeSummaryId, filteredBlockIds]);
+
+  useEffect(() => {
     const handlePointerDown = (event: PointerEvent): void => {
       if (!paletteRef.current) {
         return;
@@ -111,67 +188,99 @@ const BlockPalette = ({ blocks, onTouchDrop }: BlockPaletteProps): JSX.Element =
     setActiveSummaryId((current) => (current === definitionId ? null : current));
   }, []);
 
-  return (
-    <div
-      className={styles.blockPalette}
-      role="list"
-      data-testid="block-palette-list"
-      ref={paletteRef}
-    >
-      {blocks.map((definition) => {
-        const paletteItemClasses = [styles.paletteItem];
-        switch (definition.category) {
-          case 'action':
-            paletteItemClasses.push(styles.paletteItemAction);
-            break;
-          case 'c':
-            paletteItemClasses.push(styles.paletteItemC);
-            break;
-          case 'event':
-            paletteItemClasses.push(styles.paletteItemEvent);
-            break;
-          default:
-            paletteItemClasses.push(styles.paletteItemAction);
-            break;
-        }
-        if (definition.summary && activeSummaryId === definition.id) {
-          paletteItemClasses.push(styles.paletteItemActive);
-        }
+  const trimmedFilter = filterQuery.trim();
+  const hasFilter = trimmedFilter.length > 0;
 
-        const paletteItemClass = paletteItemClasses.join(' ');
-        const isSummaryActive = Boolean(definition.summary && activeSummaryId === definition.id);
-        return (
-          <div
-            key={definition.id}
-            role="listitem"
-            className={paletteItemClass}
-            draggable
-            onDragStart={handleDragStart(definition)}
-            onTouchStart={handleTouchStart(definition)}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-            onTouchCancel={handleTouchCancel}
-            onClick={handlePaletteItemClick(definition.id)}
-            onFocus={handlePaletteItemClick(definition.id)}
-            onMouseLeave={handlePaletteItemMouseLeave(definition.id)}
-            onBlur={handlePaletteItemBlur(definition.id)}
-            tabIndex={0}
-            data-testid={`palette-${definition.id}`}
-          >
-            <span className={styles.paletteLabel}>{definition.label}</span>
-            {definition.summary ? (
-              <small
-                className={`${styles.paletteSummary} ${
-                  isSummaryActive ? styles.paletteSummaryVisible : ''
-                }`}
-                aria-hidden={isSummaryActive ? false : true}
-              >
-                {definition.summary}
-              </small>
-            ) : null}
+  return (
+    <div className={styles.paletteWrapper} ref={paletteRef}>
+      <div className={styles.paletteControls}>
+        <input
+          type="search"
+          className={styles.paletteFilter}
+          placeholder="Search blocks"
+          aria-label="Filter blocks"
+          value={filterQuery}
+          onChange={handleFilterChange}
+        />
+      </div>
+      <div className={styles.blockPalette} role="list" data-testid="block-palette-list">
+        {groups.length === 0 ? (
+          <div className={styles.paletteEmptyState} role="status">
+            No blocks match{hasFilter ? ` “${trimmedFilter}”` : ''}.
           </div>
-        );
-      })}
+        ) : (
+          groups.map((group) => (
+            <div key={group.key} className={styles.paletteGroup} role="group" aria-label={group.label}>
+              <header className={styles.paletteGroupHeader}>{group.label}</header>
+              {group.blocks.map((definition) => {
+                const paletteItemClasses = [styles.paletteItem];
+                switch (definition.category) {
+                  case 'action':
+                    paletteItemClasses.push(styles.paletteItemAction);
+                    break;
+                  case 'c':
+                    paletteItemClasses.push(styles.paletteItemC);
+                    break;
+                  case 'event':
+                    paletteItemClasses.push(styles.paletteItemEvent);
+                    break;
+                  case 'value':
+                    paletteItemClasses.push(styles.paletteItemValue);
+                    break;
+                  case 'operator':
+                    paletteItemClasses.push(styles.paletteItemOperator);
+                    break;
+                  default:
+                    paletteItemClasses.push(styles.paletteItemAction);
+                    break;
+                }
+                if (definition.summary && activeSummaryId === definition.id) {
+                  paletteItemClasses.push(styles.paletteItemActive);
+                }
+
+                const paletteItemClass = paletteItemClasses.join(' ');
+                const isSummaryActive = Boolean(definition.summary && activeSummaryId === definition.id);
+                const badgeLabel = getBadgeLabel(definition);
+
+                return (
+                  <div
+                    key={definition.id}
+                    role="listitem"
+                    className={paletteItemClass}
+                    draggable
+                    onDragStart={handleDragStart(definition)}
+                    onTouchStart={handleTouchStart(definition)}
+                    onTouchMove={handleTouchMove}
+                    onTouchEnd={handleTouchEnd}
+                    onTouchCancel={handleTouchCancel}
+                    onClick={handlePaletteItemClick(definition.id)}
+                    onFocus={handlePaletteItemClick(definition.id)}
+                    onMouseLeave={handlePaletteItemMouseLeave(definition.id)}
+                    onBlur={handlePaletteItemBlur(definition.id)}
+                    tabIndex={0}
+                    data-testid={`palette-${definition.id}`}
+                  >
+                    <div className={styles.paletteHeaderRow}>
+                      <span className={styles.paletteLabel}>{definition.label}</span>
+                      {badgeLabel ? <span className={styles.paletteBadge}>{badgeLabel}</span> : null}
+                    </div>
+                    {definition.summary ? (
+                      <small
+                        className={`${styles.paletteSummary} ${
+                          isSummaryActive ? styles.paletteSummaryVisible : ''
+                        }`}
+                        aria-hidden={isSummaryActive ? false : true}
+                      >
+                        {definition.summary}
+                      </small>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/BlockView.tsx
+++ b/src/components/BlockView.tsx
@@ -68,6 +68,12 @@ const BlockView = ({ block, path, onDrop, onTouchDrop, onUpdateBlock, telemetry 
     case 'event':
       blockClassNames.push(styles.blockEvent);
       break;
+    case 'value':
+      blockClassNames.push(styles.blockValue);
+      break;
+    case 'operator':
+      blockClassNames.push(styles.blockOperator);
+      break;
     default:
       blockClassNames.push(styles.blockAction);
       break;

--- a/src/components/__tests__/BlockPaletteInteractions.test.tsx
+++ b/src/components/__tests__/BlockPaletteInteractions.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BlockPalette from '../BlockPalette';
+import BlockView from '../BlockView';
+import { BLOCK_LIBRARY, createBlockInstance } from '../../blocks/library';
+
+const createMockDataTransfer = (): DataTransfer => {
+  const store = new Map<string, string>();
+
+  return {
+    dropEffect: 'copy',
+    effectAllowed: 'all',
+    setData: vi.fn((type: string, value: string) => {
+      store.set(type, value);
+    }),
+    getData: vi.fn((type: string) => store.get(type) ?? ''),
+    clearData: vi.fn(() => {
+      store.clear();
+    }),
+    setDragImage: vi.fn(),
+    get files() {
+      return [] as unknown as FileList;
+    },
+    get items() {
+      return [] as unknown as DataTransferItemList;
+    },
+    get types() {
+      return Array.from(store.keys());
+    },
+  } as DataTransfer;
+};
+
+describe('BlockPalette value and operator blocks', () => {
+  it('renders grouped value and operator sections with badges', () => {
+    render(<BlockPalette blocks={BLOCK_LIBRARY} />);
+
+    expect(screen.getByText('Values & Signals')).toBeInTheDocument();
+    expect(screen.getByText('Operators')).toBeInTheDocument();
+
+    const numberLiteral = screen.getByTestId('palette-literal-number');
+    expect(within(numberLiteral).getByText('Number Literal')).toBeInTheDocument();
+    expect(within(numberLiteral).getByText('Value')).toBeInTheDocument();
+
+    const operatorBlock = screen.getByTestId('palette-operator-greater-than');
+    expect(within(operatorBlock).getByText('Operator')).toBeInTheDocument();
+  });
+
+  it('supports dragging value blocks into boolean parameter drop zones', () => {
+    const handleDrop = vi.fn();
+    const conditional = createBlockInstance('if');
+    if (conditional.expressionInputs) {
+      conditional.expressionInputs.condition = [];
+    }
+
+    render(
+      <div>
+        <BlockPalette blocks={BLOCK_LIBRARY} />
+        <BlockView block={conditional} path={[]} onDrop={handleDrop} />
+      </div>,
+    );
+
+    const [literalBoolean] = screen.getAllByTestId('palette-literal-boolean');
+    const dropZone = screen.getByTestId('block-if-parameter-condition-expression-dropzone');
+
+    const dataTransfer = createMockDataTransfer();
+
+    fireEvent.dragStart(literalBoolean, { dataTransfer });
+
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      'application/json',
+      expect.stringContaining('"blockType":"literal-boolean"'),
+    );
+
+    fireEvent.drop(dropZone, { dataTransfer });
+
+    expect(handleDrop).toHaveBeenCalledTimes(1);
+    const [, target] = handleDrop.mock.calls[0];
+    expect(target).toMatchObject({ kind: 'parameter-expression', parameterName: 'condition' });
+  });
+
+  it('filters palette items using the search input', () => {
+    render(<BlockPalette blocks={BLOCK_LIBRARY} />);
+
+    const filters = screen.getAllByLabelText('Filter blocks');
+    filters.forEach((input) => {
+      fireEvent.change(input, { target: { value: 'operator' } });
+    });
+
+    const paletteLists = screen.getAllByTestId('block-palette-list');
+    paletteLists.forEach((list) => {
+      expect(within(list).queryByTestId('palette-move')).toBeNull();
+    });
+    expect(within(paletteLists[0]).getAllByTestId(/^palette-operator-/i)).not.toHaveLength(0);
+  });
+});

--- a/src/state/__tests__/blockUtils.test.ts
+++ b/src/state/__tests__/blockUtils.test.ts
@@ -114,6 +114,8 @@ describe('blockUtils', () => {
 
     const conditional = createBlockInstance('if');
     expect(conditional.parameters?.condition).toEqual({ kind: 'boolean', value: true });
-    expect(conditional.expressionInputs?.condition).toEqual([]);
+    const conditionInputs = conditional.expressionInputs?.condition ?? [];
+    expect(conditionInputs).toHaveLength(1);
+    expect(conditionInputs[0]?.type).toBe('literal-boolean');
   });
 });

--- a/src/styles/BlockPalette.module.css
+++ b/src/styles/BlockPalette.module.css
@@ -1,3 +1,40 @@
+.paletteWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  height: 100%;
+}
+
+.paletteControls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.paletteFilter {
+  flex: 1 1 auto;
+  max-width: 20rem;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-panel-outline);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.paletteFilter:focus,
+.paletteFilter:focus-visible {
+  outline: none;
+  border-color: var(--color-accent-cyan);
+  box-shadow: 0 0 0 1px rgba(100, 249, 255, 0.35);
+}
+
+.paletteFilter::placeholder {
+  color: var(--color-text-muted);
+}
+
 .blockPalette {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
@@ -13,6 +50,19 @@
   scrollbar-gutter: stable;
   -webkit-overflow-scrolling: touch;
   align-content: start;
+}
+
+.paletteGroup {
+  display: contents;
+}
+
+.paletteGroupHeader {
+  grid-column: 1 / -1;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: var(--space-1) 0 var(--space-2);
 }
 
 .paletteItem {
@@ -62,9 +112,39 @@
   box-shadow: 0 16px 36px rgba(255, 179, 71, 0.22);
 }
 
+.paletteItemValue {
+  background: var(--color-block-value-surface);
+  border-color: var(--color-block-value-border);
+  box-shadow: 0 16px 36px rgba(63, 123, 255, 0.18);
+}
+
+.paletteItemOperator {
+  background: var(--color-block-operator-surface);
+  border-color: var(--color-block-operator-border);
+  box-shadow: 0 16px 36px rgba(255, 108, 249, 0.22);
+}
+
+.paletteHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
 .paletteLabel {
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-md);
+}
+
+.paletteBadge {
+  background: rgba(100, 249, 255, 0.2);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .paletteSummary {
@@ -92,11 +172,32 @@
   box-shadow: 0 18px 42px rgba(100, 249, 255, 0.2);
 }
 
+.paletteEmptyState {
+  grid-column: 1 / -1;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-panel-outline);
+  background: var(--color-surface-overlay);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
 @media (max-width: 720px) {
   .blockPalette {
     grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
     gap: var(--space-2);
     padding-right: 0;
+  }
+
+  .paletteControls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2);
+  }
+
+  .paletteFilter {
+    max-width: 100%;
+    width: 100%;
   }
 
   .paletteItem {
@@ -118,6 +219,10 @@
   .blockPalette {
     grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     gap: var(--space-1);
+  }
+
+  .paletteWrapper {
+    gap: var(--space-2);
   }
 
   .paletteItem {

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -25,6 +25,14 @@
   border-left-color: var(--color-accent-amber);
 }
 
+.blockValue {
+  border-left-color: var(--color-block-value-border);
+}
+
+.blockOperator {
+  border-left-color: var(--color-block-operator-border);
+}
+
 .blockHeader {
   display: flex;
   justify-content: space-between;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -105,6 +105,10 @@
   --color-block-control-border: rgba(155, 107, 255, 0.4);
   --color-block-event-surface: rgba(255, 179, 71, 0.18);
   --color-block-event-border: rgba(255, 179, 71, 0.4);
+  --color-block-value-surface: rgba(63, 123, 255, 0.18);
+  --color-block-value-border: rgba(63, 123, 255, 0.4);
+  --color-block-operator-surface: rgba(255, 108, 249, 0.18);
+  --color-block-operator-border: rgba(255, 108, 249, 0.4);
   --color-slot-surface: rgba(155, 107, 255, 0.12);
   --color-slot-border: rgba(155, 107, 255, 0.4);
   --color-slot-text: rgba(202, 177, 255, 0.85);

--- a/src/types/blocks.ts
+++ b/src/types/blocks.ts
@@ -34,6 +34,9 @@ export interface BlockDefinition {
   slots?: string[];
   parameters?: Record<string, BlockParameterDefinition>;
   expressionInputs?: string[];
+  expressionInputDefaults?: Record<string, string[]>;
+  paletteGroup?: string;
+  paletteTags?: string[];
 }
 
 export interface BlockInstance {


### PR DESCRIPTION
## Summary
- add literal, signal, and operator block definitions with sensible defaults
- group the block palette with search, badges, and new value/operator styling
- cover palette interactions and control defaults with new tests

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29d8ba6a8832e9d2f309afd52f81f