### PR TITLE
Extend inventory store with slot schema support

### DIFF
--- a/.kiro/specs/robot-overlay-inventory/tasks.md
+++ b/.kiro/specs/robot-overlay-inventory/tasks.md
@@ -55,7 +55,7 @@
   - Write tests for inventory inspector functionality
   - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9_
 
-- [ ] 8. Extend InventoryStore with slot schema support
+- [✅] 8. Extend InventoryStore with slot schema support
   - Add slot-based inventory access methods
   - Implement item stacking and splitting logic
   - Add inventory change event emission

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,26 +33,21 @@ interface InventoryOverlayView {
 }
 
 const buildInventoryOverlayData = (snapshot: InventorySnapshot): InventoryOverlayView => {
-  const entries = snapshot.entries ?? [];
-  const slotCount = Math.max(MINIMUM_INVENTORY_SLOTS, entries.length);
-  const slots: SlotSchema[] = [];
-
-  for (let index = 0; index < slotCount; index += 1) {
-    const entry = entries[index];
-    slots.push({
+  const sortedSlots = [...(snapshot.slots ?? [])].sort((a, b) => a.index - b.index);
+  const capacity = sortedSlots.length || Math.max(snapshot.slotCapacity ?? 0, MINIMUM_INVENTORY_SLOTS);
+  if (sortedSlots.length >= capacity) {
+    return { capacity, slots: sortedSlots };
+  }
+  const paddedSlots: SlotSchema[] = [...sortedSlots];
+  for (let index = sortedSlots.length; index < capacity; index += 1) {
+    paddedSlots.push({
       id: `inventory-${index}`,
       index,
-      occupantId: entry ? entry.resource : null,
-      stackCount: entry && entry.quantity > 1 ? entry.quantity : undefined,
-      metadata: {
-        stackable: true,
-        moduleSubtype: undefined,
-        locked: false,
-      },
+      occupantId: null,
+      metadata: { stackable: true, moduleSubtype: undefined, locked: false },
     });
   }
-
-  return { capacity: slotCount, slots };
+  return { capacity, slots: paddedSlots };
 };
 
 const areInventoryOverlaysEqual = (

--- a/src/simulation/robot/__tests__/inventory.test.ts
+++ b/src/simulation/robot/__tests__/inventory.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { InventoryStore } from '../inventory';
+
+const findSlotByOccupant = (snapshot: ReturnType<InventoryStore['getSnapshot']>, occupantId: string | null) => {
+  return snapshot.slots.find((slot) => slot.occupantId === occupantId) ?? null;
+};
+
+describe('InventoryStore slot schema integration', () => {
+  it('exposes a default slot schema with empty slots', () => {
+    const store = new InventoryStore();
+    const snapshot = store.getSnapshot();
+
+    expect(snapshot.slotCapacity).toBeGreaterThanOrEqual(10);
+    expect(snapshot.slots).toHaveLength(snapshot.slotCapacity);
+    for (let index = 0; index < snapshot.slotCapacity; index += 1) {
+      const slot = snapshot.slots[index]!;
+      expect(slot.id).toBe(`inventory-${index}`);
+      expect(slot.index).toBe(index);
+      expect(slot.occupantId).toBeNull();
+      expect(slot.metadata.stackable).toBe(true);
+      expect(slot.metadata.locked).toBe(false);
+    }
+  });
+
+  it('stores stackable resources and emits snapshot updates', () => {
+    const store = new InventoryStore();
+    store.setCapacitySource('test', 100);
+    let lastInventorySnapshot = store.getSnapshot();
+    let lastSlotSnapshot = store.getSlotSchemaSnapshot();
+
+    store.subscribe((snapshot) => {
+      lastInventorySnapshot = snapshot;
+    });
+    store.subscribeSlots((snapshot) => {
+      lastSlotSnapshot = snapshot;
+    });
+
+    store.store('resource.scrap', 5);
+
+    expect(lastInventorySnapshot.entries).toEqual([{ resource: 'resource.scrap', quantity: 5 }]);
+    const scrapSlot = findSlotByOccupant(lastInventorySnapshot, 'resource.scrap');
+    expect(scrapSlot).not.toBeNull();
+    expect(scrapSlot?.stackCount).toBe(5);
+
+    store.store('resource.scrap', 3);
+
+    expect(lastInventorySnapshot.entries).toEqual([{ resource: 'resource.scrap', quantity: 8 }]);
+    const updatedSlot = findSlotByOccupant(lastInventorySnapshot, 'resource.scrap');
+    expect(updatedSlot?.stackCount).toBe(8);
+
+    const slotEntry = lastSlotSnapshot.slots.find((slot) => slot.occupantId === 'resource.scrap');
+    expect(slotEntry?.stackCount).toBe(8);
+  });
+
+  it('supports splitting, merging, and swapping slot contents', () => {
+    const store = new InventoryStore();
+    store.setCapacitySource('test', 100);
+    store.store('resource.scrap', 6);
+    store.store('resource.ore', 4);
+
+    const initialSnapshot = store.getSnapshot();
+    const scrapSlot = findSlotByOccupant(initialSnapshot, 'resource.scrap');
+    const oreSlot = findSlotByOccupant(initialSnapshot, 'resource.ore');
+    const emptySlot = initialSnapshot.slots.find((slot) => slot.occupantId === null && slot.id !== scrapSlot?.id);
+
+    expect(scrapSlot).not.toBeNull();
+    expect(oreSlot).not.toBeNull();
+    expect(emptySlot).not.toBeNull();
+
+    const splitResult = store.transferSlotItem(scrapSlot!.id, emptySlot!.id, 2);
+    expect(splitResult.status).toBe('split');
+    expect(splitResult.moved).toBe(2);
+    expect(splitResult.remainder).toBe(4);
+
+    let snapshot = store.getSnapshot();
+    const splitSource = snapshot.slots.find((slot) => slot.id === scrapSlot!.id);
+    const splitTarget = snapshot.slots.find((slot) => slot.id === emptySlot!.id);
+    expect(splitSource?.stackCount).toBe(4);
+    expect(splitTarget?.occupantId).toBe('resource.scrap');
+    expect(splitTarget?.stackCount).toBe(2);
+
+    const mergeResult = store.transferSlotItem(splitTarget!.id, splitSource!.id);
+    expect(mergeResult.status).toBe('merged');
+    snapshot = store.getSnapshot();
+    const mergedSource = snapshot.slots.find((slot) => slot.id === splitSource!.id);
+    const mergedTarget = snapshot.slots.find((slot) => slot.id === splitTarget!.id);
+    expect(mergedSource?.stackCount).toBe(6);
+    expect(mergedTarget?.occupantId).toBeNull();
+
+    const swapResult = store.transferSlotItem(mergedSource!.id, oreSlot!.id);
+    expect(swapResult.status).toBe('swapped');
+
+    snapshot = store.getSnapshot();
+    const swappedSource = snapshot.slots.find((slot) => slot.id === mergedSource!.id);
+    const swappedTarget = snapshot.slots.find((slot) => slot.id === oreSlot!.id);
+    expect(swappedSource?.occupantId).toBe('resource.ore');
+    expect(swappedSource?.stackCount).toBe(4);
+    expect(swappedTarget?.occupantId).toBe('resource.scrap');
+    expect(swappedTarget?.stackCount).toBe(6);
+  });
+
+  it('updates slot metadata and provides resolved slot snapshots', () => {
+    const store = new InventoryStore();
+    const initialSlot = store.getSlot('inventory-0');
+    expect(initialSlot?.metadata.locked).toBe(false);
+    expect(initialSlot?.metadata.stackable).toBe(true);
+
+    const updated = store.setSlotMetadata('inventory-0', { locked: true, stackable: false });
+    expect(updated?.metadata.locked).toBe(true);
+    expect(updated?.metadata.stackable).toBe(false);
+
+    const nextSnapshot = store.getSlot('inventory-0');
+    expect(nextSnapshot?.metadata.locked).toBe(true);
+    expect(nextSnapshot?.metadata.stackable).toBe(false);
+  });
+});
+

--- a/src/simulation/robot/inventory.ts
+++ b/src/simulation/robot/inventory.ts
@@ -1,3 +1,5 @@
+import type { SlotMetadata, SlotSchema } from '../../types/slots';
+
 export interface InventoryEntry {
   resource: string;
   quantity: number;
@@ -8,6 +10,8 @@ export interface InventorySnapshot {
   used: number;
   available: number;
   entries: InventoryEntry[];
+  slots: SlotSchema[];
+  slotCapacity: number;
 }
 
 export interface StoreResult {
@@ -22,12 +26,62 @@ export interface WithdrawResult {
   total: number;
 }
 
+export type SlotTransferStatus =
+  | 'noop'
+  | 'invalid-source'
+  | 'invalid-target'
+  | 'invalid-amount'
+  | 'empty-source'
+  | 'slot-locked'
+  | 'rejected'
+  | 'moved'
+  | 'split'
+  | 'merged'
+  | 'swapped';
+
+export interface SlotTransferResult {
+  status: SlotTransferStatus;
+  moved: number;
+  remainder: number;
+  source: SlotSchema;
+  target: SlotSchema;
+}
+
+interface SlotDefinition {
+  id: string;
+  index: number;
+  metadata: SlotMetadata;
+}
+
+interface SlotState {
+  occupantId: string | null;
+  stackCount: number;
+}
+
+interface SlotSnapshot {
+  capacity: number;
+  slots: SlotSchema[];
+}
+
 type InventoryListener = (snapshot: InventorySnapshot) => void;
+type SlotListener = (snapshot: SlotSnapshot) => void;
+
+const DEFAULT_SLOT_CAPACITY = 10;
+const SLOT_ID_PREFIX = 'inventory';
+
+const createSlotId = (index: number): string => `${SLOT_ID_PREFIX}-${index}`;
 
 export class InventoryStore {
-  private readonly contents = new Map<string, number>();
   private readonly capacitySources = new Map<string, number>();
   private readonly listeners = new Set<InventoryListener>();
+  private readonly slotListeners = new Set<SlotListener>();
+  private readonly slotDefinitions = new Map<string, SlotDefinition>();
+  private readonly slotStates = new Map<string, SlotState>();
+  private slotCapacity = 0;
+
+  constructor(slotCapacity: number = DEFAULT_SLOT_CAPACITY) {
+    this.configureSlotCapacity(slotCapacity);
+  }
 
   setCapacitySource(id: string, capacity: number): void {
     const safeCapacity = Math.max(capacity, 0);
@@ -45,6 +99,46 @@ export class InventoryStore {
     }
   }
 
+  configureSlotCapacity(capacity: number): void {
+    const safeCapacity = Number.isFinite(capacity) ? Math.max(Math.floor(capacity), 0) : 0;
+    if (safeCapacity <= this.slotCapacity) {
+      // Prevent shrinking below existing populated slots to avoid data loss.
+      if (safeCapacity < this.slotCapacity) {
+        for (let index = safeCapacity; index < this.slotCapacity; index += 1) {
+          const slotId = createSlotId(index);
+          const state = this.slotStates.get(slotId);
+          if (state?.occupantId) {
+            return;
+          }
+        }
+        for (let index = safeCapacity; index < this.slotCapacity; index += 1) {
+          const slotId = createSlotId(index);
+          this.slotDefinitions.delete(slotId);
+          this.slotStates.delete(slotId);
+        }
+        this.slotCapacity = safeCapacity;
+        this.notifyChange();
+      }
+      return;
+    }
+
+    for (let index = this.slotCapacity; index < safeCapacity; index += 1) {
+      const slotId = createSlotId(index);
+      this.slotDefinitions.set(slotId, {
+        id: slotId,
+        index,
+        metadata: this.createSlotMetadata(),
+      });
+      this.slotStates.set(slotId, { occupantId: null, stackCount: 0 });
+    }
+    this.slotCapacity = safeCapacity;
+    this.notifyChange();
+  }
+
+  getSlotCapacity(): number {
+    return this.slotCapacity;
+  }
+
   getCapacity(): number {
     let total = 0;
     for (const value of this.capacitySources.values()) {
@@ -55,8 +149,10 @@ export class InventoryStore {
 
   getUsed(): number {
     let used = 0;
-    for (const value of this.contents.values()) {
-      used += Math.max(value, 0);
+    for (const state of this.slotStates.values()) {
+      if (state.occupantId) {
+        used += Math.max(state.stackCount, 0);
+      }
     }
     return used;
   }
@@ -66,78 +162,283 @@ export class InventoryStore {
   }
 
   getQuantity(resource: string): number {
-    return this.contents.get(resource) ?? 0;
+    const normalised = resource.trim().toLowerCase();
+    if (!normalised) {
+      return 0;
+    }
+    let total = 0;
+    for (const state of this.slotStates.values()) {
+      if (state.occupantId === normalised) {
+        total += Math.max(state.stackCount, 0);
+      }
+    }
+    return total;
+  }
+
+  setSlotMetadata(slotId: string, overrides: Partial<SlotMetadata>): SlotSchema | null {
+    const definition = this.slotDefinitions.get(slotId);
+    if (!definition) {
+      return null;
+    }
+    const nextDefinition: SlotDefinition = {
+      ...definition,
+      metadata: this.createSlotMetadata({ ...definition.metadata, ...overrides }),
+    };
+    this.slotDefinitions.set(slotId, nextDefinition);
+    const snapshot = this.buildSlotSchema(nextDefinition);
+    this.notifyChange();
+    return snapshot;
+  }
+
+  getSlot(slotId: string): SlotSchema | null {
+    const definition = this.slotDefinitions.get(slotId);
+    if (!definition) {
+      return null;
+    }
+    return this.buildSlotSchema(definition);
+  }
+
+  getSlotSchemaSnapshot(): SlotSnapshot {
+    return {
+      capacity: this.slotCapacity,
+      slots: this.getOrderedSlotDefinitions().map((definition) => this.buildSlotSchema(definition)),
+    } satisfies SlotSnapshot;
+  }
+
+  transferSlotItem(sourceId: string, targetId: string, amount?: number): SlotTransferResult {
+    if (sourceId === targetId) {
+      const definition = this.slotDefinitions.get(sourceId);
+      const snapshot = definition ? this.buildSlotSchema(definition) : null;
+      if (!snapshot) {
+        return {
+          status: 'invalid-source',
+          moved: 0,
+          remainder: 0,
+          source: { id: sourceId, index: 0, occupantId: null, metadata: { stackable: true, locked: false } },
+          target: { id: targetId, index: 0, occupantId: null, metadata: { stackable: true, locked: false } },
+        } satisfies SlotTransferResult;
+      }
+      return {
+        status: 'noop',
+        moved: 0,
+        remainder: snapshot.stackCount ?? 0,
+        source: snapshot,
+        target: snapshot,
+      } satisfies SlotTransferResult;
+    }
+
+    const sourceDefinition = this.slotDefinitions.get(sourceId);
+    if (!sourceDefinition) {
+      return this.createInvalidTransferResult(sourceId, targetId, 'invalid-source');
+    }
+    const targetDefinition = this.slotDefinitions.get(targetId);
+    if (!targetDefinition) {
+      return this.createInvalidTransferResult(sourceId, targetId, 'invalid-target');
+    }
+
+    const sourceState = this.getSlotState(sourceId);
+    const targetState = this.getSlotState(targetId);
+
+    if (!sourceState.occupantId || sourceState.stackCount <= 0) {
+      return this.createTransferResult(
+        'empty-source',
+        0,
+        sourceDefinition,
+        targetDefinition,
+      );
+    }
+
+    if (targetDefinition.metadata.locked) {
+      return this.createTransferResult('slot-locked', 0, sourceDefinition, targetDefinition);
+    }
+
+    const maxMove = Math.max(sourceState.stackCount, 0);
+    const requested = amount === undefined ? maxMove : Math.min(Math.max(amount, 0), maxMove);
+
+    if (requested <= 0) {
+      return this.createTransferResult('invalid-amount', 0, sourceDefinition, targetDefinition);
+    }
+
+    let status: SlotTransferStatus = 'rejected';
+    let moved = 0;
+
+    if (!targetState.occupantId) {
+      moved = requested;
+      sourceState.stackCount -= moved;
+      targetState.occupantId = sourceState.occupantId;
+      targetState.stackCount = moved;
+      if (sourceState.stackCount <= 0) {
+        sourceState.occupantId = null;
+        sourceState.stackCount = 0;
+        status = 'moved';
+      } else {
+        status = 'split';
+      }
+    } else {
+      const sameOccupant = targetState.occupantId === sourceState.occupantId;
+      const canMerge =
+        sameOccupant && sourceDefinition.metadata.stackable && targetDefinition.metadata.stackable;
+
+      if (canMerge) {
+        moved = requested;
+        sourceState.stackCount -= moved;
+        targetState.stackCount += moved;
+        if (sourceState.stackCount <= 0) {
+          sourceState.occupantId = null;
+          sourceState.stackCount = 0;
+        }
+        status = 'merged';
+      } else if (requested === maxMove) {
+        const targetOccupantId = targetState.occupantId;
+        const targetCount = targetState.stackCount;
+        targetState.occupantId = sourceState.occupantId;
+        targetState.stackCount = sourceState.stackCount;
+        sourceState.occupantId = targetOccupantId;
+        sourceState.stackCount = targetCount;
+        moved = maxMove;
+        status = 'swapped';
+      } else {
+        return this.createTransferResult('rejected', 0, sourceDefinition, targetDefinition);
+      }
+    }
+
+    const result = this.createTransferResult(status, moved, sourceDefinition, targetDefinition);
+    this.notifyChange();
+    return result;
   }
 
   store(resource: string, amount: number): StoreResult {
     const normalisedResource = resource.trim().toLowerCase();
     if (!normalisedResource || !Number.isFinite(amount) || amount <= 0) {
-      return { stored: 0, overflow: 0, total: this.getQuantity(normalisedResource) };
+      return { stored: 0, overflow: 0, total: this.getQuantity(normalisedResource) } satisfies StoreResult;
     }
 
     const available = this.getAvailable();
     if (available <= 0) {
-      return { stored: 0, overflow: amount, total: this.getQuantity(normalisedResource) };
+      return { stored: 0, overflow: amount, total: this.getQuantity(normalisedResource) } satisfies StoreResult;
     }
 
-    const accepted = Math.min(amount, available);
-    const overflow = Math.max(amount - accepted, 0);
-    const next = this.getQuantity(normalisedResource) + accepted;
-    this.contents.set(normalisedResource, next);
-    this.notifyChange();
-    return { stored: accepted, overflow, total: next };
+    let remaining = Math.min(amount, available);
+    let stored = 0;
+
+    const definitions = this.getOrderedSlotDefinitions();
+
+    for (const definition of definitions) {
+      if (remaining <= 0) {
+        break;
+      }
+      const state = this.getSlotState(definition.id);
+      if (state.occupantId === normalisedResource && definition.metadata.stackable) {
+        state.stackCount += remaining;
+        stored += remaining;
+        remaining = 0;
+        break;
+      }
+    }
+
+    for (const definition of definitions) {
+      if (remaining <= 0) {
+        break;
+      }
+      const state = this.getSlotState(definition.id);
+      if (!state.occupantId) {
+        state.occupantId = normalisedResource;
+        state.stackCount = remaining;
+        stored += remaining;
+        remaining = 0;
+      }
+    }
+
+    if (stored > 0) {
+      this.notifyChange();
+    }
+
+    const total = this.getQuantity(normalisedResource);
+    const overflow = amount - stored;
+    return {
+      stored,
+      overflow: Math.max(overflow, 0),
+      total,
+    } satisfies StoreResult;
   }
 
   withdraw(resource: string, amount: number): WithdrawResult {
     const normalisedResource = resource.trim().toLowerCase();
     if (!normalisedResource || !Number.isFinite(amount) || amount <= 0) {
-      return { withdrawn: 0, remaining: this.getQuantity(normalisedResource), total: this.getQuantity(normalisedResource) };
+      const total = this.getQuantity(normalisedResource);
+      return { withdrawn: 0, remaining: total, total } satisfies WithdrawResult;
     }
 
-    const current = this.getQuantity(normalisedResource);
-    if (current <= 0) {
-      return { withdrawn: 0, remaining: 0, total: 0 };
+    const totalAvailable = this.getQuantity(normalisedResource);
+    if (totalAvailable <= 0) {
+      return { withdrawn: 0, remaining: 0, total: 0 } satisfies WithdrawResult;
     }
 
-    const withdrawn = Math.min(amount, current);
-    const remaining = current - withdrawn;
-    if (remaining <= 0) {
-      this.contents.delete(normalisedResource);
-    } else {
-      this.contents.set(normalisedResource, remaining);
+    let remaining = Math.min(amount, totalAvailable);
+    let withdrawn = 0;
+
+    for (const definition of this.getOrderedSlotDefinitions()) {
+      if (remaining <= 0) {
+        break;
+      }
+      const state = this.getSlotState(definition.id);
+      if (state.occupantId !== normalisedResource) {
+        continue;
+      }
+      const removed = Math.min(state.stackCount, remaining);
+      if (removed <= 0) {
+        continue;
+      }
+      state.stackCount -= removed;
+      withdrawn += removed;
+      remaining -= removed;
+      if (state.stackCount <= 0) {
+        state.occupantId = null;
+        state.stackCount = 0;
+      }
     }
-    this.notifyChange();
-    return { withdrawn, remaining: Math.max(remaining, 0), total: Math.max(remaining, 0) };
+
+    if (withdrawn > 0) {
+      this.notifyChange();
+    }
+
+    const total = this.getQuantity(normalisedResource);
+    return {
+      withdrawn,
+      remaining: total,
+      total,
+    } satisfies WithdrawResult;
   }
 
   clear(): void {
-    if (this.contents.size === 0) {
+    if (!this.clearContents()) {
       return;
     }
-    this.contents.clear();
     this.notifyChange();
   }
 
   reset(): void {
-    this.contents.clear();
+    const hadContents = this.clearContents();
+    const hadCapacity = this.capacitySources.size > 0;
     this.capacitySources.clear();
-    this.notifyChange();
+    if (hadContents || hadCapacity) {
+      this.notifyChange();
+    }
   }
 
   getSnapshot(): InventorySnapshot {
-    const entries: InventoryEntry[] = [];
-    for (const [resource, quantity] of this.contents.entries()) {
-      entries.push({ resource, quantity });
-    }
-    entries.sort((a, b) => a.resource.localeCompare(b.resource));
-    const used = this.getUsed();
+    const { slots } = this.getSlotSchemaSnapshot();
+    const entries = this.buildEntries(slots);
+    const used = slots.reduce((total, slot) => total + Math.max(slot.stackCount ?? 0, 0), 0);
     const capacity = this.getCapacity();
     return {
       capacity,
       used,
       available: Math.max(capacity - used, 0),
       entries,
-    };
+      slots,
+      slotCapacity: this.slotCapacity,
+    } satisfies InventorySnapshot;
   }
 
   subscribe(listener: InventoryListener): () => void {
@@ -148,10 +449,126 @@ export class InventoryStore {
     };
   }
 
+  subscribeSlots(listener: SlotListener): () => void {
+    this.slotListeners.add(listener);
+    listener(this.getSlotSchemaSnapshot());
+    return () => {
+      this.slotListeners.delete(listener);
+    };
+  }
+
+  private clearContents(): boolean {
+    let changed = false;
+    for (const state of this.slotStates.values()) {
+      if (state.occupantId !== null || state.stackCount !== 0) {
+        state.occupantId = null;
+        state.stackCount = 0;
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private createSlotMetadata(overrides?: Partial<SlotMetadata>): SlotMetadata {
+    return {
+      stackable: overrides?.stackable ?? true,
+      locked: overrides?.locked ?? false,
+      moduleSubtype: overrides?.moduleSubtype,
+    } satisfies SlotMetadata;
+  }
+
+  private getSlotState(slotId: string): SlotState {
+    let state = this.slotStates.get(slotId);
+    if (!state) {
+      state = { occupantId: null, stackCount: 0 } satisfies SlotState;
+      this.slotStates.set(slotId, state);
+    }
+    return state;
+  }
+
+  private getOrderedSlotDefinitions(): SlotDefinition[] {
+    return [...this.slotDefinitions.values()].sort((a, b) => a.index - b.index);
+  }
+
+  private buildSlotSchema(definition: SlotDefinition): SlotSchema {
+    const state = this.getSlotState(definition.id);
+    return {
+      id: definition.id,
+      index: definition.index,
+      occupantId: state.occupantId,
+      stackCount: state.stackCount > 1 ? state.stackCount : undefined,
+      metadata: { ...definition.metadata },
+    } satisfies SlotSchema;
+  }
+
+  private buildEntries(slots: SlotSchema[]): InventoryEntry[] {
+    const totals = new Map<string, number>();
+    for (const slot of slots) {
+      if (!slot.occupantId) {
+        continue;
+      }
+      const amount = Math.max(slot.stackCount ?? 1, 0);
+      totals.set(slot.occupantId, (totals.get(slot.occupantId) ?? 0) + amount);
+    }
+    const entries: InventoryEntry[] = [];
+    for (const [resource, quantity] of totals.entries()) {
+      entries.push({ resource, quantity });
+    }
+    entries.sort((a, b) => a.resource.localeCompare(b.resource));
+    return entries;
+  }
+
   private notifyChange(): void {
     const snapshot = this.getSnapshot();
     for (const listener of this.listeners) {
       listener(snapshot);
     }
+    if (this.slotListeners.size > 0) {
+      const slotSnapshot: SlotSnapshot = { capacity: this.slotCapacity, slots: snapshot.slots };
+      for (const listener of this.slotListeners) {
+        listener(slotSnapshot);
+      }
+    }
+  }
+
+  private createInvalidTransferResult(
+    sourceId: string,
+    targetId: string,
+    status: SlotTransferStatus,
+  ): SlotTransferResult {
+    const source = this.slotDefinitions.get(sourceId);
+    const target = this.slotDefinitions.get(targetId);
+    return {
+      status,
+      moved: 0,
+      remainder: 0,
+      source: source ? this.buildSlotSchema(source) : this.createVirtualSlot(sourceId),
+      target: target ? this.buildSlotSchema(target) : this.createVirtualSlot(targetId),
+    } satisfies SlotTransferResult;
+  }
+
+  private createTransferResult(
+    status: SlotTransferStatus,
+    moved: number,
+    sourceDefinition: SlotDefinition,
+    targetDefinition: SlotDefinition,
+  ): SlotTransferResult {
+    return {
+      status,
+      moved,
+      remainder: this.getSlotState(sourceDefinition.id).stackCount,
+      source: this.buildSlotSchema(sourceDefinition),
+      target: this.buildSlotSchema(targetDefinition),
+    } satisfies SlotTransferResult;
+  }
+
+  private createVirtualSlot(slotId: string): SlotSchema {
+    return {
+      id: slotId,
+      index: 0,
+      occupantId: null,
+      metadata: this.createSlotMetadata(),
+    } satisfies SlotSchema;
   }
 }
+

--- a/src/simulation/robot/modules/cargoHoldModule.ts
+++ b/src/simulation/robot/modules/cargoHoldModule.ts
@@ -143,6 +143,8 @@ export class CargoHoldModule extends RobotModule {
         used: 0,
         available: this.defaultCapacity,
         entries: [],
+        slots: [],
+        slotCapacity: 0,
       });
     }
   }

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -292,7 +292,7 @@ export class RootScene {
   getInventorySnapshot(robotId: string = this.getActiveRobotId()): InventorySnapshot {
     const robotCore = this.context?.getRobotCore(robotId);
     if (!robotCore) {
-      return { capacity: 0, used: 0, available: 0, entries: [] };
+      return { capacity: 0, used: 0, available: 0, entries: [], slots: [], slotCapacity: 0 };
     }
     return robotCore.getInventorySnapshot();
   }

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -28,7 +28,14 @@ const createSceneStub = () => {
     getProgramStatus: vi.fn(() => 'idle' as const),
     runProgram: vi.fn(),
     stopProgram: vi.fn(),
-    getInventorySnapshot: vi.fn(() => ({ capacity: 0, used: 0, available: 0, entries: [] })),
+    getInventorySnapshot: vi.fn(() => ({
+      capacity: 0,
+      used: 0,
+      available: 0,
+      entries: [],
+      slots: [],
+      slotCapacity: 0,
+    })),
     subscribeInventory: vi.fn(() => () => {}),
     subscribeTelemetry: vi.fn((listener: (snapshot: SimulationTelemetrySnapshot, robotId: string | null) => void) => {
       telemetryListeners.push(listener);

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -22,6 +22,8 @@ const EMPTY_INVENTORY_SNAPSHOT: InventorySnapshot = {
   used: 0,
   available: 0,
   entries: [],
+  slots: [],
+  slotCapacity: 0,
 };
 
 const EMPTY_TELEMETRY_SNAPSHOT: SimulationTelemetrySnapshot = {


### PR DESCRIPTION
## Summary
- extend the inventory store to expose slot schema snapshots, transfer helpers, and stacking-aware store/withdraw operations
- update the application and runtime defaults to consume the new slot data and keep overlays synchronized
- add regression tests covering inventory slot behaviour and metadata updates

## Testing
- npm run typecheck
- npm test
- npx playwright test


------
https://chatgpt.com/codex/tasks/task_e_68d410bada34832eb58e2b94d1a09b46