### PR TITLE
Enhance entity overlay styling and add visual coverage

### DIFF
--- a/.kiro/specs/robot-overlay-inventory/tasks.md
+++ b/.kiro/specs/robot-overlay-inventory/tasks.md
@@ -87,7 +87,7 @@
   - Write tests for persistence and synchronization
   - _Requirements: 6.3, 6.4_
 
-- [ ] 12. Add overlay styling and visual polish
+- [✅] 12. Add overlay styling and visual polish
   - Create CSS modules for all overlay components
   - Implement responsive layout for different screen sizes
   - Add loading states and skeleton UI components

--- a/docs/planning/robot-overlay-and-inventory.md
+++ b/docs/planning/robot-overlay-and-inventory.md
@@ -53,13 +53,27 @@ This document defines the rebuilt interaction model for entity overlays, robot c
 - The `ProgramInspector` reflects the current execution state:
   - When a programme is running, the inspector is read-only and highlights the block currently executing.
   - To edit the programme the player must stop execution. Provide explicit copy that communicates the lock state and offers a stop control if absent elsewhere.
-- When execution stops, editing unlocks instantly and changes persist immediately back to the robot’s programme store.
-- The inspector should listen for chassis changes so blocks that depend on missing modules signal warnings, keeping parity with the runtime checks in the programming plan.
+  - When execution stops, editing unlocks instantly and changes persist immediately back to the robot’s programme store.
+  - The inspector should listen for chassis changes so blocks that depend on missing modules signal warnings, keeping parity with the runtime checks in the programming plan.
 
 ## Simple Entity Info Bubbles
 - Simple entities (e.g., resource nodes, loose objects) reuse the inspector framework but may supply only one lightweight inspector.
 - Minimum behaviour: display the entity name and a single-line description such as “This is a stick.”
 - Optional enrichments (health, output rate) can be layered on per entity definition without deviating from the shared inspector pipeline.
