### PR TITLE
Complete chassis inspector drag-and-drop

### DIFF
--- a/.kiro/specs/robot-overlay-inventory/tasks.md
+++ b/.kiro/specs/robot-overlay-inventory/tasks.md
@@ -31,7 +31,7 @@
   - Write tests for drag-and-drop core functionality
   - _Requirements: 6.5, 6.6, 6.7, 6.8_
 
-- [ ] 5. Implement ChassisInspector component
+- [✅] 5. Implement ChassisInspector component
   - Create chassis slot rendering with module thumbnails
   - Add module tooltip display on hover
   - Implement chassis-specific drag-and-drop handlers

--- a/src/components/inspectors/ChassisInspector.tsx
+++ b/src/components/inspectors/ChassisInspector.tsx
@@ -1,0 +1,420 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+import ModuleIcon from '../ModuleIcon';
+import type { InspectorProps } from '../../overlay/inspectorRegistry';
+import { useEntityOverlayManager } from '../../state/EntityOverlayManager';
+import { useDragContext } from '../../state/DragContext';
+import type { DragSession, DropValidationResult } from '../../types/drag';
+import type { SlotSchema } from '../../types/overlay';
+import type { ModuleBlueprint } from '../../simulation/robot/modules/moduleLibrary';
+import { MODULE_LIBRARY } from '../../simulation/robot/modules/moduleLibrary';
+import styles from '../../styles/ChassisInspector.module.css';
+
+const MODULE_BLUEPRINT_MAP = new Map<string, ModuleBlueprint>(
+  MODULE_LIBRARY.map((module) => [module.id, module]),
+);
+
+const sortSlots = (slots: SlotSchema[]): SlotSchema[] => {
+  return [...slots].sort((a, b) => a.index - b.index);
+};
+
+const getSlotTargetId = (entityId: InspectorProps['entity']['entityId'], slotId: string): string => {
+  return `chassis-slot-${entityId}-${slotId}`;
+};
+
+const resolveBlueprint = (moduleId: string | null): ModuleBlueprint | null => {
+  if (!moduleId) {
+    return null;
+  }
+  return MODULE_BLUEPRINT_MAP.get(moduleId) ?? null;
+};
+
+const describeSlotType = (slot: SlotSchema): string => {
+  if (slot.metadata.locked) {
+    return 'Locked slot';
+  }
+  if (slot.metadata.moduleSubtype) {
+    return `${slot.metadata.moduleSubtype} slot`;
+  }
+  return 'Universal slot';
+};
+
+interface ChassisSlotProps {
+  entityId: InspectorProps['entity']['entityId'];
+  slot: SlotSchema;
+  blueprint: ModuleBlueprint | null;
+  hovered: boolean;
+  activeTargetId: string | null;
+  validation: DropValidationResult | null;
+  isDragging: boolean;
+  onHoverChange: (slotId: string | null) => void;
+  onStartDrag: (event: ReactPointerEvent<HTMLButtonElement>, slot: SlotSchema) => void;
+  onDrop: (slotId: string, session: DragSession) => void;
+  registerDropTarget: ReturnType<typeof useDragContext>['registerDropTarget'];
+  setActiveTarget: ReturnType<typeof useDragContext>['setActiveTarget'];
+  validateDrop: (slot: SlotSchema, session: DragSession) => DropValidationResult;
+}
+
+const ChassisSlot = ({
+  entityId,
+  slot,
+  blueprint,
+  hovered,
+  activeTargetId,
+  validation,
+  isDragging,
+  onHoverChange,
+  onStartDrag,
+  onDrop,
+  registerDropTarget,
+  setActiveTarget,
+  validateDrop,
+}: ChassisSlotProps): JSX.Element => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const tooltipId = `chassis-slot-tooltip-${entityId}-${slot.id}`;
+  const targetId = getSlotTargetId(entityId, slot.id);
+
+  useEffect(() => {
+    const unregister = registerDropTarget({
+      id: targetId,
+      type: 'chassis-slot',
+      metadata: { entityId, slotId: slot.id },
+      accepts: (session) => validateDrop(slot, session),
+      onDrop: (session) => onDrop(slot.id, session),
+      getSnapPosition: () => {
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) {
+          return null;
+        }
+        return {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        } as const;
+      },
+    });
+    return unregister;
+  }, [entityId, onDrop, registerDropTarget, slot, targetId, validateDrop]);
+
+  const dropState = useMemo(() => {
+    if (activeTargetId !== targetId) {
+      return undefined;
+    }
+    if (!validation) {
+      return undefined;
+    }
+    return validation.canDrop ? 'active-valid' : 'active-invalid';
+  }, [activeTargetId, targetId, validation]);
+
+  const slotTypeLabel = describeSlotType(slot);
+  const occupantName = blueprint?.title ?? slot.occupantId ?? 'Empty slot';
+
+  const handlePointerEnter = useCallback(() => {
+    if (isDragging) {
+      setActiveTarget(targetId);
+    }
+  }, [isDragging, setActiveTarget, targetId]);
+
+  const handlePointerLeave = useCallback(() => {
+    if (isDragging && activeTargetId === targetId) {
+      setActiveTarget(null);
+    }
+  }, [activeTargetId, isDragging, setActiveTarget, targetId]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={styles.slot}
+      data-drop-state={dropState}
+      data-slot-locked={slot.metadata.locked ? 'true' : undefined}
+      data-testid={`chassis-slot-${slot.id}`}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      aria-describedby={slot.occupantId ? tooltipId : undefined}
+    >
+      <p className={styles.slotLabel}>{`Slot ${slot.index + 1}`}</p>
+      <p className={styles.slotType}>{slotTypeLabel}</p>
+      <button
+        type="button"
+        className={styles.moduleButton}
+        onPointerDown={(event) => onStartDrag(event, slot)}
+        onMouseEnter={() => onHoverChange(slot.id)}
+        onMouseLeave={() => onHoverChange(null)}
+        onFocus={() => onHoverChange(slot.id)}
+        onBlur={() => onHoverChange(null)}
+        disabled={!slot.occupantId || slot.metadata.locked}
+        aria-label={occupantName}
+      >
+        {blueprint ? (
+          <ModuleIcon variant={blueprint.icon} />
+        ) : (
+          <span className={styles.emptyLabel}>Add module</span>
+        )}
+        {slot.occupantId ? <span className={styles.moduleName}>{occupantName}</span> : null}
+      </button>
+      {hovered && blueprint ? (
+        <div role="tooltip" id={tooltipId} className={styles.tooltip}>
+          <p className={styles.tooltipTitle}>{blueprint.title}</p>
+          <p className={styles.tooltipSummary}>{blueprint.summary}</p>
+          <ul className={styles.tooltipStats}>
+            <li>{`Provides: ${blueprint.provides.length > 0 ? blueprint.provides.join(', ') : 'None'}`}</li>
+            <li>{`Requires: ${blueprint.requires.length > 0 ? blueprint.requires.join(', ') : 'None'}`}</li>
+            <li>{`Capacity: ${blueprint.capacityCost}`}</li>
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const ChassisInspector = ({ entity }: InspectorProps): JSX.Element => {
+  const manager = useEntityOverlayManager();
+  const {
+    registerDropTarget,
+    setActiveTarget,
+    activeTargetId,
+    validation,
+    isDragging,
+    startDrag,
+    updatePointer,
+    drop,
+    cancelDrag,
+  } = useDragContext();
+
+  const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const [hoveredSlotId, setHoveredSlotId] = useState<string | null>(null);
+
+  const initialSlots = useMemo(() => sortSlots(entity.chassis?.slots ?? []), [entity.chassis?.slots]);
+  const [slots, setSlots] = useState<SlotSchema[]>(initialSlots);
+
+  useEffect(() => {
+    setSlots(sortSlots(entity.chassis?.slots ?? []));
+  }, [entity.chassis?.slots]);
+
+  useEffect(() => {
+    return () => {
+      pointerCleanupRef.current?.();
+    };
+  }, []);
+
+  const validateDrop = useCallback(
+    (slot: SlotSchema, session: DragSession): DropValidationResult => {
+      if (session.payload.itemType !== 'module') {
+        return { canDrop: false, reason: 'unsupported-item' };
+      }
+      if (slot.metadata.locked && session.source.slotId !== slot.id) {
+        return { canDrop: false, reason: 'slot-locked' };
+      }
+      if (session.source.type === 'chassis-slot') {
+        if (session.source.entityId !== entity.entityId) {
+          return { canDrop: false, reason: 'different-entity' };
+        }
+        return { canDrop: true };
+      }
+      if (slot.metadata.locked) {
+        return { canDrop: false, reason: 'slot-locked' };
+      }
+      return { canDrop: true };
+    },
+    [entity.entityId],
+  );
+
+  const handleDropOnSlot = useCallback(
+    (targetSlotId: string, session: DragSession) => {
+      const chassis = entity.chassis;
+      if (!chassis) {
+        return;
+      }
+
+      setSlots((currentSlots) => {
+        const next = currentSlots.map((slot) => ({ ...slot }));
+        const targetIndex = next.findIndex((slot) => slot.id === targetSlotId);
+        if (targetIndex === -1) {
+          return currentSlots;
+        }
+
+        const targetSlot = next[targetIndex]!;
+
+        if (session.source.type === 'chassis-slot' && session.source.slotId) {
+          const sourceIndex = next.findIndex((slot) => slot.id === session.source.slotId);
+          if (sourceIndex === -1) {
+            return currentSlots;
+          }
+          if (sourceIndex === targetIndex) {
+            return currentSlots;
+          }
+
+          const sourceSlot = next[sourceIndex]!;
+          const destinationSlot = next[targetIndex]!;
+
+          next[sourceIndex] = { ...sourceSlot, occupantId: destinationSlot.occupantId };
+          next[targetIndex] = { ...destinationSlot, occupantId: session.payload.id };
+
+          const sorted = sortSlots(next);
+          const updatedEntity = {
+            ...entity,
+            chassis: { capacity: chassis.capacity, slots: sorted },
+          };
+          Promise.resolve().then(() => {
+            manager.upsertEntityData(updatedEntity);
+          });
+          return sorted;
+        }
+
+        if (targetSlot.occupantId === session.payload.id) {
+          return currentSlots;
+        }
+
+        next[targetIndex] = { ...targetSlot, occupantId: session.payload.id };
+        const sorted = sortSlots(next);
+        const updatedEntity = {
+          ...entity,
+          chassis: { capacity: chassis.capacity, slots: sorted },
+        };
+        Promise.resolve().then(() => {
+          manager.upsertEntityData(updatedEntity);
+        });
+        return sorted;
+      });
+    },
+    [entity, manager],
+  );
+
+  const createPreview = useCallback((blueprint: ModuleBlueprint | null) => {
+    if (!blueprint) {
+      return undefined;
+    }
+    return {
+      render: () => (
+        <div className={styles.preview}>
+          <ModuleIcon variant={blueprint.icon} />
+          <span className={styles.previewName}>{blueprint.title}</span>
+        </div>
+      ),
+      width: 120,
+      height: 120,
+      offset: { x: -60, y: -60 },
+    } as const;
+  }, []);
+
+  const handleStartDrag = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, slot: SlotSchema) => {
+      if (event.button !== 0) {
+        return;
+      }
+      if (!slot.occupantId) {
+        return;
+      }
+      if (slot.metadata.locked) {
+        return;
+      }
+
+      event.preventDefault();
+      setHoveredSlotId(null);
+
+      const blueprint = resolveBlueprint(slot.occupantId);
+      const preview = createPreview(blueprint);
+      const pointer = { x: event.clientX, y: event.clientY } as const;
+
+      startDrag(
+        {
+          source: {
+            type: 'chassis-slot',
+            id: slot.id,
+            entityId: entity.entityId,
+            slotId: slot.id,
+            metadata: { slotIndex: slot.index },
+          },
+          payload: {
+            id: slot.occupantId,
+            itemType: 'module',
+            metadata: { source: 'chassis' },
+          },
+          preview,
+          onDropCancel: () => {
+            setHoveredSlotId(null);
+          },
+        },
+        { pointer },
+      );
+
+      pointerCleanupRef.current?.();
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        updatePointer({ x: moveEvent.clientX, y: moveEvent.clientY });
+      };
+
+      const cleanup = () => {
+        window.removeEventListener('pointermove', handleMove);
+        window.removeEventListener('pointerup', handleUp);
+        window.removeEventListener('pointercancel', handleCancel);
+        pointerCleanupRef.current = null;
+      };
+
+      const handleUp = (upEvent: PointerEvent) => {
+        updatePointer({ x: upEvent.clientX, y: upEvent.clientY });
+        drop();
+        cleanup();
+      };
+
+      const handleCancel = () => {
+        cancelDrag('pointer-cancelled');
+        cleanup();
+      };
+
+      window.addEventListener('pointermove', handleMove);
+      window.addEventListener('pointerup', handleUp, { once: true });
+      window.addEventListener('pointercancel', handleCancel, { once: true });
+
+      pointerCleanupRef.current = cleanup;
+    },
+    [cancelDrag, createPreview, drop, entity.entityId, startDrag, updatePointer],
+  );
+
+  if (!entity.chassis) {
+    return (
+      <section className={styles.inspector} aria-label="Chassis inspector">
+        <p className={styles.placeholder}>Chassis data is not available for this entity.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.inspector} aria-label="Chassis inspector" data-testid="chassis-inspector">
+      <header className={styles.header}>
+        <h3 className={styles.title}>Chassis Configuration</h3>
+        <p className={styles.summary}>Arrange installed modules and review their capabilities.</p>
+      </header>
+      <div className={styles.grid}>
+        {slots.map((slot) => {
+          const blueprint = resolveBlueprint(slot.occupantId);
+          return (
+            <ChassisSlot
+              key={slot.id}
+              entityId={entity.entityId}
+              slot={slot}
+              blueprint={blueprint}
+              hovered={hoveredSlotId === slot.id}
+              activeTargetId={activeTargetId}
+              validation={validation}
+              isDragging={isDragging}
+              onHoverChange={setHoveredSlotId}
+              onStartDrag={handleStartDrag}
+              onDrop={handleDropOnSlot}
+              registerDropTarget={registerDropTarget}
+              setActiveTarget={setActiveTarget}
+              validateDrop={validateDrop}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default ChassisInspector;

--- a/src/components/inspectors/__tests__/ChassisInspector.test.tsx
+++ b/src/components/inspectors/__tests__/ChassisInspector.test.tsx
@@ -1,0 +1,191 @@
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import ChassisInspector from '../ChassisInspector';
+import { EntityOverlayManagerProvider } from '../../../state/EntityOverlayManager';
+import { DragProvider, useDragContext } from '../../../state/DragContext';
+import type { EntityOverlayData, SlotSchema } from '../../../types/overlay';
+import type { DragSession, DropTarget } from '../../../types/drag';
+import type { EntityId } from '../../../simulation/ecs/world';
+import { useEffect } from 'react';
+
+const createSlot = (id: string, index: number, occupantId: string | null): SlotSchema => ({
+  id,
+  index,
+  occupantId,
+  metadata: {
+    stackable: false,
+    moduleSubtype: undefined,
+    locked: false,
+  },
+});
+
+const createEntity = (slots: SlotSchema[]): EntityOverlayData => ({
+  entityId: 42 as EntityId,
+  name: 'Test Robot',
+  description: 'Prototype exploration unit',
+  overlayType: 'complex',
+  chassis: {
+    capacity: slots.length,
+    slots,
+  },
+});
+
+const dropTargets = new Map<string, DropTarget>();
+
+const waitForDropTarget = async (targetId: string): Promise<DropTarget> => {
+  await waitFor(() => {
+    if (!dropTargets.has(targetId)) {
+      throw new Error(`Drop target ${targetId} not yet registered`);
+    }
+  });
+  return dropTargets.get(targetId)!;
+};
+
+const createModuleSession = (
+  entity: EntityOverlayData,
+  sourceSlotId: string,
+  moduleId: string,
+): DragSession => ({
+  source: {
+    type: 'chassis-slot',
+    id: sourceSlotId,
+    entityId: entity.entityId,
+    slotId: sourceSlotId,
+  },
+  payload: {
+    id: moduleId,
+    itemType: 'module',
+  },
+});
+
+const DragController = (): null => {
+  const api = useDragContext();
+  useEffect(() => {
+    const originalRegister = api.registerDropTarget;
+    api.registerDropTarget = (target) => {
+      dropTargets.set(target.id, target);
+      return originalRegister(target);
+    };
+    return () => {
+      api.registerDropTarget = originalRegister;
+      dropTargets.clear();
+    };
+  }, [api]);
+  return null;
+};
+
+const renderInspector = (entity: EntityOverlayData) =>
+  render(
+    <EntityOverlayManagerProvider>
+      <DragProvider>
+        <DragController />
+        <ChassisInspector entity={entity} onClose={() => {}} />
+      </DragProvider>
+    </EntityOverlayManagerProvider>,
+  );
+
+afterEach(() => {
+  cleanup();
+  dropTargets.clear();
+});
+
+describe('ChassisInspector', () => {
+  it('renders chassis slots with installed module information', async () => {
+    const slots = [
+      createSlot('core-0', 0, 'core.movement'),
+      createSlot('extension-0', 1, 'arm.manipulator'),
+      createSlot('utility-0', 2, null),
+    ];
+    const entity = createEntity(slots);
+
+    renderInspector(entity);
+
+    expect(await screen.findByTestId('chassis-inspector')).toBeInTheDocument();
+    expect(screen.getByText('Chassis Configuration')).toBeInTheDocument();
+    expect(screen.getByText('Locomotion Thrusters Mk1')).toBeInTheDocument();
+    expect(screen.getByText('Precision Manipulator Rig')).toBeInTheDocument();
+    const renderedSlots = screen.getAllByTestId(/chassis-slot-/);
+    expect(renderedSlots).toHaveLength(3);
+  });
+
+  it('displays module tooltips on hover', async () => {
+    const slots = [
+      createSlot('core-0', 0, 'core.movement'),
+      createSlot('extension-0', 1, null),
+      createSlot('utility-0', 2, null),
+    ];
+    const entity = createEntity(slots);
+
+    renderInspector(entity);
+
+    const coreSlot = await screen.findByTestId('chassis-slot-core-0');
+    const movementButton = within(coreSlot).getByRole('button');
+    fireEvent.mouseEnter(movementButton);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Locomotion Thrusters Mk1');
+    expect(tooltip).toHaveTextContent('Provides: movement.linear, movement.angular');
+  });
+
+  it('swaps modules when dragging onto another occupied slot', async () => {
+    const slots = [
+      createSlot('core-0', 0, 'core.movement'),
+      createSlot('extension-0', 1, 'arm.manipulator'),
+      createSlot('utility-0', 2, null),
+    ];
+    const entity = createEntity(slots);
+
+    renderInspector(entity);
+
+    const targetId = `chassis-slot-${entity.entityId}-extension-0`;
+    const target = await waitForDropTarget(targetId);
+    const session = createModuleSession(entity, 'core-0', 'core.movement');
+    const validation = target.accepts(session);
+    expect(validation.canDrop).toBe(true);
+
+    act(() => {
+      target.onDrop(session, {
+        target,
+        snapPosition: null,
+        pointerPosition: null,
+        validation,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chassis-slot-core-0')).toHaveTextContent('Precision Manipulator Rig');
+      expect(screen.getByTestId('chassis-slot-extension-0')).toHaveTextContent('Locomotion Thrusters Mk1');
+    });
+  });
+
+  it('moves modules into empty slots when dropped on an unoccupied slot', async () => {
+    const slots = [
+      createSlot('core-0', 0, 'core.movement'),
+      createSlot('extension-0', 1, null),
+      createSlot('utility-0', 2, null),
+    ];
+    const entity = createEntity(slots);
+
+    renderInspector(entity);
+
+    const targetId = `chassis-slot-${entity.entityId}-extension-0`;
+    const target = await waitForDropTarget(targetId);
+    const session = createModuleSession(entity, 'core-0', 'core.movement');
+    const validation = target.accepts(session);
+    expect(validation.canDrop).toBe(true);
+
+    act(() => {
+      target.onDrop(session, {
+        target,
+        snapPosition: null,
+        pointerPosition: null,
+        validation,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chassis-slot-core-0')).not.toHaveTextContent('Locomotion Thrusters Mk1');
+      expect(screen.getByTestId('chassis-slot-extension-0')).toHaveTextContent('Locomotion Thrusters Mk1');
+    });
+  });
+});

--- a/src/overlay/defaultInspectors.ts
+++ b/src/overlay/defaultInspectors.ts
@@ -1,3 +1,4 @@
+import ChassisInspector from '../components/inspectors/ChassisInspector';
 import EntityInfoInspector from '../components/inspectors/EntityInfoInspector';
 import RobotProgrammingInspector from '../components/inspectors/RobotProgrammingInspector';
 import { getInspectorDefinitions, registerInspector } from './inspectorRegistry';
@@ -11,6 +12,17 @@ const ensureInspectorRegistered = (id: string, register: () => void): void => {
 };
 
 export const ensureDefaultInspectorsRegistered = (): void => {
+  ensureInspectorRegistered('robot-chassis', () => {
+    registerInspector({
+      id: 'robot-chassis',
+      label: 'Chassis',
+      group: 'systems',
+      component: ChassisInspector,
+      shouldRender: (entity) => entity.overlayType === 'complex' && Boolean(entity.chassis),
+      order: 10,
+    });
+  });
+
   ensureInspectorRegistered('entity-info', () => {
     registerInspector({
       id: 'entity-info',

--- a/src/styles/ChassisInspector.module.css
+++ b/src/styles/ChassisInspector.module.css
@@ -1,0 +1,184 @@
+.inspector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-2) 0;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.summary {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(110, 130, 170, 0.35);
+  background: rgba(10, 16, 28, 0.55);
+  min-height: 184px;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast);
+}
+
+.slot[data-drop-state='active-valid'] {
+  border-color: var(--color-accent-cyan);
+  box-shadow: 0 10px 24px rgba(80, 210, 200, 0.35);
+}
+
+.slot[data-drop-state='active-invalid'] {
+  border-color: rgba(255, 107, 107, 0.7);
+  box-shadow: 0 10px 24px rgba(255, 107, 107, 0.25);
+}
+
+.slot[data-slot-locked='true'] {
+  border-style: dashed;
+  opacity: 0.75;
+}
+
+.slotLabel {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-muted);
+}
+
+.slotType {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.moduleButton {
+  appearance: none;
+  border: none;
+  background: rgba(30, 40, 60, 0.55);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-3);
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+}
+
+.moduleButton:hover,
+.moduleButton:focus-visible {
+  outline: none;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  background: rgba(40, 60, 90, 0.75);
+}
+
+.moduleButton:disabled {
+  cursor: default;
+  opacity: 0.6;
+  background: rgba(25, 35, 55, 0.35);
+}
+
+.moduleName {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+.emptyLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + var(--space-2));
+  transform: translateX(-50%);
+  width: min(260px, 90vw);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: rgba(12, 20, 34, 0.95);
+  border: 1px solid rgba(100, 249, 255, 0.35);
+  box-shadow: 0 18px 34px rgba(10, 20, 34, 0.45);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.tooltipTitle {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.tooltipSummary {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.tooltipStats {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.tooltipStats li {
+  font-size: var(--font-size-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  width: 100%;
+  height: 100%;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: rgba(18, 26, 40, 0.92);
+  color: var(--color-text-primary);
+}
+
+.previewName {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}


### PR DESCRIPTION
## Summary
- implement the ChassisInspector component with drag handling, tooltip support, and preview rendering
- add dedicated styling and register the inspector with the default overlay definitions
- cover chassis swap and move flows via drop-target driven unit tests and mark the spec task as complete

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d3f350c774832eaafc9852774a79cb