### PR TITLE
Add entity info inspector for simple overlays

### DIFF
--- a/src/components/__tests__/EntityOverlay.test.tsx
+++ b/src/components/__tests__/EntityOverlay.test.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import EntityOverlay from '../EntityOverlay';
 import {
   EntityOverlayManagerProvider,
@@ -9,12 +8,25 @@ import {
 import { useEffect } from 'react';
 import type { EntityOverlayData } from '../../types/overlay';
 import type { EntityId } from '../../simulation/ecs/world';
+import { registerInspector } from '../../overlay/inspectorRegistry';
+import EntityInfoInspector from '../inspectors/EntityInfoInspector';
 
 const createOverlayData = (): EntityOverlayData => ({
   entityId: 5 as EntityId,
   name: 'Test Entity',
   description: 'Inspection overlay for testing',
   overlayType: 'complex',
+});
+
+const createSimpleOverlayData = (): EntityOverlayData => ({
+  entityId: 6 as EntityId,
+  name: 'Ore Vein',
+  description: 'High-yield ferrous deposit',
+  overlayType: 'simple',
+  properties: {
+    yield: 320,
+    composition: ['Iron', 'Nickel'],
+  },
 });
 
 const OverlayHarness = ({ onClose }: { onClose: () => void }): JSX.Element => {
@@ -36,6 +48,10 @@ const renderOverlay = (onClose: () => void) =>
     </EntityOverlayManagerProvider>,
   );
 
+afterEach(() => {
+  cleanup();
+});
+
 describe('EntityOverlay', () => {
   it('renders the entity name and defaults to the systems tab', async () => {
     renderOverlay(vi.fn());
@@ -50,10 +66,9 @@ describe('EntityOverlay', () => {
 
     const [systemsTab] = await screen.findAllByRole('tab', { name: 'Systems' });
     systemsTab.focus();
-    await userEvent.keyboard('{ArrowRight}');
+    fireEvent.keyDown(systemsTab, { key: 'ArrowRight' });
 
     const [programmingTab] = await screen.findAllByRole('tab', { name: 'Programming' });
-    await screen.findAllByRole('tab', { name: 'Programming' });
     await waitFor(() => {
       expect(programmingTab).toHaveAttribute('aria-selected', 'true');
     });
@@ -67,5 +82,46 @@ describe('EntityOverlay', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('renders the simple entity info bubble when an info inspector is registered', async () => {
+    try {
+      registerInspector({
+        id: 'test-entity-info',
+        label: 'Overview',
+        group: 'info',
+        component: EntityInfoInspector,
+      });
+    } catch (error) {
+      if (!(error instanceof Error) || !/already registered/i.test(error.message)) {
+        throw error;
+      }
+    }
+
+    const simpleData = createSimpleOverlayData();
+
+    const SimpleOverlayHarness = ({ onClose }: { onClose: () => void }): JSX.Element => {
+      const manager = useEntityOverlayManager();
+
+      useEffect(() => {
+        if (!manager.isOpen) {
+          manager.openOverlay(simpleData);
+        }
+      }, [manager]);
+
+      return <EntityOverlay onClose={onClose} />;
+    };
+
+    render(
+      <EntityOverlayManagerProvider>
+        <SimpleOverlayHarness onClose={vi.fn()} />
+      </EntityOverlayManagerProvider>,
+    );
+
+    await screen.findByTestId('entity-info-inspector');
+    expect(screen.getByText('Yield')).toBeInTheDocument();
+    expect(screen.getByText('320')).toBeInTheDocument();
+    expect(screen.getByText('Composition')).toBeInTheDocument();
+    expect(screen.getByText('Iron, Nickel')).toBeInTheDocument();
   });
 });

--- a/src/components/inspectors/EntityInfoInspector.tsx
+++ b/src/components/inspectors/EntityInfoInspector.tsx
@@ -1,0 +1,125 @@
+import { useMemo } from 'react';
+import type { InspectorProps } from '../../overlay/inspectorRegistry';
+import styles from '../../styles/EntityInfoInspector.module.css';
+
+type PropertyEntry = {
+  key: string;
+  label: string;
+  valueText: string;
+};
+
+const isDisplayableValue = (value: unknown): boolean => {
+  if (value === undefined) {
+    return false;
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return false;
+  }
+  return true;
+};
+
+const normaliseLabel = (key: string): string => {
+  const withSpaces = key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!withSpaces) {
+    return 'Value';
+  }
+  return withSpaces
+    .split(' ')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+};
+
+const formatValue = (value: unknown): string => {
+  if (value === null) {
+    return 'None';
+  }
+  if (Array.isArray(value)) {
+    return formatArray(value);
+  }
+  switch (typeof value) {
+    case 'string':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? String(value) : '—';
+    case 'boolean':
+      return value ? 'Yes' : 'No';
+    case 'bigint':
+      return value.toString();
+    case 'object':
+      return JSON.stringify(value);
+    default:
+      return '';
+  }
+};
+
+function formatArray(values: unknown[]): string {
+  if (values.length === 0) {
+    return 'None';
+  }
+  return values
+    .map((entry) => formatValue(entry))
+    .filter((text) => text.length > 0)
+    .join(', ');
+}
+
+const buildPropertyEntries = (entity: InspectorProps['entity']): PropertyEntry[] => {
+  const properties = entity.properties;
+  if (!properties) {
+    return [];
+  }
+  return Object.entries(properties)
+    .filter(([, value]) => isDisplayableValue(value))
+    .map(([key, value]) => ({
+      key,
+      label: normaliseLabel(key),
+      valueText: formatValue(value),
+    }))
+    .filter((entry) => entry.valueText !== '');
+};
+
+const EntityInfoInspector = ({ entity }: InspectorProps): JSX.Element => {
+  const titleId = `entity-info-${entity.entityId}`;
+  const showSummary = entity.overlayType === 'simple';
+
+  const properties = useMemo(() => buildPropertyEntries(entity), [entity]);
+
+  const summaryClassName = `${styles.summary} ${showSummary ? styles.summarySimple : ''}`.trim();
+
+  return (
+    <section className={styles.info} aria-labelledby={titleId} data-testid="entity-info-inspector">
+      <header className={summaryClassName}>
+        <h3 id={titleId} className={showSummary ? styles.summaryTitle : styles.heading}>
+          {showSummary ? entity.name : 'Entity Information'}
+        </h3>
+        {showSummary ? (
+          entity.description ? (
+            <p className={styles.description}>{entity.description}</p>
+          ) : null
+        ) : (
+          <div className={styles.summaryDetails}>
+            <p className={styles.entityName}>{entity.name}</p>
+            <p className={styles.summaryHint}>Key facts about this entity.</p>
+          </div>
+        )}
+      </header>
+      {properties.length > 0 ? (
+        <dl className={styles.properties}>
+          {properties.map((entry) => (
+            <div key={entry.key} className={styles.property}>
+              <dt className={styles.propertyLabel}>{entry.label}</dt>
+              <dd className={styles.propertyValue}>{entry.valueText}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className={styles.placeholder}>No additional properties available.</p>
+      )}
+    </section>
+  );
+};
+
+export default EntityInfoInspector;

--- a/src/components/inspectors/__tests__/EntityInfoInspector.test.tsx
+++ b/src/components/inspectors/__tests__/EntityInfoInspector.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import EntityInfoInspector from '../EntityInfoInspector';
+import type { EntityOverlayData } from '../../../types/overlay';
+import type { EntityId } from '../../../simulation/ecs/world';
+
+const baseEntity: EntityOverlayData = {
+  entityId: 101 as EntityId,
+  name: 'Iridescent Node',
+  description: 'A shimmering deposit discovered during the dawn survey.',
+  overlayType: 'simple',
+};
+
+const renderInspector = (overrides: Partial<EntityOverlayData> = {}) =>
+  render(<EntityInfoInspector entity={{ ...baseEntity, ...overrides }} onClose={() => {}} />);
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('EntityInfoInspector', () => {
+  it('shows the entity summary for simple overlays', () => {
+    renderInspector();
+
+    expect(screen.getByRole('heading', { name: baseEntity.name })).toBeInTheDocument();
+    expect(screen.getByText(baseEntity.description!)).toBeInTheDocument();
+  });
+
+  it('renders formatted properties', () => {
+    renderInspector({
+      properties: {
+        remainingYield: 128,
+        isStable: true,
+        resourceTypes: ['Iron', 'Nickel'],
+        metadata: { hazard: 'Low' },
+      },
+    });
+
+    expect(screen.getByText('Remaining Yield')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+    expect(screen.getByText('Is Stable')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('Resource Types')).toBeInTheDocument();
+    expect(screen.getByText('Iron, Nickel')).toBeInTheDocument();
+    expect(screen.getByText('Metadata')).toBeInTheDocument();
+    expect(screen.getByText('{"hazard":"Low"}')).toBeInTheDocument();
+  });
+
+  it('hides undefined properties and shows a placeholder when none remain', () => {
+    renderInspector({ properties: { ignored: undefined } });
+
+    expect(screen.getByText('No additional properties available.')).toBeInTheDocument();
+  });
+
+  it('switches to a neutral heading for complex overlays', () => {
+    renderInspector({ overlayType: 'complex' });
+
+    expect(screen.getByRole('heading', { name: 'Entity Information' })).toBeInTheDocument();
+    expect(screen.getByText(baseEntity.name)).toBeInTheDocument();
+    expect(screen.getByText('Key facts about this entity.')).toBeInTheDocument();
+  });
+});

--- a/src/overlay/defaultInspectors.ts
+++ b/src/overlay/defaultInspectors.ts
@@ -1,19 +1,34 @@
+import EntityInfoInspector from '../components/inspectors/EntityInfoInspector';
 import RobotProgrammingInspector from '../components/inspectors/RobotProgrammingInspector';
-import { registerInspector } from './inspectorRegistry';
+import { getInspectorDefinitions, registerInspector } from './inspectorRegistry';
 
-let hasRegistered = false;
-
-export const ensureDefaultInspectorsRegistered = (): void => {
-  if (hasRegistered) {
+const ensureInspectorRegistered = (id: string, register: () => void): void => {
+  const existing = getInspectorDefinitions().some((definition) => definition.id === id);
+  if (existing) {
     return;
   }
-  registerInspector({
-    id: 'robot-programming',
-    label: 'Programming',
-    group: 'programming',
-    component: RobotProgrammingInspector,
-    shouldRender: (entity) => entity.overlayType === 'complex',
-    order: 50,
+  register();
+};
+
+export const ensureDefaultInspectorsRegistered = (): void => {
+  ensureInspectorRegistered('entity-info', () => {
+    registerInspector({
+      id: 'entity-info',
+      label: 'Overview',
+      group: 'info',
+      component: EntityInfoInspector,
+      order: 10,
+    });
   });
-  hasRegistered = true;
+
+  ensureInspectorRegistered('robot-programming', () => {
+    registerInspector({
+      id: 'robot-programming',
+      label: 'Programming',
+      group: 'programming',
+      component: RobotProgrammingInspector,
+      shouldRender: (entity) => entity.overlayType === 'complex',
+      order: 50,
+    });
+  });
 };

--- a/src/state/__tests__/EntityOverlayManager.test.tsx
+++ b/src/state/__tests__/EntityOverlayManager.test.tsx
@@ -26,6 +26,20 @@ describe('EntityOverlayManager', () => {
     expect(result.current.selectedEntityId).toBe(1);
   });
 
+  it('opens an overlay and defaults to the info tab for simple entities', () => {
+    const { result } = renderHook(() => useEntityOverlayManager(), {
+      wrapper: EntityOverlayManagerProvider,
+    });
+
+    act(() => {
+      result.current.openOverlay(createOverlayData(8 as EntityId, 'simple'));
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.activeTab).toBe('info');
+    expect(result.current.selectedEntityId).toBe(8);
+  });
+
   it('supports specifying an initial tab when opening', () => {
     const { result } = renderHook(() => useEntityOverlayManager(), {
       wrapper: EntityOverlayManagerProvider,

--- a/src/styles/EntityInfoInspector.module.css
+++ b/src/styles/EntityInfoInspector.module.css
@@ -1,0 +1,111 @@
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-panel-outline);
+  box-shadow: var(--shadow-medium);
+  color: var(--color-text-primary);
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.summarySimple {
+  text-align: center;
+  align-items: center;
+}
+
+.summaryTitle {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.heading {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  text-align: left;
+}
+
+.description {
+  margin: 0;
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+}
+
+.summaryDetails {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.entityName {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.summaryHint {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.properties {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.property {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-panel-outline);
+  box-shadow: var(--shadow-soft);
+}
+
+.propertyLabel {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.propertyValue {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.placeholder {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 640px) {
+  .info {
+    padding: var(--space-5);
+  }
+
+  .properties {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- add an EntityInfoInspector component with styling to show names, descriptions, and properties in the overlay info tab
- register the inspector by default and expand unit tests covering simple overlays and overlay manager behavior
- exercise overlay integration tests to verify the new info bubble wiring

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d3d661b1b8832e8e1b7f221f9c0641