### PR TITLE
Add Playwright install postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "npx playwright install --with-deps"
   },
   "dependencies": {
     "pixi-viewport": "^6.0.3",


### PR DESCRIPTION
## Summary
- add a postinstall script to automatically install Playwright browsers and system dependencies

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2b0047a44832eaab5540f701a7736