### PR TITLE
Add block deletion controls to workspace blocks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,14 @@ const DEFAULT_ROBOT_ID = 'MF-01';
 const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 
 const App = (): JSX.Element => {
-  const { workspace, handleDrop, handleTouchDrop, replaceWorkspace, updateBlockInstance } = useBlockWorkspace();
+  const {
+    workspace,
+    handleDrop,
+    handleTouchDrop,
+    replaceWorkspace,
+    updateBlockInstance,
+    removeBlockInstance,
+  } = useBlockWorkspace();
   const { selectedRobotId, clearSelection } = useRobotSelection();
   const [isOverlayOpen, setOverlayOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<OverlayTab>('inventory');
@@ -188,6 +195,7 @@ const App = (): JSX.Element => {
         onDrop={handleDrop}
         onTouchDrop={handleTouchDrop}
         onUpdateBlock={updateBlockInstance}
+        onRemoveBlock={removeBlockInstance}
         robotId={activeRobotId}
       />
       <OnboardingFlow replaceWorkspace={replaceWorkspace} openProgrammingOverlay={handleProgramRobot} />

--- a/src/components/RobotProgrammingPanel.tsx
+++ b/src/components/RobotProgrammingPanel.tsx
@@ -12,6 +12,7 @@ interface RobotProgrammingPanelProps {
   onDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  onRemoveBlock: (instanceId: string) => void;
   onClose: () => void;
   onConfirm: () => void;
   robotId: string;
@@ -22,6 +23,7 @@ const RobotProgrammingPanel = ({
   onDrop,
   onTouchDrop,
   onUpdateBlock,
+  onRemoveBlock,
   onClose,
   onConfirm,
   robotId,
@@ -61,6 +63,7 @@ const RobotProgrammingPanel = ({
             onDrop={onDrop}
             onTouchDrop={onTouchDrop}
             onUpdateBlock={onUpdateBlock}
+            onRemoveBlock={onRemoveBlock}
             telemetry={telemetry}
           />
         </section>

--- a/src/components/SimulationOverlay.tsx
+++ b/src/components/SimulationOverlay.tsx
@@ -25,6 +25,7 @@ interface SimulationOverlayProps {
   onDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  onRemoveBlock: (instanceId: string) => void;
   robotId: string;
 }
 
@@ -38,6 +39,7 @@ const SimulationOverlay = ({
   onDrop,
   onTouchDrop,
   onUpdateBlock,
+  onRemoveBlock,
   robotId,
 }: SimulationOverlayProps): JSX.Element | null => {
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -180,6 +182,7 @@ const SimulationOverlay = ({
               onDrop={onDrop}
               onTouchDrop={onTouchDrop}
               onUpdateBlock={onUpdateBlock}
+              onRemoveBlock={onRemoveBlock}
               onClose={onClose}
               onConfirm={onConfirm}
               robotId={robotId}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -10,10 +10,11 @@ interface WorkspaceProps {
   onDrop: (event: React.DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop?: (payload: DragPayload, target: DropTarget) => void;
   onUpdateBlock?: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  onRemoveBlock: (instanceId: string) => void;
   telemetry?: RobotTelemetryData;
 }
 
-const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock, telemetry }: WorkspaceProps): JSX.Element => {
+const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock, onRemoveBlock, telemetry }: WorkspaceProps): JSX.Element => {
   const workspaceTarget = (position: number): DropTarget => ({
     kind: 'workspace',
     position,
@@ -69,6 +70,7 @@ const Workspace = ({ blocks, onDrop, onTouchDrop, onUpdateBlock, telemetry }: Wo
                     onDrop={onDrop}
                     onTouchDrop={onTouchDrop}
                     onUpdateBlock={onUpdateBlock}
+                    onRemoveBlock={onRemoveBlock}
                     telemetry={telemetry}
                   />
                   <DropZone

--- a/src/components/__tests__/BlockParameterEditors.test.tsx
+++ b/src/components/__tests__/BlockParameterEditors.test.tsx
@@ -14,9 +14,17 @@ afterEach(() => {
 });
 
 describe('Block parameter editors', () => {
-  const renderBlockView = (block: BlockInstance, options: { onDrop?: ReturnType<typeof vi.fn>; onUpdateBlock?: ReturnType<typeof vi.fn> } = {}) => {
+  const renderBlockView = (
+    block: BlockInstance,
+    options: {
+      onDrop?: ReturnType<typeof vi.fn>;
+      onUpdateBlock?: ReturnType<typeof vi.fn>;
+      onRemoveBlock?: ReturnType<typeof vi.fn>;
+    } = {},
+  ) => {
     const onDrop = options.onDrop ?? vi.fn();
     const onUpdateBlock = options.onUpdateBlock ?? vi.fn();
+    const onRemoveBlock = options.onRemoveBlock ?? vi.fn();
 
     render(
       <BlockView
@@ -24,10 +32,11 @@ describe('Block parameter editors', () => {
         path={[]}
         onDrop={onDrop}
         onUpdateBlock={onUpdateBlock}
+        onRemoveBlock={onRemoveBlock}
       />,
     );
 
-    return { onDrop, onUpdateBlock };
+    return { onDrop, onUpdateBlock, onRemoveBlock };
   };
 
   it('updates numeric parameters when editing the field value', () => {
@@ -102,6 +111,18 @@ describe('Block parameter editors', () => {
       position: 0,
       ancestorIds: [block.instanceId],
     });
+  });
+
+  it('invokes the remove callback when clicking the delete button', () => {
+    const block = createBlockInstance('repeat');
+    const onRemoveBlock = vi.fn();
+    renderBlockView(block, { onRemoveBlock });
+
+    const deleteButton = screen.getByTestId('block-repeat-delete');
+    deleteButton.click();
+
+    expect(onRemoveBlock).toHaveBeenCalledTimes(1);
+    expect(onRemoveBlock).toHaveBeenCalledWith(block.instanceId);
   });
 
   it('refreshes signal options when telemetry snapshots change', async () => {

--- a/src/components/__tests__/SimulationOverlay.test.tsx
+++ b/src/components/__tests__/SimulationOverlay.test.tsx
@@ -24,6 +24,7 @@ describe('SimulationOverlay panels', () => {
     onDrop: vi.fn(),
     onTouchDrop: vi.fn(),
     onUpdateBlock: vi.fn(),
+    onRemoveBlock: vi.fn(),
     robotId: 'MF-01',
   } as const;
 

--- a/src/hooks/useBlockWorkspace.ts
+++ b/src/hooks/useBlockWorkspace.ts
@@ -59,6 +59,7 @@ export function useBlockWorkspace(): {
   handleTouchDrop: (payload: DragPayload, target: DropTarget) => void;
   replaceWorkspace: Dispatch<SetStateAction<WorkspaceState>>;
   updateBlockInstance: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
+  removeBlockInstance: (instanceId: string) => void;
 } {
   const [workspace, setWorkspace] = useState<WorkspaceState>([]);
 
@@ -126,11 +127,19 @@ export function useBlockWorkspace(): {
     [],
   );
 
+  const removeBlockInstance = useCallback((instanceId: string) => {
+    setWorkspace((current) => {
+      const result = removeBlock(current, instanceId);
+      return result.removed ? result.blocks : current;
+    });
+  }, []);
+
   return {
     workspace,
     handleDrop,
     handleTouchDrop,
     replaceWorkspace: setWorkspace,
     updateBlockInstance,
+    removeBlockInstance,
   };
 }

--- a/src/styles/BlockView.module.css
+++ b/src/styles/BlockView.module.css
@@ -44,6 +44,34 @@
   font-size: var(--font-size-md);
 }
 
+.blockDeleteButton {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  line-height: 0;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.blockDeleteButton:hover,
+.blockDeleteButton:focus-visible {
+  background: var(--color-surface-overlay);
+  color: var(--color-accent-cyan);
+  outline: none;
+}
+
+.blockDeleteButton:active {
+  transform: scale(0.96);
+}
+
+.blockDeleteIcon {
+  width: 1rem;
+  height: 1rem;
+  pointer-events: none;
+}
+
 .blockSummary {
   margin: 0;
   color: var(--color-text-secondary);


### PR DESCRIPTION
## Summary
- add a `removeBlockInstance` helper to the block workspace hook and thread it through the programming overlay stack
- render a delete button on every block (including nested expressions) and style it to match the workspace UI
- add a unit test to confirm the delete control calls the supplied removal callback

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2e470aad0832ebd41dd64dbb36fe4