### PR TITLE
Add Storybook showcases for core UI surfaces

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build site
         run: npm run build
 
+      - name: Build Storybook
+        run: npm run build-storybook -- --output-dir dist/storybook
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,6 +35,12 @@ const config: StorybookConfig = {
       config.resolve.extensions = extensions;
     }
 
+    if (config.output) {
+      config.output.publicPath = './';
+    } else {
+      config.output = { publicPath: './' };
+    }
+
     return config;
   },
 };

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import '../src/styles/theme.css';
 
 const preview: Preview = {
   parameters: {

--- a/src/stories/OverlayWindows.stories.tsx
+++ b/src/stories/OverlayWindows.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import EntityOverlay from '../components/EntityOverlay';
+import { EntityOverlayManagerProvider, useEntityOverlayManager } from '../state/EntityOverlayManager';
+import { DragProvider } from '../state/DragContext';
+import { ensureDefaultInspectorsRegistered } from '../overlay/defaultInspectors';
+import type { EntityOverlayData } from '../types/overlay';
+
+ensureDefaultInspectorsRegistered();
+
+const sampleEntity: EntityOverlayData = {
+  entityId: 101,
+  name: 'Sentry Drone',
+  description:
+    'Autonomous perimeter drone equipped with a short-range survey scanner and limited cargo capacity.',
+  overlayType: 'simple',
+  properties: {
+    chassis: 'Scout Mk II',
+    status: 'Idle',
+    batteryLevel: '78%',
+    lastCommand: 'Hold Position',
+  },
+};
+
+const OverlayPreview = (): JSX.Element => {
+  const { openOverlay, closeOverlay } = useEntityOverlayManager();
+
+  useEffect(() => {
+    openOverlay(sampleEntity, { initialTab: 'info' });
+  }, [openOverlay]);
+
+  return <EntityOverlay onClose={closeOverlay} />;
+};
+
+const meta = {
+  title: 'Overlay Windows/EntityOverlay',
+  component: EntityOverlay,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof EntityOverlay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SimpleEntity: Story = {
+  render: () => (
+    <div
+      style={{
+        background: 'var(--color-background)',
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+        boxSizing: 'border-box',
+      }}
+    >
+      <DragProvider>
+        <EntityOverlayManagerProvider>
+          <OverlayPreview />
+        </EntityOverlayManagerProvider>
+      </DragProvider>
+    </div>
+  ),
+};

--- a/src/stories/ProgrammingBlocks.stories.tsx
+++ b/src/stories/ProgrammingBlocks.stories.tsx
@@ -1,0 +1,107 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Workspace from '../components/Workspace';
+import { createBlockInstance } from '../blocks/library';
+import type { WorkspaceState } from '../types/blocks';
+
+const buildWorkspace = (): WorkspaceState => {
+  const whenStarted = createBlockInstance('start');
+  const scanArea = createBlockInstance('scan-resources');
+  const repeatLoop = createBlockInstance('repeat');
+  const gatherResource = createBlockInstance('gather-resource');
+  const returnHome = createBlockInstance('return-home');
+
+  repeatLoop.slots = {
+    do: [gatherResource, returnHome],
+  };
+
+  const moveTo = createBlockInstance('move-to');
+  const literalX = createBlockInstance('literal-number');
+  const literalY = createBlockInstance('literal-number');
+
+  moveTo.parameters = {
+    useScanHit: { kind: 'boolean', value: false },
+    scanHitIndex: { kind: 'number', value: 1 },
+    targetX: { kind: 'number', value: 12 },
+    targetY: { kind: 'number', value: -6 },
+    speed: { kind: 'number', value: 90 },
+  };
+
+  moveTo.expressionInputs = {
+    targetX: [literalX],
+    targetY: [literalY],
+  };
+
+  return [whenStarted, scanArea, moveTo, repeatLoop];
+};
+
+type WorkspaceProps = ComponentProps<typeof Workspace>;
+
+const logDrop: WorkspaceProps['onDrop'] = (event, target) => {
+  event.preventDefault();
+  // eslint-disable-next-line no-console -- Storybook interaction logging helper
+  console.log('drop', target);
+};
+
+const logTouchDrop: NonNullable<WorkspaceProps['onTouchDrop']> = (payload, target) => {
+  // eslint-disable-next-line no-console -- Storybook interaction logging helper
+  console.log('touch-drop', { payload, target });
+};
+
+const logUpdate: NonNullable<WorkspaceProps['onUpdateBlock']> = (instanceId) => {
+  // eslint-disable-next-line no-console -- Storybook interaction logging helper
+  console.log('update-block', instanceId);
+};
+
+const logRemove: WorkspaceProps['onRemoveBlock'] = (instanceId) => {
+  // eslint-disable-next-line no-console -- Storybook interaction logging helper
+  console.log('remove-block', instanceId);
+};
+
+const meta = {
+  title: 'Programming Blocks/Workspace',
+  component: Workspace,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    blocks: { control: false },
+    onDrop: { control: false },
+    onTouchDrop: { control: false },
+    onUpdateBlock: { control: false },
+    onRemoveBlock: { control: false },
+    telemetry: { control: false },
+  },
+} satisfies Meta<typeof Workspace>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WorkspaceShowcase: Story = {
+  args: {
+    blocks: buildWorkspace(),
+    onDrop: logDrop,
+    onTouchDrop: logTouchDrop,
+    onUpdateBlock: logUpdate,
+    onRemoveBlock: logRemove,
+  },
+  render: (args: WorkspaceProps) => (
+    <div
+      style={{
+        background: 'var(--color-background)',
+        padding: '2rem',
+        minHeight: '100vh',
+        boxSizing: 'border-box',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ maxWidth: '640px', width: '100%' }}>
+        <Workspace {...args} />
+      </div>
+    </div>
+  ),
+};

--- a/src/stories/UIButtons.stories.tsx
+++ b/src/stories/UIButtons.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import panelStyles from '../styles/RobotProgrammingPanel.module.css';
+
+const meta = {
+  title: 'UI Buttons/ProgrammingActions',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div
+      style={{
+        background: 'var(--color-surface-glass-strong)',
+        padding: '2rem',
+        borderRadius: 'var(--radius-lg)',
+        boxShadow: 'var(--shadow-soft)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        minWidth: '320px',
+        maxWidth: '420px',
+      }}
+    >
+      <div className={panelStyles.actions} style={{ justifyContent: 'center' }}>
+        <button type="button" className={`${panelStyles.primary}`}>Deploy routine</button>
+        <button type="button" className={`${panelStyles.secondary}`}>Cancel</button>
+      </div>
+      <div className={panelStyles.actions} style={{ justifyContent: 'center' }}>
+        <button type="button" className={`${panelStyles.primary}`} disabled>
+          Deploy routine
+        </button>
+        <button type="button" className={`${panelStyles.secondary}`} disabled>
+          Cancel
+        </button>
+      </div>
+    </div>
+  ),
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ButtonStates: Story = {};

--- a/src/stories/UIPanels.stories.tsx
+++ b/src/stories/UIPanels.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ModuleInventory from '../components/ModuleInventory';
+
+const meta = {
+  title: 'UI Panels/ModuleInventory',
+  component: ModuleInventory,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof ModuleInventory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const CatalogueOverview: Story = {
+  render: () => (
+    <div
+      style={{
+        background: 'var(--color-background-muted)',
+        padding: '2rem',
+        minHeight: '100vh',
+        boxSizing: 'border-box',
+        display: 'flex',
+        justifyContent: 'center',
+        overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '960px', width: '100%' }}>
+        <ModuleInventory />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- import the shared theme in Storybook so design tokens are available to stories
- add Storybook stories that showcase the programming workspace, module inventory panel, programming buttons, and entity overlay window
- build Storybook during the Pages workflow and publish it alongside the main site at /mind-fragment/storybook

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d446e8d858832e8edab18f585809a0