### PR TITLE
Add overlay drag-and-drop infrastructure

### DIFF
--- a/.kiro/specs/robot-overlay-inventory/tasks.md
+++ b/.kiro/specs/robot-overlay-inventory/tasks.md
@@ -1,13 +1,13 @@
 # Implementation Plan
 
-- [ ] 1. Create core overlay infrastructure and data models
+- [✅] 1. Create core overlay infrastructure and data models
   - Implement EntityOverlayManager context and provider
   - Create base Inspector interface and registration system
   - Define unified SlotSchema and EntityOverlayData types
   - Write unit tests for overlay state management
   - _Requirements: 1.1, 1.5, 6.1, 6.2_
 
-- [ ] 2. Implement entity selection and overlay lifecycle
+- [✅] 2. Implement entity selection and overlay lifecycle
   - Add entity click handlers to ECS systems
   - Create EntityOverlay modal component with tab navigation
   - Implement overlay opening/closing with focus management
@@ -15,7 +15,7 @@
   - Write tests for overlay lifecycle and accessibility
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
 
-- [ ] 3. Create simple entity info bubble system
+- [✅] 3. Create simple entity info bubble system
   - Implement EntityInfoInspector component
   - Add simple entity detection logic
   - Create info bubble layout and styling
@@ -23,7 +23,7 @@
   - Write tests for simple entity display
   - _Requirements: 5.1, 5.2, 5.3, 5.4_
 
-- [ ] 4. Build drag-and-drop infrastructure
+- [✅] 4. Build drag-and-drop infrastructure
   - Create DragContext and DropTarget interfaces
   - Implement drag preview system with live thumbnails
   - Add drop validation and snap-to-grid logic

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   EntityOverlayManagerProvider,
   useEntityOverlayManager,
 } from './state/EntityOverlayManager';
+import { DragProvider } from './state/DragContext';
 import { ProgrammingInspectorProvider } from './state/ProgrammingInspectorContext';
 import EntityOverlay from './components/EntityOverlay';
 import { ensureDefaultInspectorsRegistered } from './overlay/defaultInspectors';
@@ -230,7 +231,9 @@ const AppContent = (): JSX.Element => {
         </button>
       </div>
       <ProgrammingInspectorProvider value={programmingContextValue}>
-        <EntityOverlay onClose={handleOverlayClose} />
+        <DragProvider>
+          <EntityOverlay onClose={handleOverlayClose} />
+        </DragProvider>
       </ProgrammingInspectorProvider>
       {ONBOARDING_ENABLED ? (
         <OnboardingFlow

--- a/src/components/DragPreviewLayer.tsx
+++ b/src/components/DragPreviewLayer.tsx
@@ -1,0 +1,29 @@
+import { useDragContext } from '../state/DragContext';
+import styles from '../styles/DragPreviewLayer.module.css';
+
+const DragPreviewLayer = (): JSX.Element | null => {
+  const { isDragging, preview, pointerPosition } = useDragContext();
+
+  if (!isDragging || !preview) {
+    return null;
+  }
+
+  const { x: pointerX, y: pointerY } = pointerPosition ?? { x: 0, y: 0 };
+  const { x: offsetX, y: offsetY } = preview.offset ?? { x: 0, y: 0 };
+
+  const style = {
+    width: `${preview.width}px`,
+    height: `${preview.height}px`,
+    transform: `translate(${pointerX + offsetX}px, ${pointerY + offsetY}px)`,
+  } as const;
+
+  return (
+    <div className={styles.layer} aria-hidden="true">
+      <div className={styles.preview} style={style} data-testid="drag-preview">
+        {preview.render()}
+      </div>
+    </div>
+  );
+};
+
+export default DragPreviewLayer;

--- a/src/components/EntityOverlay.tsx
+++ b/src/components/EntityOverlay.tsx
@@ -5,6 +5,7 @@ import { getInspectorsForEntity } from '../overlay/inspectorRegistry';
 import type { InspectorDefinition } from '../overlay/inspectorRegistry';
 import type { InspectorTabId } from '../types/overlay';
 import styles from '../styles/SimulationOverlay.module.css';
+import DragPreviewLayer from './DragPreviewLayer';
 
 const TAB_LABELS: Record<InspectorTabId, string> = {
   systems: 'Systems',
@@ -207,6 +208,7 @@ const EntityOverlay = ({ onClose }: EntityOverlayProps): JSX.Element | null => {
             </button>
           </header>
         </div>
+        <DragPreviewLayer />
       </div>
     );
   }
@@ -301,6 +303,7 @@ const EntityOverlay = ({ onClose }: EntityOverlayProps): JSX.Element | null => {
           ))}
         </div>
       </div>
+      <DragPreviewLayer />
     </div>
   );
 };

