### PR TITLE
Disable onboarding flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import type { WorkspaceState } from './types/blocks';
 import styles from './styles/App.module.css';
 
 const DEFAULT_ROBOT_ID = 'MF-01';
+const ONBOARDING_ENABLED = false;
 
 const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 
@@ -204,7 +205,12 @@ const App = (): JSX.Element => {
         onRemoveBlock={removeBlockInstance}
         robotId={activeRobotId}
       />
-      <OnboardingFlow replaceWorkspace={replaceWorkspace} openProgrammingOverlay={handleProgramRobot} />
+      {ONBOARDING_ENABLED ? (
+        <OnboardingFlow
+          replaceWorkspace={replaceWorkspace}
+          openProgrammingOverlay={handleProgramRobot}
+        />
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a temporary feature flag to disable rendering the onboarding flow component
- keep the existing onboarding logic available for future reactivation without removing supporting code

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d2f2b2300c832eb2d365835d649d00