### PR TITLE
Support expression-driven block programs

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -112,6 +112,9 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
       count: { kind: 'number', defaultValue: 3 },
     },
     expressionInputs: ['count'],
+    expressionInputDefaults: {
+      count: ['literal-number'],
+    },
     paletteGroup: 'Control',
     paletteTags: ['loop'],
   },
@@ -324,7 +327,36 @@ export function createBlockInstance(blockType: string): BlockInstance {
           continue;
         }
 
-        target.push(createBlockInstance(blockType));
+        const expressionBlock = createBlockInstance(blockType);
+        target.push(expressionBlock);
+
+        const parentParameter = instance.parameters?.[inputName];
+        const expressionParameters = expressionBlock.parameters;
+        const expressionValue = expressionParameters?.value;
+
+        if (parentParameter && expressionParameters && expressionValue) {
+          switch (parentParameter.kind) {
+            case 'number':
+              if (expressionValue.kind === 'number') {
+                expressionParameters.value = {
+                  kind: 'number',
+                  value: parentParameter.value,
+                };
+              }
+              break;
+            case 'boolean':
+              if (expressionValue.kind === 'boolean') {
+                expressionParameters.value = {
+                  kind: 'boolean',
+                  value: parentParameter.value,
+                };
+              }
+              break;
+            case 'string':
+            case 'signal':
+              break;
+          }
+        }
       }
     }
   }

--- a/src/simulation/ecs/systems/__tests__/systems.test.ts
+++ b/src/simulation/ecs/systems/__tests__/systems.test.ts
@@ -32,6 +32,7 @@ import {
   BlockProgramRunner,
   type ProgramDebugState,
 } from '../../../runtime/blockProgramRunner';