--- a/src/components/__tests__/DragPreviewLayer.test.tsx
+++ b/src/components/__tests__/DragPreviewLayer.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import { describe, expect, it } from 'vitest';
+import DragPreviewLayer from '../DragPreviewLayer';
+import { DragProvider, useDragContext } from '../../state/DragContext';
+
+const StartDrag = (): null => {
+  const { startDrag } = useDragContext();
+
+  useEffect(() => {
+    startDrag(
+      {
+        source: { type: 'inventory-slot', id: 'slot-test' },
+        payload: { id: 'module-test', itemType: 'module' },
+        preview: {
+          render: () => <span data-testid="preview-content">Module</span>,
+          width: 40,
+          height: 40,
+        },
+      },
+      { pointer: { x: 10, y: 20 } },
+    );
+  }, [startDrag]);
+
+  return null;
+};
+
+describe('DragPreviewLayer', () => {
+  it('renders the drag preview when a session is active', async () => {
+    render(
+      <DragProvider>
+        <StartDrag />
+        <DragPreviewLayer />
+      </DragProvider>,
+    );
+
+    const preview = await screen.findByTestId('drag-preview');
+    expect(preview).toBeInTheDocument();
+    expect(screen.getByTestId('preview-content')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/EntityOverlay.test.tsx
+++ b/src/components/__tests__/EntityOverlay.test.tsx
@@ -10,6 +10,7 @@ import type { EntityOverlayData } from '../../types/overlay';
 import type { EntityId } from '../../simulation/ecs/world';
 import { registerInspector } from '../../overlay/inspectorRegistry';
 import EntityInfoInspector from '../inspectors/EntityInfoInspector';
+import { DragProvider } from '../../state/DragContext';
 
 const createOverlayData = (): EntityOverlayData => ({
   entityId: 5 as EntityId,
@@ -44,7 +45,9 @@ const OverlayHarness = ({ onClose }: { onClose: () => void }): JSX.Element => {
 const renderOverlay = (onClose: () => void) =>
   render(
     <EntityOverlayManagerProvider>
-      <OverlayHarness onClose={onClose} />
+      <DragProvider>
+        <OverlayHarness onClose={onClose} />
+      </DragProvider>
     </EntityOverlayManagerProvider>,
   );
 
@@ -114,7 +117,9 @@ describe('EntityOverlay', () => {
 
     render(
       <EntityOverlayManagerProvider>
-        <SimpleOverlayHarness onClose={vi.fn()} />
+        <DragProvider>
+          <SimpleOverlayHarness onClose={vi.fn()} />
+        </DragProvider>
       </EntityOverlayManagerProvider>,
     );
 

--- a/src/state/DragContext.tsx
+++ b/src/state/DragContext.tsx
@@ -1,0 +1,252 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type {
+  DragPreview,
+  DragSession,
+  DropResult,
+  DropTarget,
+  DropValidationResult,
+  Point,
+  SnapPosition,
+} from '../types/drag';
+
+interface DragContextValue {
+  isDragging: boolean;
+  session: DragSession | null;
+  preview: DragPreview | null;
+  pointerPosition: Point | null;
+  activeTargetId: string | null;
+  validation: DropValidationResult | null;
+  startDrag: (session: DragSession, options?: { pointer?: Point }) => void;
+  updatePreview: (preview: DragPreview | null) => void;
+  updatePointer: (position: Point | null) => void;
+  registerDropTarget: (target: DropTarget) => () => void;
+  setActiveTarget: (targetId: string | null) => DropValidationResult | null;
+  drop: (targetId?: string) => DropResult;
+  cancelDrag: (reason?: string) => void;
+}
+
+const DragContext = createContext<DragContextValue | undefined>(undefined);
+
+const DEFAULT_CANCEL_REASON = 'cancelled';
+
+const clampValue = (value: number, min?: number, max?: number): number => {
+  let result = value;
+  if (typeof min === 'number') {
+    result = Math.max(result, min);
+  }
+  if (typeof max === 'number') {
+    result = Math.min(result, max);
+  }
+  return result;
+};
+
+export interface GridSnapConfig {
+  origin: Point;
+  cellSize: { width: number; height: number };
+  clamp?: {
+    minColumn?: number;
+    maxColumn?: number;
+    minRow?: number;
+    maxRow?: number;
+  };
+}
+
+export const createGridSnapper = (config: GridSnapConfig) => {
+  const { origin, cellSize, clamp } = config;
+
+  if (cellSize.width <= 0 || cellSize.height <= 0) {
+    throw new Error('Grid snap cell sizes must be positive numbers.');
+  }
+
+  return (_session: DragSession, pointer: Point | null): SnapPosition | null => {
+    if (!pointer) {
+      return null;
+    }
+
+    const rawColumn = Math.round((pointer.x - origin.x) / cellSize.width);
+    const rawRow = Math.round((pointer.y - origin.y) / cellSize.height);
+
+    const column = clampValue(rawColumn, clamp?.minColumn, clamp?.maxColumn);
+    const row = clampValue(rawRow, clamp?.minRow, clamp?.maxRow);
+
+    return {
+      x: origin.x + column * cellSize.width,
+      y: origin.y + row * cellSize.height,
+    };
+  };
+};
+
+export const DragProvider = ({ children }: { children: ReactNode }): JSX.Element => {
+  const dropTargetsRef = useRef<Map<string, DropTarget>>(new Map());
+  const [session, setSession] = useState<DragSession | null>(null);
+  const [preview, setPreview] = useState<DragPreview | null>(null);
+  const [pointerPosition, setPointerPosition] = useState<Point | null>(null);
+  const [activeTargetId, setActiveTargetId] = useState<string | null>(null);
+  const [validation, setValidation] = useState<DropValidationResult | null>(null);
+
+  const resetState = useCallback(() => {
+    setSession(null);
+    setPreview(null);
+    setPointerPosition(null);
+    setActiveTargetId(null);
+    setValidation(null);
+  }, []);
+
+  const startDrag = useCallback(
+    (nextSession: DragSession, options?: { pointer?: Point }) => {
+      setSession(nextSession);
+      setPreview(nextSession.preview ?? null);
+      setPointerPosition(options?.pointer ?? null);
+      setActiveTargetId(null);
+      setValidation(null);
+    },
+    [],
+  );
+
+  const updatePreview = useCallback((nextPreview: DragPreview | null) => {
+    setPreview(nextPreview);
+  }, []);
+
+  const updatePointer = useCallback((position: Point | null) => {
+    setPointerPosition(position);
+  }, []);
+
+  const registerDropTarget = useCallback((target: DropTarget) => {
+    const map = dropTargetsRef.current;
+    if (map.has(target.id)) {
+      throw new Error(`Drop target with id "${target.id}" already registered.`);
+    }
+    map.set(target.id, target);
+
+    return () => {
+      const current = dropTargetsRef.current.get(target.id);
+      if (current === target) {
+        dropTargetsRef.current.delete(target.id);
+      }
+    };
+  }, []);
+
+  const resolveTarget = useCallback((targetId: string | null): DropTarget | null => {
+    if (!targetId) {
+      return null;
+    }
+    return dropTargetsRef.current.get(targetId) ?? null;
+  }, []);
+
+  const setActiveTarget = useCallback(
+    (targetId: string | null): DropValidationResult | null => {
+      const target = resolveTarget(targetId);
+      if (!session || !target) {
+        setActiveTargetId(null);
+        setValidation(null);
+        return null;
+      }
+
+      const result = target.accepts(session);
+      setActiveTargetId(targetId);
+      setValidation(result);
+      return result;
+    },
+    [resolveTarget, session],
+  );
+
+  const cancelDrag = useCallback(
+    (reason?: string) => {
+      if (session?.onDropCancel) {
+        session.onDropCancel({ reason: reason ?? DEFAULT_CANCEL_REASON });
+      }
+      resetState();
+    },
+    [resetState, session],
+  );
+
+  const drop = useCallback(
+    (targetId?: string): DropResult => {
+      if (!session) {
+        return { status: 'cancelled', reason: 'no-active-session' };
+      }
+
+      const resolvedTargetId = targetId ?? activeTargetId;
+      const target = resolveTarget(resolvedTargetId ?? null);
+
+      if (!target) {
+        cancelDrag('no-target');
+        return { status: 'cancelled', reason: 'no-target' };
+      }
+
+      const validationResult = target.accepts(session);
+      if (!validationResult.canDrop) {
+        cancelDrag(validationResult.reason ?? 'invalid-drop');
+        return { status: 'cancelled', reason: validationResult.reason ?? 'invalid-drop' };
+      }
+
+      const snapPosition = target.getSnapPosition
+        ? target.getSnapPosition(session, pointerPosition)
+        : null;
+
+      const success = {
+        target,
+        snapPosition,
+        pointerPosition,
+        validation: validationResult,
+      } as const;
+
+      target.onDrop(session, success);
+      session.onDropSuccess?.(success);
+      resetState();
+
+      return { status: 'success', ...success };
+    },
+    [activeTargetId, cancelDrag, pointerPosition, resetState, resolveTarget, session],
+  );
+
+  const value = useMemo<DragContextValue>(
+    () => ({
+      isDragging: session !== null,
+      session,
+      preview,
+      pointerPosition,
+      activeTargetId,
+      validation,
+      startDrag,
+      updatePreview,
+      updatePointer,
+      registerDropTarget,
+      setActiveTarget,
+      drop,
+      cancelDrag,
+    }),
+    [
+      activeTargetId,
+      cancelDrag,
+      drop,
+      pointerPosition,
+      preview,
+      registerDropTarget,
+      session,
+      setActiveTarget,
+      startDrag,
+      updatePointer,
+      updatePreview,
+      validation,
+    ],
+  );
+
+  return <DragContext.Provider value={value}>{children}</DragContext.Provider>;
+};
+
+export const useDragContext = (): DragContextValue => {
+  const context = useContext(DragContext);
+  if (!context) {
+    throw new Error('useDragContext must be used within a DragProvider');
+  }
+  return context;
+};

--- a/src/state/__tests__/DragContext.test.tsx
+++ b/src/state/__tests__/DragContext.test.tsx
@@ -1,0 +1,179 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DragProvider, createGridSnapper, useDragContext } from '../DragContext';
+import type { DragSession } from '../../types/drag';
+import type { ReactNode } from 'react';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <DragProvider>{children}</DragProvider>
+);
+
+const createSession = (overrides: Partial<DragSession> = {}): DragSession => ({
+  source: {
+    type: 'inventory-slot',
+    id: 'slot-1',
+  },
+  payload: {
+    id: 'module-1',
+    itemType: 'module',
+  },
+  preview: {
+    render: () => null,
+    width: 32,
+    height: 32,
+    offset: { x: -16, y: -16 },
+  },
+  ...overrides,
+});
+
+describe('DragContext', () => {
+  it('starts a drag session and records pointer position', () => {
+    const { result } = renderHook(() => useDragContext(), { wrapper });
+
+    act(() => {
+      result.current.startDrag(createSession(), { pointer: { x: 120, y: 80 } });
+    });
+
+    expect(result.current.isDragging).toBe(true);
+    expect(result.current.pointerPosition).toEqual({ x: 120, y: 80 });
+    expect(result.current.preview?.width).toBe(32);
+
+    act(() => {
+      result.current.cancelDrag();
+    });
+
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('performs a successful drop with snap-to-grid details', () => {
+    const onDrop = vi.fn();
+    const onDropSuccess = vi.fn();
+    const { result } = renderHook(() => useDragContext(), { wrapper });
+
+    act(() => {
+      result.current.registerDropTarget({
+        id: 'target-success',
+        type: 'inventory-slot',
+        accepts: () => ({ canDrop: true }),
+        getSnapPosition: createGridSnapper({
+          origin: { x: 0, y: 0 },
+          cellSize: { width: 50, height: 50 },
+        }),
+        onDrop,
+      });
+    });
+
+    act(() => {
+      result.current.startDrag(
+        createSession({
+          onDropSuccess,
+        }),
+        { pointer: { x: 74, y: 125 } },
+      );
+    });
+
+    let dropResult: ReturnType<typeof result.current.drop> | null = null;
+    act(() => {
+      dropResult = result.current.drop('target-success');
+    });
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const dropArgs = onDrop.mock.calls[0];
+    expect(dropArgs[1]).toMatchObject({
+      snapPosition: { x: 50, y: 150 },
+      validation: { canDrop: true },
+    });
+
+    expect(onDropSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapPosition: { x: 50, y: 150 },
+        validation: { canDrop: true },
+      }),
+    );
+
+    expect(dropResult).not.toBeNull();
+    expect(dropResult).toMatchObject({
+      status: 'success',
+      snapPosition: { x: 50, y: 150 },
+    });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('cancels a drop when validation fails', () => {
+    const onDrop = vi.fn();
+    const onDropCancel = vi.fn();
+    const { result } = renderHook(() => useDragContext(), { wrapper });
+
+    act(() => {
+      result.current.registerDropTarget({
+        id: 'target-invalid',
+        type: 'inventory-slot',
+        accepts: () => ({ canDrop: false, reason: 'occupied' }),
+        onDrop,
+      });
+    });
+
+    act(() => {
+      result.current.startDrag(createSession({ onDropCancel }));
+    });
+
+    let dropResult: ReturnType<typeof result.current.drop> | null = null;
+    act(() => {
+      dropResult = result.current.drop('target-invalid');
+    });
+
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onDropCancel).toHaveBeenCalledWith({ reason: 'occupied' });
+    expect(dropResult).toEqual({ status: 'cancelled', reason: 'occupied' });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('evaluates drop targets when activated', () => {
+    const { result } = renderHook(() => useDragContext(), { wrapper });
+
+    act(() => {
+      result.current.registerDropTarget({
+        id: 'target-hover',
+        type: 'chassis-slot',
+        accepts: () => ({ canDrop: true }),
+        onDrop: vi.fn(),
+      });
+    });
+
+    act(() => {
+      result.current.startDrag(createSession());
+    });
+
+    let validation: ReturnType<typeof result.current.setActiveTarget> | null = null;
+    act(() => {
+      validation = result.current.setActiveTarget('target-hover');
+    });
+
+    expect(validation).toEqual({ canDrop: true });
+    expect(result.current.activeTargetId).toBe('target-hover');
+
+    act(() => {
+      result.current.setActiveTarget(null);
+    });
+
+    expect(result.current.activeTargetId).toBeNull();
+    expect(result.current.validation).toBeNull();
+  });
+});
+
+describe('createGridSnapper', () => {
+  it('snaps to the nearest grid coordinate and respects clamps', () => {
+    const snapper = createGridSnapper({
+      origin: { x: 20, y: 40 },
+      cellSize: { width: 30, height: 30 },
+      clamp: { minColumn: 0, maxColumn: 2, minRow: -1, maxRow: 1 },
+    });
+
+    const snapped = snapper(createSession(), { x: 200, y: -80 });
+
+    expect(snapped).toEqual({ x: 80, y: 10 });
+
+    const centreSnap = snapper(createSession(), null);
+    expect(centreSnap).toBeNull();
+  });
+});

--- a/src/styles/DragPreviewLayer.module.css
+++ b/src/styles/DragPreviewLayer.module.css
@@ -1,0 +1,14 @@
+.layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.preview {
+  position: absolute;
+  will-change: transform;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/types/drag.ts
+++ b/src/types/drag.ts
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import type { EntityId } from '../simulation/ecs/world';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface DragPreviewOffset {
+  x: number;
+  y: number;
+}
+
+export interface DragPreview {
+  render: () => ReactNode;
+  width: number;
+  height: number;
+  offset?: DragPreviewOffset;
+}
+
+export interface DragSource {
+  type: string;
+  id: string;
+  entityId?: EntityId;
+  slotId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DragPayload {
+  id: string;
+  itemType: string;
+  stackCount?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DropValidationResult {
+  canDrop: boolean;
+  reason?: string;
+}
+
+export interface SnapPosition {
+  x: number;
+  y: number;
+}
+
+export interface DragSession {
+  source: DragSource;
+  payload: DragPayload;
+  preview?: DragPreview;
+  onDropSuccess?: (details: DropSuccessDetails) => void;
+  onDropCancel?: (details: DropCancelDetails) => void;
+}
+
+export interface DropTarget {
+  id: string;
+  type: string;
+  metadata?: Record<string, unknown>;
+  accepts: (session: DragSession) => DropValidationResult;
+  onDrop: (session: DragSession, details: DropSuccessDetails) => void;
+  getSnapPosition?: (session: DragSession, pointer: Point | null) => SnapPosition | null;
+}
+
+export interface DropSuccessDetails {
+  target: DropTarget;
+  snapPosition: SnapPosition | null;
+  pointerPosition: Point | null;
+  validation: DropValidationResult;
+}
+
+export interface DropCancelDetails {
+  reason: string;
+}
+
+export type DropResult =
+  | ({ status: 'success' } & DropSuccessDetails)
+  | ({ status: 'cancelled' } & DropCancelDetails);


### PR DESCRIPTION
## Summary
- add shared drag types and a DragContext with grid snapping utilities to manage overlay drag-and-drop sessions
- render a DragPreviewLayer for live thumbnails and cover the new infrastructure with unit tests
- wrap the overlay in the new provider and mark the drag-and-drop task as complete in the specification plan

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e6fc8cec832ea60ef1055a15d1be