### PR TITLE
Fix Storybook asset error that broke Pages deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The sci-fi theme references Orbitron and Rajdhani via local `@font-face` rules, 
    - `src/styles/fonts/Orbitron-Regular.ttf`
    - `src/styles/fonts/Orbitron-Bold.ttf`
    - `src/styles/fonts/Rajdhani-Regular.ttf`
-   - (optional) supply an alternative Rajdhani bold weight as `src/styles/fonts/Rajdhani-Bold.ttf` — the CSS falls back to the regular weight if it is absent.
+   - (optional) swap in a heavier Rajdhani variant by updating `src/styles/theme.css` — the default build maps the 700 weight to the regular file so pipelines succeed without an extra binary.
 3. Restart `npm run dev` so Vite picks up the new assets. The UI will fall back to system fonts if the files are absent, so you can still develop without them.
 
 ## Current Priorities

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -35,7 +35,6 @@
   src:
     local('Rajdhani Bold'),
     local('Rajdhani'),
-    url('./fonts/Rajdhani-Bold.ttf') format('truetype'),
     url('./fonts/Rajdhani-Regular.ttf') format('truetype');
 }
 


### PR DESCRIPTION
## Summary
- stop referencing the missing Rajdhani bold font so Storybook can build without errors
- update the README font instructions to explain the new fallback behaviour

## Testing
- npm run typecheck
- npm test
- npm run build
- npm run build-storybook -- --output-dir dist/storybook
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d4698da134832e9070b4e2d204aa7e