+import { createNumberLiteralBinding } from '../../../runtime/blockProgram';
 import { RobotChassis } from '../../../robot';
 import { STATUS_MODULE_ID } from '../../../robot/modules/statusModule';
 import type {
@@ -339,14 +340,31 @@ describe('simulation systems', () => {
     const viewport = { scale: { x: 2, y: 0.5 } } as unknown as Viewport;
 
     const programInstructions: BlockInstruction[] = [
-      { kind: 'wait', duration: 1 } as BlockInstruction,
-      { kind: 'loop', instructions: [{ kind: 'gather', duration: 2, target: 'auto' } as BlockInstruction] } as BlockInstruction,
+      {
+        kind: 'wait',
+        duration: createNumberLiteralBinding(1, { label: 'Debug → wait' }),
+      },
+      {
+        kind: 'loop',
+        mode: 'forever',
+        instructions: [
+          {
+            kind: 'gather',
+            duration: createNumberLiteralBinding(2, { label: 'Debug → gather' }),
+            target: 'auto',
+          },
+        ],
+      },
     ];
 
     let debugState: ProgramDebugState | null = {
       status: 'running',
       program: { instructions: programInstructions } as CompiledProgram,
-      currentInstruction: { kind: 'move', speed: 3, duration: 2 } as BlockInstruction,
+      currentInstruction: {
+        kind: 'move',
+        duration: createNumberLiteralBinding(2, { label: 'Debug → move duration' }),
+        speed: createNumberLiteralBinding(3, { label: 'Debug → move speed' }),
+      },
       timeRemaining: 1.25,
       frames: [{ kind: 'sequence', index: 0, length: 2 }],
     } satisfies ProgramDebugState;

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -1,4 +1,10 @@
-import type { BlockInstance, WorkspaceState } from '../../types/blocks';
+import { BLOCK_MAP } from '../../blocks/library';
+import type {
+  BlockInstance,
+  BlockParameterDefinition,
+  BlockParameterSignalOption,
+  WorkspaceState,
+} from '../../types/blocks';
 
 export type DiagnosticSeverity = 'info' | 'warning' | 'error';
 
@@ -7,16 +13,130 @@ export interface Diagnostic {
   message: string;
 }
 
+export type ParameterSource = 'default' | 'user';
+export type ExpressionValueType = 'number' | 'boolean';
+
+export interface NumberParameterMetadata {
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface LiteralExpression<TValue extends ExpressionValueType> {
+  kind: 'literal';
+  valueType: TValue;
+  value: TValue extends 'number' ? number : boolean;
+  source: ParameterSource;
+  metadata?: TValue extends 'number' ? NumberParameterMetadata : undefined;
+  label?: string;
+}
+
+export interface SignalDescriptor {
+  id: string;
+  label: string;
+  description?: string;
+  moduleId: string | null;
+  signalId: string | null;
+}
+
+export interface SignalExpression<TValue extends ExpressionValueType> {
+  kind: 'signal';
+  valueType: TValue;
+  signal: SignalDescriptor;
+  fallback?: LiteralExpression<TValue> | null;
+}
+
+export interface OperatorExpression<TValue extends ExpressionValueType> {
+  kind: 'operator';
+  valueType: TValue;
+  operator: 'add' | 'greater-than' | 'and';
+  inputs: ExpressionNode[];
+  label?: string;
+}
+
+export type ExpressionNode =
+  | LiteralExpression<'number'>
+  | LiteralExpression<'boolean'>
+  | SignalExpression<'number'>
+  | SignalExpression<'boolean'>
+  | OperatorExpression<'number'>
+  | OperatorExpression<'boolean'>;
+
+export type NumberExpression = Extract<ExpressionNode, { valueType: 'number' }>;
+export type BooleanExpression = Extract<ExpressionNode, { valueType: 'boolean' }>;
+
+export interface NumberParameterBinding {
+  literal: LiteralExpression<'number'> | null;
+  expression: NumberExpression | null;
+}
+
+export interface BooleanParameterBinding {
+  literal: LiteralExpression<'boolean'> | null;
+  expression: BooleanExpression | null;
+}
+
+export interface SignalParameterBinding {
+  selected: SignalDescriptor | null;
+  source: ParameterSource;
+  allowNone: boolean;
+  options: SignalDescriptor[];
+}
+
 export type BlockInstruction =
-  | { kind: 'move'; duration: number; speed: number }
-  | { kind: 'turn'; duration: number; angularVelocity: number }
-  | { kind: 'wait'; duration: number }
-  | { kind: 'scan'; duration: number; filter: string | null }
-  | { kind: 'gather'; duration: number; target: 'auto' }
-  | { kind: 'deposit'; duration: number }
-  | { kind: 'status-toggle'; duration: number }
-  | { kind: 'status-set'; duration: number; value: boolean }
-  | { kind: 'loop'; instructions: BlockInstruction[] };
+  | {
+      kind: 'move';
+      duration: NumberParameterBinding;
+      speed: NumberParameterBinding;
+    }
+  | {
+      kind: 'turn';
+      duration: NumberParameterBinding;
+      angularVelocity: NumberParameterBinding;
+    }
+  | {
+      kind: 'wait';
+      duration: NumberParameterBinding;
+    }
+  | {
+      kind: 'scan';
+      duration: NumberParameterBinding;
+      filter: string | null;
+    }
+  | {
+      kind: 'gather';
+      duration: NumberParameterBinding;
+      target: 'auto';
+    }
+  | {
+      kind: 'deposit';
+      duration: NumberParameterBinding;
+    }
+  | {
+      kind: 'status-toggle';
+      duration: NumberParameterBinding;
+    }
+  | {
+      kind: 'status-set';
+      duration: NumberParameterBinding;
+      value: BooleanParameterBinding;
+    }
+  | {
+      kind: 'loop';
+      mode: 'forever';
+      instructions: BlockInstruction[];
+    }
+  | {
+      kind: 'loop';
+      mode: 'counted';
+      instructions: BlockInstruction[];
+      iterations: NumberParameterBinding;
+    }
+  | {
+      kind: 'branch';
+      condition: BooleanParameterBinding;
+      whenTrue: BlockInstruction[];
+      whenFalse: BlockInstruction[];
+    };
 
 export interface CompiledProgram {
   instructions: BlockInstruction[];
@@ -32,21 +152,620 @@ const TURN_RATE = Math.PI / 2;
 const WAIT_DURATION = 1;
 const SCAN_DURATION = 1;
 const GATHER_DURATION = 1.5;
-const DEFAULT_REPEAT_COUNT = 3;
 
 interface CompilationContext {
-  repeatInfoIssued: boolean;
-  conditionalInfoIssued: boolean;
-  conditionalElseWarned: boolean;
   unsupportedBlocks: Set<string>;
 }
 
 const createContext = (): CompilationContext => ({
-  repeatInfoIssued: false,
-  conditionalInfoIssued: false,
-  conditionalElseWarned: false,
   unsupportedBlocks: new Set<string>(),
 });
+
+export function createNumberLiteralExpression(
+  value: number,
+  { source = 'default', metadata, label }: { source?: ParameterSource; metadata?: NumberParameterMetadata; label?: string } = {},
+): LiteralExpression<'number'> {
+  return {
+    kind: 'literal',
+    valueType: 'number',
+    value,
+    source,
+    metadata,
+    label,
+  } satisfies LiteralExpression<'number'>;
+}
+
+export function createBooleanLiteralExpression(
+  value: boolean,
+  { source = 'default', label }: { source?: ParameterSource; label?: string } = {},
+): LiteralExpression<'boolean'> {
+  return {
+    kind: 'literal',
+    valueType: 'boolean',
+    value,
+    source,
+    label,
+  } satisfies LiteralExpression<'boolean'>;
+}
+
+export function createNumberLiteralBinding(
+  value: number,
+  options: { source?: ParameterSource; metadata?: NumberParameterMetadata; label?: string } = {},
+): NumberParameterBinding {
+  const literal = createNumberLiteralExpression(value, options);
+  return { literal, expression: literal } satisfies NumberParameterBinding;
+}
+
+export function createBooleanLiteralBinding(
+  value: boolean,
+  options: { source?: ParameterSource; label?: string } = {},
+): BooleanParameterBinding {
+  const literal = createBooleanLiteralExpression(value, options);
+  return { literal, expression: literal } satisfies BooleanParameterBinding;
+}
+
+const describeValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value ? `"${value}"` : '""';
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value.toString() : String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'undefined') {
+    return 'undefined';
+  }
+  if (Array.isArray(value)) {
+    return 'list';
+  }
+  return typeof value;
+};
+
+const formatParameterLabel = (blockLabel: string, parameterName: string): string => `${blockLabel} → ${parameterName}`;
+
+const getBlockLabel = (blockType: string): string => BLOCK_MAP[blockType]?.label ?? blockType;
+
+const getParameterDefinition = (
+  blockType: string,
+  parameterName: string,
+): BlockParameterDefinition | undefined => BLOCK_MAP[blockType]?.parameters?.[parameterName];
+
+const parseSignalIdentifier = (id: string | null): { moduleId: string | null; signalId: string | null } => {
+  if (!id) {
+    return { moduleId: null, signalId: null };
+  }
+  const lastDot = id.lastIndexOf('.');
+  if (lastDot <= 0 || lastDot >= id.length - 1) {
+    return { moduleId: null, signalId: id };
+  }
+  const moduleId = id.slice(0, lastDot);
+  const signalId = id.slice(lastDot + 1);
+  return { moduleId, signalId };
+};
+
+const mapSignalOption = (option: BlockParameterSignalOption): SignalDescriptor => {
+  const { moduleId, signalId } = parseSignalIdentifier(option.id);
+  return {
+    id: option.id,
+    label: option.label,
+    description: option.description,
+    moduleId,
+    signalId,
+  } satisfies SignalDescriptor;
+};
+
+interface NumberBindingOptions {
+  label: string;
+  fallback?: number;
+  minimum?: number;
+  maximum?: number;
+  enforceInteger?: boolean;
+}
+
+interface BooleanBindingOptions {
+  label: string;
+  fallback?: boolean;
+}
+
+const clampNumber = (value: number, min?: number, max?: number): number => {
+  let result = value;
+  if (typeof min === 'number' && Number.isFinite(min)) {
+    result = Math.max(result, min);
+  }
+  if (typeof max === 'number' && Number.isFinite(max)) {
+    result = Math.min(result, max);
+  }
+  return result;
+};
+
+const resolveNumberBinding = (
+  block: BlockInstance,
+  parameterName: string,
+  diagnostics: Diagnostic[],
+  options: NumberBindingOptions,
+): NumberParameterBinding => {
+  const blockLabel = getBlockLabel(block.type);
+  const label = formatParameterLabel(blockLabel, parameterName);
+  const definition = getParameterDefinition(block.type, parameterName);
+
+  const metadata: NumberParameterMetadata = {};
+  if (definition?.kind === 'number') {
+    if (typeof definition.min === 'number') {
+      metadata.min = definition.min;
+    }
+    if (typeof definition.max === 'number') {
+      metadata.max = definition.max;
+    }
+    if (typeof definition.step === 'number') {
+      metadata.step = definition.step;
+    }
+  }
+
+  const fallback =
+    typeof options.fallback === 'number'
+      ? options.fallback
+      : definition?.kind === 'number'
+        ? definition.defaultValue
+        : 0;
+
+  let value = fallback;
+  let source: ParameterSource = 'default';
+
+  const parameter = block.parameters?.[parameterName];
+  if (parameter) {
+    if (parameter.kind === 'number' && Number.isFinite(parameter.value)) {
+      value = parameter.value;
+      const differsFromDefault = Math.abs(value - fallback) > 1e-6;
+      source = differsFromDefault ? 'user' : 'default';
+    } else {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${label} received ${describeValue((parameter as { value?: unknown })?.value)}; defaulting to ${fallback}.`,
+      });
+    }
+  }
+
+  if (typeof options.minimum === 'number' && value < options.minimum) {
+    diagnostics.push({
+      severity: 'warning',
+      message: `${label} must be at least ${options.minimum}; clamping ${value} to ${options.minimum}.`,
+    });
+    value = options.minimum;
+    source = 'user';
+  }
+
+  if (typeof options.maximum === 'number' && value > options.maximum) {
+    diagnostics.push({
+      severity: 'warning',
+      message: `${label} must be at most ${options.maximum}; clamping ${value} to ${options.maximum}.`,
+    });
+    value = options.maximum;
+    source = 'user';
+  }
+
+  value = clampNumber(value, metadata.min, metadata.max);
+
+  if (options.enforceInteger) {
+    const integerValue = value >= 0 ? Math.floor(value) : Math.ceil(value);
+    if (integerValue !== value) {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${label} must be a whole number; rounding ${value} to ${integerValue}.`,
+      });
+      value = integerValue;
+      source = 'user';
+    }
+  }
+
+  const literal = createNumberLiteralExpression(value, { source, metadata, label });
+
+  const expression = compileNumberExpressionInput(block, parameterName, diagnostics, {
+    label,
+    fallback: literal,
+  });
+
+  return { literal, expression } satisfies NumberParameterBinding;
+};
+
+const resolveBooleanBinding = (
+  block: BlockInstance,
+  parameterName: string,
+  diagnostics: Diagnostic[],
+  options: BooleanBindingOptions,
+): BooleanParameterBinding => {
+  const blockLabel = getBlockLabel(block.type);
+  const label = formatParameterLabel(blockLabel, parameterName);
+  const definition = getParameterDefinition(block.type, parameterName);
+
+  const fallback =
+    typeof options.fallback === 'boolean'
+      ? options.fallback
+      : definition?.kind === 'boolean'
+        ? definition.defaultValue
+        : false;
+
+  let value = fallback;
+  let source: ParameterSource = 'default';
+
+  const parameter = block.parameters?.[parameterName];
+  if (parameter) {
+    if (parameter.kind === 'boolean') {
+      value = parameter.value;
+      source = parameter.value === fallback ? 'default' : 'user';
+    } else {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${label} received ${describeValue((parameter as { value?: unknown })?.value)}; defaulting to ${fallback}.`,
+      });
+    }
+  }
+
+  const literal = createBooleanLiteralExpression(value, { source, label });
+
+  const expression = compileBooleanExpressionInput(block, parameterName, diagnostics, {
+    label,
+    fallback: literal,
+  });
+
+  return { literal, expression } satisfies BooleanParameterBinding;
+};
+
+interface NumberExpressionOptions {
+  label: string;
+  fallback?: LiteralExpression<'number'> | null;
+}
+
+interface BooleanExpressionOptions {
+  label: string;
+  fallback?: LiteralExpression<'boolean'> | null;
+}
+
+const compileNumberExpressionInput = (
+  block: BlockInstance,
+  inputName: string,
+  diagnostics: Diagnostic[],
+  options: NumberExpressionOptions,
+): NumberExpression | null => {
+  const expressionBlocks = block.expressionInputs?.[inputName];
+  if (!expressionBlocks || expressionBlocks.length === 0) {
+    if (options.fallback) {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${options.label} is missing a value; defaulting to ${options.fallback.value}.`,
+      });
+    }
+    return null;
+  }
+  const [root] = expressionBlocks;
+  return compileNumberExpression(root, diagnostics, options);
+};
+
+const compileBooleanExpressionInput = (
+  block: BlockInstance,
+  inputName: string,
+  diagnostics: Diagnostic[],
+  options: BooleanExpressionOptions,
+): BooleanExpression | null => {
+  const expressionBlocks = block.expressionInputs?.[inputName];
+  if (!expressionBlocks || expressionBlocks.length === 0) {
+    if (options.fallback) {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${options.label} is missing a value; defaulting to ${options.fallback.value ? 'true' : 'false'}.`,
+      });
+    }
+    return null;
+  }
+  const [root] = expressionBlocks;
+  return compileBooleanExpression(root, diagnostics, options);
+};
+
+const compileNumberExpression = (
+  block: BlockInstance,
+  diagnostics: Diagnostic[],
+  options: NumberExpressionOptions,
+): NumberExpression | null => {
+  const label = getBlockLabel(block.type);
+  switch (block.type) {
+    case 'literal-number': {
+      const literalDefinition = getParameterDefinition(block.type, 'value');
+      const metadata: NumberParameterMetadata = {};
+      if (literalDefinition?.kind === 'number') {
+        if (typeof literalDefinition.min === 'number') {
+          metadata.min = literalDefinition.min;
+        }
+        if (typeof literalDefinition.max === 'number') {
+          metadata.max = literalDefinition.max;
+        }
+        if (typeof literalDefinition.step === 'number') {
+          metadata.step = literalDefinition.step;
+        }
+      }
+      const parameter = block.parameters?.value;
+      const fallback = literalDefinition?.kind === 'number' ? literalDefinition.defaultValue : 0;
+      let value = fallback;
+      let source: ParameterSource = 'default';
+      if (parameter) {
+        if (parameter.kind === 'number' && Number.isFinite(parameter.value)) {
+          value = parameter.value;
+          source = Math.abs(parameter.value - fallback) > 1e-6 ? 'user' : 'default';
+        } else {
+          diagnostics.push({
+            severity: 'warning',
+            message: `${label} literal received ${describeValue((parameter as { value?: unknown })?.value)}; defaulting to ${fallback}.`,
+          });
+        }
+      }
+      return createNumberLiteralExpression(value, { source, metadata, label });
+    }
+    case 'read-signal': {
+      const selection = resolveSignalSelection(block, 'signal', diagnostics, label);
+      if (!selection.selected) {
+        if (options.fallback) {
+          diagnostics.push({
+            severity: 'warning',
+            message: `${options.label} has no signal selected; defaulting to ${options.fallback.value}.`,
+          });
+        }
+        return options.fallback ?? createNumberLiteralExpression(0, { label: options.label });
+      }
+      return {
+        kind: 'signal',
+        valueType: 'number',
+        signal: selection.selected,
+        fallback: options.fallback ?? null,
+      } satisfies SignalExpression<'number'>;
+    }
+    case 'operator-add': {
+      const first = block.expressionInputs?.firstValue?.[0];
+      const second = block.expressionInputs?.secondValue?.[0];
+      const firstExpression = first
+        ? compileNumberExpression(first, diagnostics, {
+            label: `${label} → first value`,
+            fallback: options.fallback,
+          })
+        : null;
+      const secondExpression = second
+        ? compileNumberExpression(second, diagnostics, {
+            label: `${label} → second value`,
+            fallback: options.fallback,
+          })
+        : null;
+
+      const inputs: NumberExpression[] = [];
+      if (firstExpression) {
+        inputs.push(firstExpression);
+      }
+      if (secondExpression) {
+        inputs.push(secondExpression);
+      }
+      if (inputs.length !== 2) {
+        diagnostics.push({
+          severity: 'warning',
+          message: `${label} is missing inputs; defaulting to ${options.fallback?.value ?? 0}.`,
+        });
+      }
+      const safeInputs = inputs.length === 2 ? inputs : [
+        firstExpression ?? options.fallback ?? createNumberLiteralExpression(0, { label: options.label }),
+        secondExpression ?? options.fallback ?? createNumberLiteralExpression(0, { label: options.label }),
+      ];
+      return {
+        kind: 'operator',
+        valueType: 'number',
+        operator: 'add',
+        inputs: safeInputs,
+        label,
+      } satisfies OperatorExpression<'number'>;
+    }
+    default: {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${options.label} cannot use the ${label} block; defaulting to ${options.fallback?.value ?? 0}.`,
+      });
+      return options.fallback ?? createNumberLiteralExpression(0, { label: options.label });
+    }
+  }
+};
+
+const compileBooleanExpression = (
+  block: BlockInstance,
+  diagnostics: Diagnostic[],
+  options: BooleanExpressionOptions,
+): BooleanExpression | null => {
+  const label = getBlockLabel(block.type);
+  switch (block.type) {
+    case 'literal-boolean': {
+      const definition = getParameterDefinition(block.type, 'value');
+      const fallback = definition?.kind === 'boolean' ? definition.defaultValue : false;
+      const parameter = block.parameters?.value;
+      let value = fallback;
+      let source: ParameterSource = 'default';
+      if (parameter) {
+        if (parameter.kind === 'boolean') {
+          value = parameter.value;
+          source = parameter.value === fallback ? 'default' : 'user';
+        } else {
+          diagnostics.push({
+            severity: 'warning',
+            message: `${label} literal received ${describeValue((parameter as { value?: unknown })?.value)}; defaulting to ${fallback}.`,
+          });
+        }
+      }
+      return createBooleanLiteralExpression(value, { source, label });
+    }
+    case 'read-signal': {
+      const selection = resolveSignalSelection(block, 'signal', diagnostics, label);
+      if (!selection.selected) {
+        if (options.fallback) {
+          diagnostics.push({
+            severity: 'warning',
+            message: `${options.label} has no signal selected; defaulting to ${options.fallback.value ? 'true' : 'false'}.`,
+          });
+        }
+        return options.fallback ?? createBooleanLiteralExpression(false, { label: options.label });
+      }
+      return {
+        kind: 'signal',
+        valueType: 'boolean',
+        signal: selection.selected,
+        fallback: options.fallback ?? null,
+      } satisfies SignalExpression<'boolean'>;
+    }
+    case 'operator-and': {
+      const first = block.expressionInputs?.firstValue?.[0];
+      const second = block.expressionInputs?.secondValue?.[0];
+      const firstExpression = first
+        ? compileBooleanExpression(first, diagnostics, {
+            label: `${label} → first value`,
+            fallback: options.fallback,
+          })
+        : null;
+      const secondExpression = second
+        ? compileBooleanExpression(second, diagnostics, {
+            label: `${label} → second value`,
+            fallback: options.fallback,
+          })
+        : null;
+
+      const inputs: BooleanExpression[] = [];
+      if (firstExpression) {
+        inputs.push(firstExpression);
+      }
+      if (secondExpression) {
+        inputs.push(secondExpression);
+      }
+      if (inputs.length !== 2) {
+        diagnostics.push({
+          severity: 'warning',
+          message: `${label} is missing inputs; defaulting to ${options.fallback?.value ? 'true' : 'false'}.`,
+        });
+      }
+      const safeInputs = inputs.length === 2 ? inputs : [
+        firstExpression ?? options.fallback ?? createBooleanLiteralExpression(false, { label: options.label }),
+        secondExpression ?? options.fallback ?? createBooleanLiteralExpression(false, { label: options.label }),
+      ];
+      return {
+        kind: 'operator',
+        valueType: 'boolean',
+        operator: 'and',
+        inputs: safeInputs,
+        label,
+      } satisfies OperatorExpression<'boolean'>;
+    }
+    case 'operator-greater-than': {
+      const first = block.expressionInputs?.firstValue?.[0];
+      const second = block.expressionInputs?.secondValue?.[0];
+      const firstExpression = first
+        ? compileNumberExpression(first, diagnostics, {
+            label: `${label} → first value`,
+            fallback: options.fallback ? createNumberLiteralExpression(options.fallback.value ? 1 : 0, { label: options.label }) : undefined,
+          })
+        : null;
+      const secondExpression = second
+        ? compileNumberExpression(second, diagnostics, {
+            label: `${label} → second value`,
+            fallback: options.fallback ? createNumberLiteralExpression(options.fallback.value ? 1 : 0, { label: options.label }) : undefined,
+          })
+        : null;
+
+      const inputs: NumberExpression[] = [];
+      if (firstExpression) {
+        inputs.push(firstExpression);
+      }
+      if (secondExpression) {
+        inputs.push(secondExpression);
+      }
+      if (inputs.length !== 2) {
+        diagnostics.push({
+          severity: 'warning',
+          message: `${label} is missing inputs; defaulting to ${options.fallback?.value ? 'true' : 'false'}.`,
+        });
+      }
+      const safeInputs = inputs.length === 2 ? inputs : [
+        firstExpression ?? createNumberLiteralExpression(0, { label: options.label }),
+        secondExpression ?? createNumberLiteralExpression(0, { label: options.label }),
+      ];
+      return {
+        kind: 'operator',
+        valueType: 'boolean',
+        operator: 'greater-than',
+        inputs: safeInputs,
+        label,
+      } satisfies OperatorExpression<'boolean'>;
+    }
+    default: {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${options.label} cannot use the ${label} block; defaulting to ${options.fallback?.value ? 'true' : 'false'}.`,
+      });
+      return options.fallback ?? createBooleanLiteralExpression(false, { label: options.label });
+    }
+  }
+};
+
+const resolveSignalSelection = (
+  block: BlockInstance,
+  parameterName: string,
+  diagnostics: Diagnostic[],
+  contextLabel: string,
+): SignalParameterBinding => {
+  const definition = getParameterDefinition(block.type, parameterName);
+  if (!definition || definition.kind !== 'signal') {
+    return {
+      selected: null,
+      source: 'default',
+      allowNone: true,
+      options: [],
+    } satisfies SignalParameterBinding;
+  }
+
+  const options = definition.options.map(mapSignalOption);
+  const allowNone = definition.allowNone !== false;
+
+  const parameter = block.parameters?.[parameterName];
+  const rawValue = parameter && parameter.kind === 'signal' ? parameter.value : null;
+
+  const defaultOptionId = definition.defaultValue ?? null;
+  const defaultOption = options.find((option) => option.id === defaultOptionId) ?? null;
+
+  let selected: SignalDescriptor | null = null;
+  let source: ParameterSource = 'default';
+
+  if (rawValue) {
+    const candidate = options.find((option) => option.id === rawValue) ?? null;
+    if (candidate) {
+      selected = candidate;
+      source = candidate.id === defaultOption?.id ? 'default' : 'user';
+    } else {
+      diagnostics.push({
+        severity: 'warning',
+        message: `${contextLabel} references unknown signal ${describeValue(rawValue)}; defaulting to ${defaultOption?.label ?? 'none'}.`,
+      });
+    }
+  } else if (!allowNone && defaultOption) {
+    selected = defaultOption;
+  }
+
+  if (!selected && !allowNone && defaultOption) {
+    diagnostics.push({
+      severity: 'warning',
+      message: `${contextLabel} must select a signal; defaulting to ${defaultOption.label}.`,
+    });
+    selected = defaultOption;
+  }
+
+  return {
+    selected,
+    source,
+    allowNone,
+    options,
+  } satisfies SignalParameterBinding;
+};
 
 const compileSequence = (
   blocks: BlockInstance[] | undefined,
@@ -71,47 +790,94 @@ const compileBlock = (
 ): BlockInstruction[] => {
   switch (block.type) {
     case 'move':
-      return [{ kind: 'move', duration: 1, speed: MOVE_SPEED }];
+      return [
+        {
+          kind: 'move',
+          duration: createNumberLiteralBinding(1, { label: 'Move → duration' }),
+          speed: createNumberLiteralBinding(MOVE_SPEED, { label: 'Move → speed' }),
+        },
+      ];
     case 'turn':
-      return [{ kind: 'turn', duration: 1, angularVelocity: TURN_RATE }];
+      return [
+        {
+          kind: 'turn',
+          duration: createNumberLiteralBinding(1, { label: 'Turn → duration' }),
+          angularVelocity: createNumberLiteralBinding(TURN_RATE, { label: 'Turn → rate' }),
+        },
+      ];
     case 'wait':
-      return [{ kind: 'wait', duration: WAIT_DURATION }];
+      return [
+        {
+          kind: 'wait',
+          duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Wait → duration' }),
+        },
+      ];
     case 'scan-resources':
-      return [{ kind: 'scan', duration: SCAN_DURATION, filter: null }];
-    case 'toggle-status':
-      return [{ kind: 'status-toggle', duration: 0 }];
-    case 'set-status': {
-      const parameter = block.parameters?.value;
-      const value = parameter?.kind === 'boolean' ? parameter.value : true;
-      return [{ kind: 'status-set', duration: 0, value }];
-    }
+      return [
+        {
+          kind: 'scan',
+          duration: createNumberLiteralBinding(SCAN_DURATION, { label: 'Scan → duration' }),
+          filter: null,
+        },
+      ];
     case 'gather-resource':
-      return [{ kind: 'gather', duration: GATHER_DURATION, target: 'auto' }];
-    case 'return-home':
-      return [{ kind: 'move', duration: 1, speed: MOVE_SPEED }];
+      return [
+        {
+          kind: 'gather',
+          duration: createNumberLiteralBinding(GATHER_DURATION, { label: 'Gather → duration' }),
+          target: 'auto',
+        },
+      ];
     case 'deposit-cargo':
-      return [{ kind: 'deposit', duration: WAIT_DURATION }];
+      return [
+        {
+          kind: 'deposit',
+          duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Deposit → duration' }),
+        },
+      ];
+    case 'toggle-status':
+      return [
+        {
+          kind: 'status-toggle',
+          duration: createNumberLiteralBinding(0, { label: 'Toggle Status → duration' }),
+        },
+      ];
+    case 'set-status': {
+      const valueBinding = resolveBooleanBinding(block, 'value', diagnostics, {
+        label: formatParameterLabel(getBlockLabel('set-status'), 'value'),
+        fallback: true,
+      });
+      return [
+        {
+          kind: 'status-set',
+          duration: createNumberLiteralBinding(0, { label: 'Set Status → duration' }),
+          value: valueBinding,
+        },
+      ];
+    }
     case 'repeat': {
       const inner = compileSequence(block.slots?.do, diagnostics, context);
       if (inner.length === 0) {
+        diagnostics.push({
+          severity: 'warning',
+          message: 'Repeat block has no actions and will be ignored.',
+        });
         return [];
       }
-      if (!context.repeatInfoIssued) {
-        diagnostics.push({
-          severity: 'info',
-          message:
-            'Repeat blocks currently loop their configured number of times while parameter editing is under construction.',
-        });
-        context.repeatInfoIssued = true;
-      }
-      const countParameter = block.parameters?.count;
-      const rawCount = countParameter?.kind === 'number' ? countParameter.value : DEFAULT_REPEAT_COUNT;
-      const repeatCount = Math.max(0, Math.floor(rawCount));
-      const repetitions: BlockInstruction[] = [];
-      for (let index = 0; index < repeatCount; index += 1) {
-        repetitions.push(...inner.map((instruction) => ({ ...instruction })));
-      }
-      return repetitions;
+      const countBinding = resolveNumberBinding(block, 'count', diagnostics, {
+        label: formatParameterLabel(getBlockLabel('repeat'), 'count'),
+        fallback: 3,
+        minimum: 0,
+        enforceInteger: true,
+      });
+      return [
+        {
+          kind: 'loop',
+          mode: 'counted',
+          iterations: countBinding,
+          instructions: inner,
+        },
+      ];
     }
     case 'parallel': {
       const branchA = compileSequence(block.slots?.branchA, diagnostics, context);
@@ -122,8 +888,7 @@ const compileBlock = (
       if (!context.unsupportedBlocks.has(block.type)) {
         diagnostics.push({
           severity: 'warning',
-          message:
-            'Parallel blocks execute their branches sequentially in this MVP preview.',
+          message: 'Parallel blocks execute their branches sequentially in this build.',
         });
         context.unsupportedBlocks.add(block.type);
       }
@@ -134,35 +899,47 @@ const compileBlock = (
       if (inner.length === 0) {
         diagnostics.push({
           severity: 'warning',
-          message: 'Forever blocks need actions inside them to have an effect.',
+          message: 'Forever block has no actions and will be ignored.',
         });
         return [];
       }
-      return [{ kind: 'loop', instructions: inner }];
+      return [
+        {
+          kind: 'loop',
+          mode: 'forever',
+          instructions: inner,
+        },
+      ];
     }
     case 'if': {
       const thenInstructions = compileSequence(block.slots?.then, diagnostics, context);
       const elseInstructions = compileSequence(block.slots?.else, diagnostics, context);
 
-      if (!context.conditionalInfoIssued) {
-        diagnostics.push({
-          severity: 'info',
-          message:
-            'Conditionals are wired to always follow their THEN branch while sensor inputs are stubbed in this slice.',
-        });
-        context.conditionalInfoIssued = true;
-      }
-
-      if (elseInstructions.length > 0 && !context.conditionalElseWarned) {
+      if (thenInstructions.length === 0 && elseInstructions.length === 0) {
         diagnostics.push({
           severity: 'warning',
-          message: 'Else branches are ignored for now; add recovery steps under THEN to handle hazards.',
+          message: 'If block has no actions in either branch and will be ignored.',
         });
-        context.conditionalElseWarned = true;
+        return [];
       }
 
-      return thenInstructions;
+      const conditionBinding = resolveBooleanBinding(block, 'condition', diagnostics, {
+        label: formatParameterLabel(getBlockLabel('if'), 'condition'),
+        fallback: true,
+      });
+
+      return [
+        {
+          kind: 'branch',
+          condition: conditionBinding,
+          whenTrue: thenInstructions,
+          whenFalse: elseInstructions,
+        },
+      ];
     }
+    case 'wait-signal':
+    case 'broadcast-signal':
+    case 'move-to':
     default: {
       if (!context.unsupportedBlocks.has(block.type)) {
         diagnostics.push({
@@ -202,5 +979,5 @@ export const compileWorkspaceProgram = (workspace: WorkspaceState): CompilationR
   return {
     program: { instructions },
     diagnostics,
-  };
+  } satisfies CompilationResult;
 };

--- a/src/simulation/runtime/defaultProgram.ts
+++ b/src/simulation/runtime/defaultProgram.ts
@@ -1,4 +1,4 @@
-import type { CompiledProgram } from './blockProgram';
+import { createNumberLiteralBinding, type CompiledProgram } from './blockProgram';
 
 const BLINK_INTERVAL_SECONDS = 2;
 
@@ -6,9 +6,10 @@ export const DEFAULT_STARTUP_PROGRAM: CompiledProgram = {
   instructions: [
     {
       kind: 'loop',
+      mode: 'forever',
       instructions: [
-        { kind: 'status-toggle', duration: 0 },
-        { kind: 'wait', duration: BLINK_INTERVAL_SECONDS },
+        { kind: 'status-toggle', duration: createNumberLiteralBinding(0, { label: 'Startup → toggle' }) },
+        { kind: 'wait', duration: createNumberLiteralBinding(BLINK_INTERVAL_SECONDS, { label: 'Startup → wait' }) },
       ],
     },
   ],

--- a/src/state/__tests__/blockUtils.test.ts
+++ b/src/state/__tests__/blockUtils.test.ts
@@ -110,7 +110,9 @@ describe('blockUtils', () => {
   it('seeds parameter defaults and expression containers for control blocks', () => {
     const repeat = createBlockInstance('repeat');
     expect(repeat.parameters?.count).toEqual({ kind: 'number', value: 3 });
-    expect(repeat.expressionInputs?.count).toEqual([]);
+    const repeatExpressionInputs = repeat.expressionInputs?.count ?? [];
+    expect(repeatExpressionInputs).toHaveLength(1);
+    expect(repeatExpressionInputs[0]?.type).toBe('literal-number');
 
     const conditional = createBlockInstance('if');
     expect(conditional.parameters?.condition).toEqual({ kind: 'boolean', value: true });

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { simulationRuntime } from '../simulationRuntime';
 import { DEFAULT_STARTUP_PROGRAM } from '../../simulation/runtime/defaultProgram';
+import { createNumberLiteralBinding, type CompiledProgram } from '../../simulation/runtime/blockProgram';
 import type { RootScene } from '../../simulation/rootScene';
 
 const createSceneStub = () => {
@@ -61,7 +62,11 @@ describe('simulationRuntime', () => {
   });
 
   it('prioritises queued programs over the default startup routine', () => {
-    const customProgram = { instructions: [{ kind: 'wait' as const, duration: 1 }] };
+    const customProgram: CompiledProgram = {
+      instructions: [
+        { kind: 'wait', duration: createNumberLiteralBinding(1, { label: 'Queued → wait' }) },
+      ],
+    };
     simulationRuntime.runProgram(customProgram);
 
     const scene = createSceneStub();


### PR DESCRIPTION
## Summary
- extend the block compiler to produce expression-aware parameter bindings, signal descriptors, and branch instructions
- teach the program runner to evaluate literal, signal, and operator expressions at runtime and honour conditional branches
- refresh debug overlays, default programs, and tests to exercise literal overrides and telemetry driven flows

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2a45bdfa4832eb70669fbc43e367b