### PR TITLE
Limit palette block width to visible content

### DIFF
--- a/src/styles/BlockPalette.module.css
+++ b/src/styles/BlockPalette.module.css
@@ -156,6 +156,7 @@
   transition: opacity var(--transition-base), max-height var(--transition-base), margin-top var(--transition-base);
   margin: 0;
   pointer-events: none;
+  inline-size: 0;
 }
 
 .paletteSummaryVisible,
@@ -165,6 +166,7 @@
   max-height: 12rem;
   margin-top: var(--space-2);
   pointer-events: auto;
+  inline-size: 100%;
 }
 
 .paletteItemActive {


### PR DESCRIPTION
## Summary
- collapse hidden block palette summaries to zero inline size so they no longer expand the block width
- ensure summaries expand to the available width only when revealed

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2ad634aa4832e852e42fd8ff4d90c