+
+## Overlay Styling Reference
+- `src/styles/SimulationOverlay.module.css` now provides the overarching layout primitives for the modal shell. Key hooks: `overlay`, `dialog`, `headerContent`, `tabSkeletonList`, `panelSkeletonGroup`, and the breakpoint-specific media queries for ≤960 px, ≤720 px, and ≤480 px.
+  :::task-stub{title="Trace overlay class usage"}
+  Cross-check any future updates to `EntityOverlay.tsx` against the class map in `src/styles/SimulationOverlay.module.css` so new hooks stay discoverable here.
+  :::
+- Inspector modules share colour and spacing tokens: `ChassisInspector.module.css` introduces `gridSkeleton`, `slotHovered`, and `slotSkeletonTile`, while `InventoryInspector.module.css` mirrors the pattern with `gridSkeleton`, `slotDragging`, and `headerSkeletonTitle`.
+  :::task-stub{title="Audit inspector skeleton classes"}
+  When extending inspector UIs, update both the relevant CSS module and this table to keep hover/skeleton class naming consistent across subsystems.
+  :::
+- `RobotProgrammingPanel.module.css` exposes `programmingShell`, `programmingSkeleton`, and per-column skeleton classes so the programming inspector can swap between loading placeholders and the interactive panel without layout shifts.
+  :::task-stub{title="Keep programming skeletons aligned"}
+  Coordinate changes to `RobotProgrammingInspector.tsx` and `RobotProgrammingPanel.module.css` so the shell/skeleton classes stay in sync with Storybook documentation.
+  :::
 
 ## Data Model and Persistence Updates
 - Inventories and chassis loadouts should share a common slot schema that records:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,12 +11,20 @@ export default defineConfig({
     trace: 'on-first-retry',
     headless: true,
   },
-  webServer: {
-    command: 'npm run build && npm run preview -- --host 0.0.0.0 --port 4173',
-    url: 'http://127.0.0.1:4173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 180000,
-  },
+  webServer: [
+    {
+      command: 'npm run build && npm run preview -- --host 0.0.0.0 --port 4173',
+      url: 'http://127.0.0.1:4173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 180000,
+    },
+    {
+      command: 'npx storybook dev -p 6006 --ci --quiet --host 0.0.0.0',
+      url: 'http://127.0.0.1:6006/iframe.html',
+      reuseExistingServer: !process.env.CI,
+      timeout: 180000,
+    },
+  ],
   projects: [
     {
       name: 'chromium',

--- a/playwright/entity-overlay-visual.spec.ts
+++ b/playwright/entity-overlay-visual.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+const STORY_ID = 'overlay-windows-entityoverlay--complex-entity';
+
+const viewports = [
+  { name: 'desktop', width: 1280, height: 720 },
+  { name: 'tablet', width: 900, height: 1024 },
+] as const;
+
+const tabs = [
+  { label: 'Systems', id: 'systems' },
+  { label: 'Programming', id: 'programming' },
+  { label: 'Info', id: 'info' },
+] as const;
+
+test.describe('entity overlay visual regression', () => {
+  test.use({ baseURL: 'http://127.0.0.1:6006' });
+
+  for (const viewport of viewports) {
+    test(`captures overlay tabs at ${viewport.name} resolution`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(`/iframe.html?id=${STORY_ID}&viewMode=story`, { waitUntil: 'networkidle' });
+
+      const overlay = page.getByTestId('entity-overlay');
+      await expect(overlay).toBeVisible();
+      await expect(overlay.locator('[data-loading="true"]')).toHaveCount(0);
+
+      for (const tab of tabs) {
+        await page.getByRole('tab', { name: tab.label }).click();
+        const panel = page.locator(`#simulation-overlay-panel-${tab.id}`);
+        await expect(panel).toBeVisible();
+        await expect(overlay).toHaveScreenshot(`entity-overlay-${viewport.name}-${tab.id}.png`, {
+          animations: 'disabled',
+        });
+      }
+    });
+  }
+});

--- a/src/components/DragPreviewLayer.tsx
+++ b/src/components/DragPreviewLayer.tsx
@@ -1,26 +1,82 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useDragContext } from '../state/DragContext';
+import type { DragPreview, Point } from '../types/drag';
 import styles from '../styles/DragPreviewLayer.module.css';
+
+const EXIT_DURATION_MS = 160;
 
 const DragPreviewLayer = (): JSX.Element | null => {
   const { isDragging, preview, pointerPosition } = useDragContext();
+  const [cachedPreview, setCachedPreview] = useState<DragPreview | null>(null);
+  const [cachedPointer, setCachedPointer] = useState<Point>({ x: 0, y: 0 });
+  const [isVisible, setIsVisible] = useState(false);
+  const [transitionState, setTransitionState] = useState<'entering' | 'active' | 'leaving'>('entering');
 
-  if (!isDragging || !preview) {
+  useEffect(() => {
+    if (preview) {
+      setCachedPreview(preview);
+    }
+  }, [preview]);
+
+  useEffect(() => {
+    if (pointerPosition) {
+      setCachedPointer(pointerPosition);
+    }
+  }, [pointerPosition]);
+
+  useEffect(() => {
+    if (isDragging && preview) {
+      setCachedPreview(preview);
+      setIsVisible(true);
+      setTransitionState('entering');
+      const frame = requestAnimationFrame(() => {
+        setTransitionState('active');
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+
+    if (!isDragging && isVisible) {
+      setTransitionState('leaving');
+      const timeout = window.setTimeout(() => {
+        setIsVisible(false);
+        setCachedPreview(null);
+      }, EXIT_DURATION_MS);
+      return () => window.clearTimeout(timeout);
+    }
+
+    if (!isDragging) {
+      setCachedPreview(null);
+    }
+
+    return undefined;
+  }, [isDragging, isVisible, preview]);
+
+  const activePreview = useMemo(() => preview ?? cachedPreview, [cachedPreview, preview]);
+
+  if (!isVisible || !activePreview) {
     return null;
   }
 
-  const { x: pointerX, y: pointerY } = pointerPosition ?? { x: 0, y: 0 };
-  const { x: offsetX, y: offsetY } = preview.offset ?? { x: 0, y: 0 };
+  const pointer = pointerPosition ?? cachedPointer;
+  const offset = activePreview.offset ?? { x: 0, y: 0 };
+  const style: CSSProperties & { '--translate-x': string; '--translate-y': string } = {
+    width: `${activePreview.width}px`,
+    height: `${activePreview.height}px`,
+    '--translate-x': `${pointer.x + offset.x}px`,
+    '--translate-y': `${pointer.y + offset.y}px`,
+  };
 
-  const style = {
-    width: `${preview.width}px`,
-    height: `${preview.height}px`,
-    transform: `translate(${pointerX + offsetX}px, ${pointerY + offsetY}px)`,
-  } as const;
+  const transitionClass =
+    transitionState === 'entering'
+      ? styles.previewEntering
+      : transitionState === 'leaving'
+      ? styles.previewLeaving
+      : styles.previewActive;
 
   return (
     <div className={styles.layer} aria-hidden="true">
-      <div className={styles.preview} style={style} data-testid="drag-preview">
-        {preview.render()}
+      <div className={`${styles.preview} ${transitionClass}`.trim()} style={style} data-testid="drag-preview">
+        {activePreview.render()}
       </div>
     </div>
   );

--- a/src/components/SkeletonBlock.tsx
+++ b/src/components/SkeletonBlock.tsx
@@ -1,0 +1,48 @@
+import type { CSSProperties, HTMLAttributes } from 'react';
+import styles from '../styles/Skeleton.module.css';
+
+type SkeletonVariant = 'block' | 'text' | 'pill' | 'circle';
+
+export interface SkeletonBlockProps extends HTMLAttributes<HTMLSpanElement> {
+  width?: number | string;
+  height?: number | string;
+  variant?: SkeletonVariant;
+}
+
+const formatSize = (value: number | string | undefined): string | undefined => {
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+  return value;
+};
+
+const SkeletonBlock = ({
+  width,
+  height,
+  variant = 'block',
+  className,
+  style,
+  'aria-hidden': ariaHidden,
+  ...rest
+}: SkeletonBlockProps): JSX.Element => {
+  const sizeStyle: CSSProperties = {
+    width: formatSize(width),
+    height: formatSize(height),
+    ...style,
+  };
+
+  const classes = [styles.skeleton, styles[variant], className]
+    .filter((token): token is string => Boolean(token))
+    .join(' ');
+
+  return (
+    <span
+      className={classes}
+      style={sizeStyle}
+      aria-hidden={ariaHidden ?? 'true'}
+      {...rest}
+    />
+  );
+};
+
+export default SkeletonBlock;

--- a/src/components/inspectors/RobotProgrammingInspector.tsx
+++ b/src/components/inspectors/RobotProgrammingInspector.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import RobotProgrammingPanel from '../RobotProgrammingPanel';
+import SkeletonBlock from '../SkeletonBlock';
 import type { InspectorProps } from '../../overlay/inspectorRegistry';
 import { useProgrammingInspector } from '../../state/ProgrammingInspectorContext';
 import { useSimulationRuntime } from '../../hooks/useSimulationRuntime';
 import { MODULE_LIBRARY } from '../../simulation/robot/modules/moduleLibrary';
 import type { BlockInstance, WorkspaceState } from '../../types/blocks';
+import programmingStyles from '../../styles/RobotProgrammingPanel.module.css';
 
 const MODULE_LABELS = new Map(MODULE_LIBRARY.map((module) => [module.id, module.title]));
 
@@ -59,7 +61,7 @@ const gatherModuleRequirements = (
   return requirements;
 };
 
-const RobotProgrammingInspector = ({ entity }: InspectorProps): JSX.Element => {
+const RobotProgrammingInspector = ({ entity, isLoading }: InspectorProps): JSX.Element => {
   const { workspace, onDrop, onTouchDrop, onUpdateBlock, onRemoveBlock, robotId } =
     useProgrammingInspector();
   const { status, stopProgram } = useSimulationRuntime(robotId);
@@ -111,20 +113,58 @@ const RobotProgrammingInspector = ({ entity }: InspectorProps): JSX.Element => {
   const activeBlockId = entity.programState?.activeBlockId ?? null;
   const canStopProgram = status === 'running' ? stopProgram : undefined;
 
+  if (isLoading) {
+    return (
+      <section
+        className={`${programmingStyles.programmingShell} ${programmingStyles.programmingSkeleton}`.trim()}
+        aria-label="Programming inspector"
+        data-testid="robot-programming-inspector"
+        data-loading="true"
+        aria-busy="true"
+      >
+        <div className={programmingStyles.summarySkeleton}>
+          <SkeletonBlock className={programmingStyles.summarySkeletonTitle} height={24} width="40%" />
+          <SkeletonBlock className={programmingStyles.summarySkeletonBody} height={16} width="68%" />
+          <SkeletonBlock className={programmingStyles.summarySkeletonBody} height={16} width="55%" />
+        </div>
+        <div className={programmingStyles.layoutSkeleton}>
+          <div className={programmingStyles.paletteSkeleton}>
+            <SkeletonBlock height={18} width="60%" variant="text" />
+            <SkeletonBlock className={programmingStyles.paletteSkeletonBody} height={140} />
+          </div>
+          <div className={programmingStyles.workspaceSkeleton}>
+            <SkeletonBlock height={18} width="50%" variant="text" />
+            <SkeletonBlock className={programmingStyles.workspaceSkeletonSurface} height={180} />
+          </div>
+        </div>
+        <div className={programmingStyles.footerSkeleton}>
+          <SkeletonBlock height={36} width="28%" />
+          <SkeletonBlock height={12} width="50%" variant="text" />
+        </div>
+      </section>
+    );
+  }
+
   return (
-    <RobotProgrammingPanel
-      workspace={workspace}
-      onDrop={onDrop}
-      onTouchDrop={onTouchDrop}
-      onUpdateBlock={onUpdateBlock}
-      onRemoveBlock={onRemoveBlock}
-      robotId={robotId}
-      isReadOnly={isRunning}
-      onRequestStop={canStopProgram}
-      moduleWarnings={moduleWarnings}
-      activeBlockId={activeBlockId}
-      warningBlockIds={warningBlockIds}
-    />
+    <section
+      className={programmingStyles.programmingShell}
+      aria-label="Programming inspector"
+      data-testid="robot-programming-inspector"
+    >
+      <RobotProgrammingPanel
+        workspace={workspace}
+        onDrop={onDrop}
+        onTouchDrop={onTouchDrop}
+        onUpdateBlock={onUpdateBlock}
+        onRemoveBlock={onRemoveBlock}
+        robotId={robotId}
+        isReadOnly={isRunning}
+        onRequestStop={canStopProgram}
+        moduleWarnings={moduleWarnings}
+        activeBlockId={activeBlockId}
+        warningBlockIds={warningBlockIds}
+      />
+    </section>
   );
 };
 

--- a/src/components/inspectors/__tests__/ChassisInspector.test.tsx
+++ b/src/components/inspectors/__tests__/ChassisInspector.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import ChassisInspector from '../ChassisInspector';
+import chassisStyles from '../../../styles/ChassisInspector.module.css';
 import { EntityOverlayManagerProvider, useEntityOverlayManager } from '../../../state/EntityOverlayManager';
 import { DragProvider, useDragContext } from '../../../state/DragContext';
 import type { EntityOverlayData } from '../../../types/overlay';
@@ -87,13 +88,21 @@ const ManagerCapture = (): null => {
   return null;
 };
 
-const renderInspector = (entity: EntityOverlayData) =>
+const renderInspector = (
+  entity: EntityOverlayData,
+  options?: { isLoading?: boolean },
+) =>
   render(
     <EntityOverlayManagerProvider>
       <DragProvider>
         <ManagerCapture />
         <DragController />
-        <ChassisInspector entity={entity} onClose={() => {}} />
+        <ChassisInspector
+          entity={entity}
+          onClose={() => {}}
+          isLoading={options?.isLoading ?? false}
+          persistenceState={{ status: 'idle', error: null }}
+        />
       </DragProvider>
     </EntityOverlayManagerProvider>,
   );
@@ -121,6 +130,21 @@ describe('ChassisInspector', () => {
     expect(screen.getByText('Precision Manipulator Rig')).toBeInTheDocument();
     const renderedSlots = screen.getAllByTestId(/chassis-slot-/);
     expect(renderedSlots).toHaveLength(3);
+  });
+
+  it('renders loading skeleton classes when the inspector is loading', async () => {
+    const slots = [
+      createSlot('core-0', 0, 'core.movement'),
+      createSlot('extension-0', 1, null),
+    ];
+    const entity = createEntity(slots);
+
+    renderInspector(entity, { isLoading: true });
+
+    const inspector = await screen.findByTestId('chassis-inspector');
+    expect(inspector).toHaveAttribute('data-loading', 'true');
+    expect(inspector.className.split(' ')).toContain(chassisStyles.loading);
+    expect(inspector).toHaveAttribute('aria-label', 'Chassis inspector');
   });
 
   it('displays module tooltips on hover', async () => {

--- a/src/components/inspectors/__tests__/EntityInfoInspector.test.tsx
+++ b/src/components/inspectors/__tests__/EntityInfoInspector.test.tsx
@@ -12,7 +12,14 @@ const baseEntity: EntityOverlayData = {
 };
 
 const renderInspector = (overrides: Partial<EntityOverlayData> = {}) =>
-  render(<EntityInfoInspector entity={{ ...baseEntity, ...overrides }} onClose={() => {}} />);
+  render(
+    <EntityInfoInspector
+      entity={{ ...baseEntity, ...overrides }}
+      onClose={() => {}}
+      isLoading={false}
+      persistenceState={{ status: 'idle', error: null }}
+    />,
+  );
 
 afterEach(() => {
   cleanup();

--- a/src/components/inspectors/__tests__/RobotProgrammingInspector.test.tsx
+++ b/src/components/inspectors/__tests__/RobotProgrammingInspector.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import RobotProgrammingInspector from '../RobotProgrammingInspector';
+import programmingStyles from '../../../styles/RobotProgrammingPanel.module.css';
 import { ProgrammingInspectorProvider } from '../../../state/ProgrammingInspectorContext';
 import { createBlockInstance } from '../../../blocks/library';
 import type { WorkspaceState } from '../../../types/blocks';
@@ -55,7 +56,11 @@ const createWorkspaceWithMoveBlock = (): WorkspaceState => {
   return [start];
 };
 
-const renderInspector = (entity: EntityOverlayData, workspace: WorkspaceState) => {
+const renderInspector = (
+  entity: EntityOverlayData,
+  workspace: WorkspaceState,
+  options?: { isLoading?: boolean },
+) => {
   const contextValue = {
     workspace,
     onDrop: vi.fn(),
@@ -67,7 +72,12 @@ const renderInspector = (entity: EntityOverlayData, workspace: WorkspaceState) =
 
   return render(
     <ProgrammingInspectorProvider value={contextValue}>
-      <RobotProgrammingInspector entity={entity} onClose={() => {}} />
+      <RobotProgrammingInspector
+        entity={entity}
+        onClose={() => {}}
+        isLoading={options?.isLoading ?? false}
+        persistenceState={{ status: 'idle', error: null }}
+      />
     </ProgrammingInspectorProvider>,
   );
 };
@@ -113,5 +123,16 @@ describe('RobotProgrammingInspector', () => {
     expect(screen.getByText(/locomotion thrusters mk1/i)).toBeInTheDocument();
     const moveBlock = screen.getByTestId('block-move');
     expect(moveBlock).toHaveAttribute('data-state-warning', 'true');
+  });
+
+  it('renders skeleton layout when loading', () => {
+    const workspace = createWorkspaceWithMoveBlock();
+    const entity = createEntity();
+
+    renderInspector(entity, workspace, { isLoading: true });
+
+    const inspector = screen.getByTestId('robot-programming-inspector');
+    expect(inspector).toHaveAttribute('data-loading', 'true');
+    expect(inspector.className.split(' ')).toContain(programmingStyles.programmingSkeleton);
   });
 });

--- a/src/overlay/inspectorRegistry.ts
+++ b/src/overlay/inspectorRegistry.ts
@@ -1,9 +1,12 @@
 import type { ComponentType } from 'react';
+import type { EntityPersistenceState } from '../state/EntityOverlayManager';
 import type { EntityOverlayData, InspectorTabId } from '../types/overlay';
 
 export interface InspectorProps {
   entity: EntityOverlayData;
   onClose: () => void;
+  isLoading: boolean;
+  persistenceState: EntityPersistenceState;
 }
 
 export interface InspectorDefinition<TProps extends InspectorProps = InspectorProps> {

--- a/src/stories/OverlayWindows.stories.tsx
+++ b/src/stories/OverlayWindows.stories.tsx
@@ -22,12 +22,73 @@ const sampleEntity: EntityOverlayData = {
   },
 };
 
-const OverlayPreview = (): JSX.Element => {
+const complexEntity: EntityOverlayData = {
+  entityId: 202,
+  name: 'Courier Drone',
+  description: 'Multi-purpose hauler outfitted for autonomous resource ferry duties.',
+  overlayType: 'complex',
+  chassis: {
+    capacity: 3,
+    slots: [
+      {
+        id: 'core-0',
+        index: 0,
+        occupantId: 'core.movement',
+        metadata: { stackable: false, moduleSubtype: undefined, locked: false },
+      },
+      {
+        id: 'sensor-0',
+        index: 1,
+        occupantId: 'sensor.survey',
+        metadata: { stackable: false, moduleSubtype: undefined, locked: false },
+      },
+      {
+        id: 'utility-0',
+        index: 2,
+        occupantId: null,
+        metadata: { stackable: false, moduleSubtype: undefined, locked: false },
+      },
+    ],
+  },
+  inventory: {
+    capacity: 4,
+    slots: [
+      {
+        id: 'cargo-0',
+        index: 0,
+        occupantId: 'resource.scrap',
+        stackCount: 6,
+        metadata: { stackable: true, moduleSubtype: undefined, locked: false },
+      },
+      {
+        id: 'cargo-1',
+        index: 1,
+        occupantId: 'core.movement',
+        metadata: { stackable: false, moduleSubtype: undefined, locked: false },
+      },
+      {
+        id: 'cargo-2',
+        index: 2,
+        occupantId: null,
+        metadata: { stackable: true, moduleSubtype: undefined, locked: false },
+      },
+      {
+        id: 'cargo-3',
+        index: 3,
+        occupantId: null,
+        metadata: { stackable: true, moduleSubtype: undefined, locked: false },
+      },
+    ],
+  },
+  programState: { isRunning: false, activeBlockId: null },
+};
+
+const OverlayPreview = ({ entity }: { entity: EntityOverlayData }): JSX.Element => {
   const { openOverlay, closeOverlay } = useEntityOverlayManager();
 
   useEffect(() => {
-    openOverlay(sampleEntity, { initialTab: 'info' });
-  }, [openOverlay]);
+    openOverlay(entity, { initialTab: entity.overlayType === 'simple' ? 'info' : 'systems' });
+  }, [entity, openOverlay]);
 
   return <EntityOverlay onClose={closeOverlay} />;
 };
@@ -60,7 +121,29 @@ export const SimpleEntity: Story = {
     >
       <DragProvider>
         <EntityOverlayManagerProvider>
-          <OverlayPreview />
+          <OverlayPreview entity={sampleEntity} />
+        </EntityOverlayManagerProvider>
+      </DragProvider>
+    </div>
+  ),
+};
+
+export const ComplexEntity: Story = {
+  render: () => (
+    <div
+      style={{
+        background: 'var(--color-background)',
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+        boxSizing: 'border-box',
+      }}
+    >
+      <DragProvider>
+        <EntityOverlayManagerProvider>
+          <OverlayPreview entity={complexEntity} />
         </EntityOverlayManagerProvider>
       </DragProvider>
     </div>

--- a/src/styles/ChassisInspector.module.css
+++ b/src/styles/ChassisInspector.module.css
@@ -5,6 +5,10 @@
   padding: var(--space-2) 0;
 }
 
+.loading {
+  gap: var(--space-4);
+}
+
 .header {
   display: flex;
   flex-direction: column;
@@ -29,6 +33,12 @@
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.gridSkeleton {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
 .slot {
   position: relative;
   display: flex;
@@ -39,7 +49,7 @@
   border: 1px solid rgba(110, 130, 170, 0.35);
   background: rgba(10, 16, 28, 0.55);
   min-height: 184px;
-  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast), background var(--transition-fast);
 }
 
 .slot[data-drop-state='active-valid'] {
@@ -55,6 +65,30 @@
 .slot[data-slot-locked='true'] {
   border-style: dashed;
   opacity: 0.75;
+}
+
+.slot::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  border: 2px solid transparent;
+  pointer-events: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.slotHovered::after,
+.slot[data-hovered='true']::after {
+  border-color: rgba(100, 249, 255, 0.4);
+  box-shadow: 0 0 0 2px rgba(100, 249, 255, 0.12);
+}
+
+.slotDragging {
+  transform: translateY(-1px);
+}
+
+.slotEmpty {
+  background: rgba(10, 16, 28, 0.4);
 }
 
 .slotLabel {
@@ -98,6 +132,25 @@
   cursor: default;
   opacity: 0.6;
   background: rgba(25, 35, 55, 0.35);
+}
+
+.headerSkeletonTitle,
+.headerSkeletonSummary {
+  display: block;
+}
+
+.slotSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.slotSkeletonType {
+  width: 60%;
+}
+
+.slotSkeletonTile {
+  border-radius: var(--radius-md);
 }
 
 .moduleName {

--- a/src/styles/DragPreviewLayer.module.css
+++ b/src/styles/DragPreviewLayer.module.css
@@ -11,4 +11,24 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  --scale: 1;
+  --opacity: 1;
+  transform: translate(var(--translate-x, 0), var(--translate-y, 0)) scale(var(--scale, 1));
+  opacity: var(--opacity, 1);
+  transition: transform 160ms cubic-bezier(0.16, 0.84, 0.44, 1), opacity 160ms ease;
+}
+
+.previewEntering {
+  --scale: 0.92;
+  --opacity: 0;
+}
+
+.previewActive {
+  --scale: 1;
+  --opacity: 1;
+}
+
+.previewLeaving {
+  --scale: 0.96;
+  --opacity: 0;
 }

--- a/src/styles/InventoryInspector.module.css
+++ b/src/styles/InventoryInspector.module.css
@@ -5,6 +5,10 @@
   padding: var(--space-2) 0;
 }
 
+.loading {
+  gap: var(--space-4);
+}
+
 .header {
   display: flex;
   flex-direction: column;
@@ -29,6 +33,12 @@
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
+.gridSkeleton {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
 .slot {
   position: relative;
   display: flex;
@@ -39,7 +49,7 @@
   border: 1px solid rgba(110, 130, 170, 0.35);
   background: rgba(10, 16, 28, 0.55);
   min-height: 160px;
-  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast), background var(--transition-fast);
 }
 
 .slot[data-drop-state='active-valid'] {
@@ -55,6 +65,30 @@
 .slot[data-slot-locked='true'] {
   border-style: dashed;
   opacity: 0.65;
+}
+
+.slot::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  border: 2px solid transparent;
+  pointer-events: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.slotHovered::after,
+.slot[data-hovered='true']::after {
+  border-color: rgba(100, 249, 255, 0.4);
+  box-shadow: 0 0 0 2px rgba(100, 249, 255, 0.1);
+}
+
+.slotDragging {
+  transform: translateY(-1px);
+}
+
+.slotEmpty {
+  background: rgba(10, 16, 28, 0.42);
 }
 
 .slotLabel {
@@ -93,6 +127,21 @@
   cursor: default;
   opacity: 0.6;
   background: rgba(25, 35, 55, 0.35);
+}
+
+.headerSkeletonTitle,
+.headerSkeletonSummary {
+  display: block;
+}
+
+.slotSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.slotSkeletonTile {
+  border-radius: var(--radius-md);
 }
 
 .itemVisual {

--- a/src/styles/RobotProgrammingPanel.module.css
+++ b/src/styles/RobotProgrammingPanel.module.css
@@ -11,6 +11,61 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.programmingShell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  flex: 1;
+  min-height: 0;
+}
+
+.programmingSkeleton {
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(140, 175, 215, 0.25);
+  background: rgba(14, 20, 38, 0.6);
+  gap: var(--space-5);
+}
+
+.summarySkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.summarySkeletonTitle,
+.summarySkeletonBody {
+  display: block;
+}
+
+.layoutSkeleton {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: var(--space-5);
+}
+
+.paletteSkeleton,
+.workspaceSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: rgba(22, 32, 52, 0.65);
+  border: 1px solid rgba(120, 160, 210, 0.22);
+}
+
+.paletteSkeletonBody,
+.workspaceSkeletonSurface {
+  border-radius: var(--radius-md);
+}
+
+.footerSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
 .summary {
   display: flex;
   flex-direction: column;
@@ -199,6 +254,10 @@
     grid-template-rows: auto;
     gap: var(--space-5);
   }
+
+  .layoutSkeleton {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
@@ -219,6 +278,15 @@
     gap: var(--space-4);
   }
 
+  .programmingSkeleton {
+    gap: var(--space-4);
+    padding: var(--space-4);
+  }
+
+  .layoutSkeleton {
+    gap: var(--space-4);
+  }
+
   .palette,
   .workspace {
     padding: var(--space-4);
@@ -234,6 +302,11 @@
   .programming {
     gap: var(--space-4);
     padding-right: 0;
+  }
+
+  .programmingSkeleton {
+    padding: var(--space-3);
+    gap: var(--space-3);
   }
 
   .summary {

--- a/src/styles/SimulationOverlay.module.css
+++ b/src/styles/SimulationOverlay.module.css
@@ -3,9 +3,10 @@
   inset: 0;
   z-index: 10;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: min(var(--space-12), 6vh) min(var(--space-10), 6vw);
+  justify-content: flex-start;
+  padding: var(--space-6) var(--space-4) var(--space-8);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -20,28 +21,40 @@
 .dialog {
   position: relative;
   z-index: 1;
-  width: min(1160px, 100%);
+  width: min(100%, 960px);
   max-height: calc(100vh - var(--space-6));
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-6);
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: var(--space-5);
   background: var(--gradient-panel);
   color: var(--color-text-primary);
   border-radius: var(--radius-xl);
+  border: 1px solid rgba(110, 140, 188, 0.35);
   box-shadow: var(--shadow-strong);
-  padding: var(--space-8) var(--space-9);
+  padding: var(--space-6) var(--space-6) var(--space-7);
   overflow: hidden;
+}
+
+.dialog[data-loading='true'] {
+  transition: opacity var(--transition-slow);
 }
 
 .header {
   display: flex;
   justify-content: space-between;
-  gap: var(--space-6);
+  gap: var(--space-5);
   align-items: flex-start;
 }
 
+.headerContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: min(44rem, 100%);
+}
+
 .kicker {
-  margin: 0 0 var(--space-2);
+  margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-size: var(--font-size-xs);
@@ -49,16 +62,45 @@
 }
 
 .title {
-  margin: 0 0 var(--space-2);
-  font-size: var(--font-size-xl);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: clamp(var(--font-size-lg), 3vw, var(--font-size-2xl));
   line-height: var(--line-height-tight);
+  min-height: 1em;
+}
+
+.titleSkeleton {
+  display: block;
+  width: min(24rem, 82%);
 }
 
 .description {
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
   color: var(--color-text-secondary);
   max-width: 36rem;
   font-size: var(--font-size-md);
+}
+
+.descriptionSkeleton {
+  display: block;
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .close {
@@ -70,7 +112,7 @@
   cursor: pointer;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
-  transition: background-color var(--transition-base), color var(--transition-base);
+  transition: background-color var(--transition-base), color var(--transition-base), transform var(--transition-fast);
 }
 
 .close:hover,
@@ -78,12 +120,41 @@
   background: rgba(100, 249, 255, 0.12);
   color: var(--color-text-primary);
   outline: none;
+  transform: translateY(-1px);
+}
+
+.errorBanner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: rgba(255, 107, 107, 0.12);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  color: var(--color-text-primary);
+}
+
+.errorTitle {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.errorMessage {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .tabList {
   display: flex;
-  flex-wrap: wrap;
   gap: var(--space-3);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.tabList[aria-busy='true'] {
+  opacity: 0.6;
 }
 
 .tab {
@@ -95,7 +166,8 @@
   padding: var(--space-2) var(--space-5);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-fast), box-shadow var(--transition-fast);
+  white-space: nowrap;
 }
 
 .tab:hover,
@@ -117,12 +189,16 @@
   box-shadow: var(--shadow-glow-purple);
 }
 
-.tabActive[data-variant='inventory'] {
-  background: linear-gradient(135deg, rgba(79, 209, 197, 0.3), rgba(79, 209, 197, 0.15));
+.tabSkeletonList {
+  display: flex;
+  gap: var(--space-3);
+  width: 100%;
 }
 
-.tabActive[data-variant='catalog'] {
-  background: linear-gradient(135deg, rgba(100, 249, 255, 0.28), rgba(66, 95, 175, 0.18));
+.tabSkeleton {
+  flex: 1;
+  min-width: 96px;
+  border-radius: var(--radius-pill);
 }
 
 .content {
@@ -131,6 +207,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  gap: var(--space-5);
 }
 
 .panel {
@@ -148,12 +225,33 @@
 }
 
 .panelProgramming {
-  flex: 1;
-  min-height: 0;
+  padding-right: 0;
+}
+
+.panelSkeletonGroup {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  padding-right: 0;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  background: rgba(18, 26, 44, 0.6);
+  border: 1px solid rgba(140, 175, 215, 0.25);
+}
+
+.panelSkeletonHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.panelSkeletonGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+}
+
+.panelSkeletonTile {
+  border-radius: var(--radius-md);
 }
 
 .placeholder {
@@ -186,10 +284,23 @@
 }
 
 @media (max-width: 960px) {
+  .overlay {
+    padding: var(--space-5) var(--space-4) var(--space-6);
+  }
+
   .dialog {
-    padding: var(--space-7) var(--space-7) var(--space-8);
+    width: min(100%, 840px);
     max-height: calc(100vh - var(--space-4));
-    width: min(960px, 100%);
+    padding: var(--space-5) var(--space-5) var(--space-6);
+    gap: var(--space-4);
+  }
+
+  .tabList {
+    gap: var(--space-2);
+  }
+
+  .tab {
+    padding: var(--space-2) var(--space-4);
   }
 
   .panel {
@@ -199,32 +310,70 @@
 
 @media (max-width: 720px) {
   .overlay {
-    align-items: flex-start;
-    padding: var(--space-5) var(--space-4);
+    align-items: stretch;
+    padding: var(--space-4) var(--space-3) var(--space-5);
   }
 
   .dialog {
-    padding: var(--space-5) var(--space-5) var(--space-6);
-    border-radius: var(--radius-lg);
-    gap: var(--space-5);
     width: 100%;
-    max-height: calc(100vh - 2 * var(--space-5));
-    height: calc(100vh - 2 * var(--space-5));
+    border-radius: var(--radius-lg);
     align-self: stretch;
   }
 
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-4);
+  }
+
+  .close {
+    align-self: flex-end;
+  }
+
   .tabList {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: var(--space-2);
+  }
+
+  .tabList::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .tabSkeletonList {
     gap: var(--space-2);
   }
 
-  .tab {
-    width: 100%;
-    justify-content: center;
-    text-align: center;
+  .tab,
+  .tabSkeleton {
+    flex: 1 0 auto;
   }
 
   .content {
     gap: var(--space-4);
-    min-height: 0;
+  }
+
+  .panelSkeletonGroup {
+    padding: var(--space-4);
+  }
+}
+
+@media (max-width: 480px) {
+  .dialog {
+    padding: var(--space-4) var(--space-4) var(--space-5);
+    border-radius: var(--radius-md);
+    max-height: calc(100vh - var(--space-3));
+  }
+
+  .title {
+    font-size: var(--font-size-xl);
+  }
+
+  .description {
+    font-size: var(--font-size-sm);
+  }
+
+  .close {
+    padding: var(--space-1) var(--space-3);
   }
 }

--- a/src/styles/Skeleton.module.css
+++ b/src/styles/Skeleton.module.css
@@ -1,0 +1,75 @@
+.skeleton {
+  display: inline-block;
+  position: relative;
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    135deg,
+    rgba(94, 112, 144, 0.35),
+    rgba(50, 68, 100, 0.35)
+  );
+  overflow: hidden;
+  transform-origin: center;
+  animation: skeletonPulse 1.8s ease-in-out infinite;
+}
+
+.block {
+  border-radius: var(--radius-md);
+}
+
+.text {
+  border-radius: var(--radius-pill);
+  min-height: 0.8em;
+}
+
+.pill {
+  border-radius: var(--radius-pill);
+}
+
+.circle {
+  border-radius: 999px;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    rgba(180, 210, 255, 0.32) 45%,
+    rgba(180, 210, 255, 0.32) 55%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: skeletonShimmer 2.4s ease-in-out infinite;
+}
+
+@keyframes skeletonPulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+@keyframes skeletonShimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton,
+  .skeleton::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add skeleton-driven loading states, responsive layout hooks, and persistence error messaging to the entity overlay
- introduce a reusable `SkeletonBlock`, hover/transition polish across chassis, inventory, and programming inspectors, and refine the drag preview animation
- extend Playwright with a Storybook visual regression spec and document the overlay class catalogue in the planning notes

## Testing
- npm test
- npm run typecheck
- npx playwright test *(fails: Storybook webServer timed out after 180000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f4a3d60c832e8789fddd6432fa08