### PR TITLE
Add robot module loadout management UI

### DIFF
--- a/src/components/InventoryStatus.tsx
+++ b/src/components/InventoryStatus.tsx
@@ -1,4 +1,5 @@
 import useInventoryTelemetry from '../hooks/useInventoryTelemetry';
+import ModuleLoadoutManager from './ModuleLoadoutManager';
 import styles from '../styles/InventoryStatus.module.css';
 
 const formatResourceName = (resource: string): string =>
@@ -15,30 +16,33 @@ const InventoryStatus = (): JSX.Element => {
   const hasContents = snapshot.entries.length > 0;
 
   return (
-    <section className={styles.inventory} aria-labelledby="inventory-status-heading" data-testid="inventory-status">
-      <header className={styles.header}>
-        <h3 id="inventory-status-heading" className={styles.title}>
-          Cargo Inventory
-        </h3>
-        <p className={styles.capacity} data-testid="inventory-capacity">
-          <strong className={styles.capacityValue}>{Math.round(snapshot.used)}</strong>
-          <span aria-hidden="true"> / </span>
-          {Math.round(snapshot.capacity)} units occupied
-        </p>
-      </header>
-      {hasContents ? (
-        <ul className={styles.list} data-testid="inventory-contents">
-          {snapshot.entries.map((entry) => (
-            <li key={entry.resource} className={styles.entry}>
-              <span className={styles.name}>{formatResourceName(entry.resource)}</span>
-              <span className={styles.quantity}>{formatUnits(entry.quantity)}</span>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className={styles.empty}>No resources stored yet. Run a gather routine to collect materials.</p>
-      )}
-    </section>
+    <div className={styles.wrapper} data-testid="inventory-status">
+      <section className={styles.inventory} aria-labelledby="inventory-status-heading">
+        <header className={styles.header}>
+          <h3 id="inventory-status-heading" className={styles.title}>
+            Cargo Inventory
+          </h3>
+          <p className={styles.capacity} data-testid="inventory-capacity">
+            <strong className={styles.capacityValue}>{Math.round(snapshot.used)}</strong>
+            <span aria-hidden="true"> / </span>
+            {Math.round(snapshot.capacity)} units occupied
+          </p>
+        </header>
+        {hasContents ? (
+          <ul className={styles.list} data-testid="inventory-contents">
+            {snapshot.entries.map((entry) => (
+              <li key={entry.resource} className={styles.entry}>
+                <span className={styles.name}>{formatResourceName(entry.resource)}</span>
+                <span className={styles.quantity}>{formatUnits(entry.quantity)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles.empty}>No resources stored yet. Run a gather routine to collect materials.</p>
+        )}
+      </section>
+      <ModuleLoadoutManager />
+    </div>
   );
 };
 

--- a/src/components/ModuleLoadoutManager.tsx
+++ b/src/components/ModuleLoadoutManager.tsx
@@ -1,0 +1,161 @@
+import { useCallback } from 'react';
+import type { DragEvent } from 'react';
+import { getModuleBlueprint } from '../simulation/robot/modules/moduleLibrary';
+import type { ModuleBlueprint } from '../simulation/robot/modules/moduleLibrary';
+import type { ModuleStateSnapshot } from '../simulation/robot/RobotChassis';
+import { simulationRuntime } from '../state/simulationRuntime';
+import useModuleState from '../hooks/useModuleState';
+import styles from '../styles/ModuleLoadoutManager.module.css';
+
+const MODULE_DRAG_DATA = 'application/x-module-id';
+const MODULE_DRAG_SOURCE = 'application/x-module-source';
+
+const getBlueprint = (moduleId: string): ModuleBlueprint | null => getModuleBlueprint(moduleId);
+
+const formatQuantity = (quantity: number): string => `${quantity}×`;
+
+const formatDistance = (distance: number): string => `${distance.toFixed(1)}u`;
+
+const ModuleLoadoutManager = (): JSX.Element => {
+  const moduleState = useModuleState();
+
+  const handleDragStart = useCallback((moduleId: string, source: 'mounted' | 'inventory') => {
+    return (event: DragEvent<HTMLDivElement>) => {
+      event.dataTransfer?.setData(MODULE_DRAG_DATA, moduleId);
+      event.dataTransfer?.setData(MODULE_DRAG_SOURCE, source);
+      event.dataTransfer.effectAllowed = 'move';
+    };
+  }, []);
+
+  const handleInventoryDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
+    const moduleId = event.dataTransfer?.getData(MODULE_DRAG_DATA);
+    const source = event.dataTransfer?.getData(MODULE_DRAG_SOURCE);
+    if (!moduleId || source !== 'mounted') {
+      return;
+    }
+    event.preventDefault();
+    void simulationRuntime.storeModule(moduleId);
+  }, []);
+
+  const handleMountedDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
+    const moduleId = event.dataTransfer?.getData(MODULE_DRAG_DATA);
+    const source = event.dataTransfer?.getData(MODULE_DRAG_SOURCE);
+    if (!moduleId || source !== 'inventory') {
+      return;
+    }
+    event.preventDefault();
+    void simulationRuntime.mountModule(moduleId);
+  }, []);
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (event.dataTransfer?.types.includes(MODULE_DRAG_DATA)) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }, []);
+
+  const renderMountedModules = (snapshot: ModuleStateSnapshot) => {
+    if (snapshot.installed.length === 0) {
+      return <div className={styles.empty}>No modules mounted.</div>;
+    }
+    return snapshot.installed.map((entry) => {
+      const blueprint = getBlueprint(entry.id);
+      return (
+        <div
+          key={entry.id}
+          className={styles.card}
+          draggable
+          onDragStart={handleDragStart(entry.id, 'mounted')}
+        >
+          <div className={styles.cardTitle}>{blueprint?.title ?? entry.id}</div>
+          <div className={styles.cardMeta}>{`${entry.slot.toUpperCase()} · ${entry.index}`}</div>
+          <div className={styles.cardActions}>
+            <button type="button" onClick={() => void simulationRuntime.storeModule(entry.id)}>
+              Store in inventory
+            </button>
+          </div>
+        </div>
+      );
+    });
+  };
+
+  const renderInventoryModules = (snapshot: ModuleStateSnapshot) => {
+    if (snapshot.inventory.length === 0) {
+      return <div className={styles.empty}>Inventory is empty.</div>;
+    }
+    return snapshot.inventory.map((entry) => {
+      const blueprint = getBlueprint(entry.id);
+      return (
+        <div
+          key={entry.id}
+          className={styles.card}
+          draggable
+          onDragStart={handleDragStart(entry.id, 'inventory')}
+        >
+          <div className={styles.cardTitle}>{blueprint?.title ?? entry.id}</div>
+          <div className={styles.cardMeta}>{formatQuantity(entry.quantity)}</div>
+          <div className={styles.cardActions}>
+            <button type="button" onClick={() => void simulationRuntime.mountModule(entry.id)}>
+              Mount
+            </button>
+            <button type="button" onClick={() => void simulationRuntime.dropModule(entry.id)}>
+              Drop
+            </button>
+          </div>
+        </div>
+      );
+    });
+  };
+
+  const renderGroundModules = (snapshot: ModuleStateSnapshot) => {
+    if (snapshot.ground.length === 0) {
+      return <div className={styles.empty}>No modules nearby.</div>;
+    }
+    return snapshot.ground.map((entry) => {
+      const blueprint = getBlueprint(entry.moduleId);
+      return (
+        <div key={entry.nodeId} className={styles.card}>
+          <div className={styles.cardTitle}>{blueprint?.title ?? entry.moduleId}</div>
+          <div className={styles.cardMeta}>{`${formatQuantity(entry.quantity)} · ${formatDistance(entry.distance)}`}</div>
+          <div className={styles.cardActions}>
+            <button type="button" onClick={() => void simulationRuntime.pickUpModule(entry.nodeId)}>
+              Pick up
+            </button>
+          </div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className={styles.manager}>
+      <section className={styles.section} aria-labelledby="module-loadout-mounted">
+        <header className={styles.sectionHeader}>
+          <h4 id="module-loadout-mounted">Mounted modules</h4>
+          <p>Drag modules here to install them onto the chassis.</p>
+        </header>
+        <div className={styles.dropZone} onDragOver={handleDragOver} onDrop={handleMountedDrop}>
+          {renderMountedModules(moduleState)}
+        </div>
+      </section>
+      <section className={styles.section} aria-labelledby="module-loadout-inventory">
+        <header className={styles.sectionHeader}>
+          <h4 id="module-loadout-inventory">Module inventory</h4>
+          <p>Drag mounted modules here or use actions to stash and deploy hardware.</p>
+        </header>
+        <div className={styles.dropZone} onDragOver={handleDragOver} onDrop={handleInventoryDrop}>
+          {renderInventoryModules(moduleState)}
+        </div>
+      </section>
+      <section className={styles.section} aria-labelledby="module-loadout-ground">
+        <header className={styles.sectionHeader}>
+          <h4 id="module-loadout-ground">Nearby modules</h4>
+          <p>Retrieve loose hardware detected around the chassis.</p>
+        </header>
+        <div className={styles.groundList}>{renderGroundModules(moduleState)}</div>
+      </section>
+    </div>
+  );
+};
+
+export default ModuleLoadoutManager;

--- a/src/hooks/useModuleState.ts
+++ b/src/hooks/useModuleState.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import type { ModuleStateSnapshot } from '../simulation/robot/RobotChassis';
+import { simulationRuntime } from '../state/simulationRuntime';
+
+export const useModuleState = (): ModuleStateSnapshot => {
+  const [snapshot, setSnapshot] = useState<ModuleStateSnapshot>(
+    simulationRuntime.getModuleStateSnapshot(),
+  );
+
+  useEffect(() => simulationRuntime.subscribeModuleState(setSnapshot), []);
+
+  return snapshot;
+};
+
+export default useModuleState;

--- a/src/simulation/assetService.ts
+++ b/src/simulation/assetService.ts
@@ -146,9 +146,40 @@ assetService.defineVectorAsset('resource/biotic-spore', () => {
   return graphic;
 });
 
+const drawModuleToken = (fill: number, stroke: number, detail: number): Graphics => {
+  const graphic = new Graphics();
+  graphic.roundRect(-20, -24, 40, 48, 8);
+  graphic.fill({ color: fill, alpha: 0.9 });
+  graphic.setStrokeStyle({ width: 3, color: stroke, alpha: 0.95 });
+  graphic.stroke();
+
+  graphic.roundRect(-12, -8, 24, 16, 4);
+  graphic.fill({ color: detail, alpha: 0.95 });
+
+  graphic.setStrokeStyle({ width: 2, color: stroke, alpha: 0.6 });
+  graphic.moveTo(-10, 12);
+  graphic.lineTo(10, 12);
+  graphic.stroke();
+
+  return graphic;
+};
+
+assetService.defineVectorAsset('module/movement', () => drawModuleToken(0x4ecdc4, 0x1a535c, 0xf4fdfd));
+assetService.defineVectorAsset('module/manipulation', () => drawModuleToken(0xff6b6b, 0xc44536, 0xfff1f1));
+assetService.defineVectorAsset('module/inventory', () => drawModuleToken(0x6ab04c, 0x218c74, 0xf6ffed));
+assetService.defineVectorAsset('module/crafting', () => drawModuleToken(0xf7b731, 0xf4a261, 0xfff9e6));
+assetService.defineVectorAsset('module/scanning', () => drawModuleToken(0x778beb, 0x4a69bd, 0xf1f4ff));
+assetService.defineVectorAsset('module/status', () => drawModuleToken(0x9b5de5, 0x482677, 0xf7ecff));
+
 export const RESOURCE_TEXTURE_IDS: Record<string, string> = {
   default: 'resource/default',
   'ferrous-ore': 'resource/ferrous-ore',
   'silicate-crystal': 'resource/silicate-crystal',
   'biotic-spore': 'resource/biotic-spore',
+  'module:core.movement': 'module/movement',
+  'module:arm.manipulator': 'module/manipulation',
+  'module:storage.cargo': 'module/inventory',
+  'module:fabricator.basic': 'module/crafting',
+  'module:sensor.survey': 'module/scanning',
+  'module:status.signal': 'module/status',
 };

--- a/src/simulation/robot/__tests__/RobotChassis.test.ts
+++ b/src/simulation/robot/__tests__/RobotChassis.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { RobotChassis, type ModuleActionContext, type ModuleUpdateContext } from '../RobotChassis';
+import {
+  RobotChassis,
+  type ModuleActionContext,
+  type ModuleUpdateContext,
+  type ModuleStateSnapshot,
+} from '../RobotChassis';
 import { RobotModule } from '../RobotModule';
 import type { ModulePort } from '../moduleBus';
+import { toModuleResourceId } from '../moduleInventory';
 
 interface LinearMovementOptions {
   id: string;
@@ -187,5 +193,99 @@ describe('Module messaging and actuator resolution', () => {
     const stateAfterSecondTick = chassis.getStateSnapshot();
     expect(stateAfterSecondTick.position.x).toBeCloseTo(10);
     expect(stateAfterSecondTick.orientation).toBeGreaterThan(stateAfterTick.orientation);
+  });
+});
+
+describe('Module storage and loadout management', () => {
+  it('unmounts modules into inventory and exposes them via the module state snapshot', () => {
+    const chassis = new RobotChassis({ capacity: 6 });
+    const power = new PowerCoreModule();
+    const mover = new RobotModule({
+      id: 'move.basic',
+      title: 'Basic Movement',
+      provides: ['movement.basic'],
+      requires: ['power.core'],
+      attachment: { slot: 'core', index: 1 },
+    });
+
+    chassis.attachModule(power);
+    chassis.attachModule(mover);
+    chassis.inventory.setCapacitySource('test-hold', 10);
+
+    const storeResult = chassis.storeModule('move.basic');
+    expect(storeResult).toEqual({ success: true, moduleId: 'move.basic', quantity: 1 });
+    expect(chassis.moduleStack.getModule('move.basic')).toBeNull();
+    expect(chassis.inventory.getQuantity(toModuleResourceId('move.basic'))).toBe(1);
+
+    const snapshot = chassis.getModuleStateSnapshot();
+    expect(snapshot.installed.find((entry) => entry.id === 'move.basic')).toBeUndefined();
+    expect(snapshot.inventory).toEqual([{ id: 'move.basic', quantity: 1 }]);
+  });
+
+  it('blocks unmounting when dependencies would break', () => {
+    const chassis = new RobotChassis({ capacity: 6 });
+    chassis.attachModule(new PowerCoreModule());
+    chassis.attachModule(
+      new RobotModule({
+        id: 'support.frame',
+        title: 'Support Frame',
+        provides: ['support.frame'],
+        attachment: { slot: 'support', index: 0 },
+      }),
+    );
+    chassis.attachModule(
+      new RobotModule({
+        id: 'tool.aux',
+        title: 'Aux Tool',
+        requires: ['support.frame'],
+        attachment: { slot: 'extension', index: 0 },
+      }),
+    );
+
+    const result = chassis.storeModule('support.frame');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe('blocked');
+    }
+    expect(chassis.moduleStack.getModule('support.frame')).not.toBeNull();
+  });
+
+  it('mounts stored modules back onto the chassis', () => {
+    const chassis = new RobotChassis({ capacity: 6 });
+    chassis.attachModule(new PowerCoreModule());
+    chassis.inventory.setCapacitySource('test-hold', 10);
+    chassis.inventory.store(toModuleResourceId('storage.cargo'), 1);
+
+    const result = chassis.mountModule('storage.cargo');
+    expect(result).toEqual({ success: true, moduleId: 'storage.cargo' });
+    expect(chassis.moduleStack.getModule('storage.cargo')).not.toBeNull();
+    expect(chassis.inventory.getQuantity(toModuleResourceId('storage.cargo'))).toBe(0);
+  });
+
+  it('drops stored modules into the world and picks them back up', () => {
+    const chassis = new RobotChassis({ capacity: 6 });
+    chassis.attachModule(new PowerCoreModule());
+    chassis.inventory.setCapacitySource('test-hold', 10);
+    chassis.inventory.store(toModuleResourceId('support.frame'), 2);
+
+    const drop = chassis.dropModule('support.frame', 2, { mergeDistance: 0 });
+    expect(drop).toMatchObject({ success: true, moduleId: 'support.frame', quantity: 2 });
+    if (!drop.success) {
+      throw new Error('Expected drop to succeed');
+    }
+    const nodeId = drop.nodeId;
+
+    expect(chassis.inventory.getQuantity(toModuleResourceId('support.frame'))).toBe(0);
+
+    const pickup = chassis.pickUpModule(nodeId, 1);
+    expect(pickup.success).toBe(true);
+    if (!pickup.success) {
+      throw new Error('Expected pickup to succeed');
+    }
+    expect(pickup.moduleId).toBe('support.frame');
+    expect(chassis.inventory.getQuantity(toModuleResourceId('support.frame'))).toBe(1);
+
+    const stateAfterPickup: ModuleStateSnapshot = chassis.getModuleStateSnapshot();
+    expect(stateAfterPickup.ground.find((entry) => entry.nodeId === nodeId)?.quantity).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/simulation/robot/moduleInventory.ts
+++ b/src/simulation/robot/moduleInventory.ts
@@ -1,0 +1,66 @@
+import type { InventorySnapshot } from './inventory';
+import type { ModuleSnapshot } from './moduleStack';
+
+export const MODULE_RESOURCE_PREFIX = 'module:';
+
+export interface ModuleInventoryEntry {
+  id: string;
+  quantity: number;
+}
+
+export interface DroppedModuleEntry {
+  nodeId: string;
+  moduleId: string;
+  quantity: number;
+  position: { x: number; y: number };
+  distance: number;
+}
+
+export interface ModuleStateSnapshot {
+  installed: ModuleSnapshot[];
+  inventory: ModuleInventoryEntry[];
+  ground: DroppedModuleEntry[];
+}
+
+export const toModuleResourceId = (moduleId: string): string =>
+  `${MODULE_RESOURCE_PREFIX}${moduleId.trim().toLowerCase()}`;
+
+export const fromModuleResourceId = (resourceId: string): string | null => {
+  if (!resourceId?.toLowerCase().startsWith(MODULE_RESOURCE_PREFIX)) {
+    return null;
+  }
+  const moduleId = resourceId.slice(MODULE_RESOURCE_PREFIX.length);
+  return moduleId ? moduleId : null;
+};
+
+export const extractModuleInventory = (snapshot: InventorySnapshot): ModuleInventoryEntry[] => {
+  const modules: ModuleInventoryEntry[] = [];
+  for (const entry of snapshot.entries) {
+    const moduleId = fromModuleResourceId(entry.resource);
+    if (!moduleId) {
+      continue;
+    }
+    const quantity = Math.max(Math.round(entry.quantity), 0);
+    if (quantity <= 0) {
+      continue;
+    }
+    modules.push({ id: moduleId, quantity });
+  }
+  modules.sort((a, b) => a.id.localeCompare(b.id));
+  return modules;
+};
+
+export const EMPTY_MODULE_STATE: ModuleStateSnapshot = {
+  installed: [],
+  inventory: [],
+  ground: [],
+};
+
+export const distanceBetween = (
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): number => {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
+};

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -3,6 +3,7 @@ import { simulationRuntime } from '../simulationRuntime';
 import { DEFAULT_STARTUP_PROGRAM } from '../../simulation/runtime/defaultProgram';
 import { createNumberLiteralBinding, type CompiledProgram } from '../../simulation/runtime/blockProgram';
 import type { RootScene } from '../../simulation/rootScene';
+import { EMPTY_MODULE_STATE } from '../../simulation/robot/RobotChassis';
 
 const createSceneStub = () => {
   const subscriptions: { status: ((status: string) => void) | null } = { status: null };
@@ -19,7 +20,9 @@ const createSceneStub = () => {
     getInventorySnapshot: vi.fn(() => ({ capacity: 0, used: 0, available: 0, entries: [] })),
     subscribeInventory: vi.fn(() => () => {}),
     subscribeTelemetry: vi.fn(() => () => {}),
+    subscribeModuleState: vi.fn(() => () => {}),
     getTelemetrySnapshot: vi.fn(() => ({ values: {}, actions: {} })),
+    getModuleStateSnapshot: vi.fn(() => EMPTY_MODULE_STATE),
     getSelectedRobot: vi.fn(() => null),
     selectRobot: vi.fn(),
     clearRobotSelection: vi.fn(),

--- a/src/styles/InventoryStatus.module.css
+++ b/src/styles/InventoryStatus.module.css
@@ -1,3 +1,9 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
 .inventory {
   margin: 0;
   padding: var(--space-5) var(--space-6);

--- a/src/styles/ModuleLoadoutManager.module.css
+++ b/src/styles/ModuleLoadoutManager.module.css
@@ -1,0 +1,94 @@
+.manager {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.section {
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-panel-outline);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.sectionHeader h4 {
+  margin: 0;
+  font-size: var(--font-size-md);
+}
+
+.sectionHeader p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.dropZone,
+.groundList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-3);
+  min-height: 56px;
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-panel-outline-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  box-shadow: var(--shadow-soft);
+}
+
+.cardTitle {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+}
+
+.cardMeta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.cardActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.cardActions button {
+  flex: 1;
+  border: 1px solid var(--color-panel-outline);
+  background: var(--color-surface-accent);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.cardActions button:hover {
+  background: var(--color-surface);
+}
+
+.empty {
+  padding: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 720px) {
+  .dropZone,
+  .groundList {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add robot module inventory helpers and extend RobotChassis with store, drop, pickup, and subscription support
- surface module state through the runtime/scene layers and build a drag-and-drop ModuleLoadoutManager in the inventory overlay
- expand assets, styling, and unit tests to cover the new module workflows

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2e2afbe28832eb87f0f0c5b10e724