### PR TITLE
Handle compile diagnostics in programming overlay

### DIFF
--- a/src/components/inspectors/RobotProgrammingInspector.tsx
+++ b/src/components/inspectors/RobotProgrammingInspector.tsx
@@ -60,8 +60,16 @@ const gatherModuleRequirements = (
 };
 
 const RobotProgrammingInspector = ({ entity }: InspectorProps): JSX.Element => {
-  const { workspace, onDrop, onTouchDrop, onUpdateBlock, onRemoveBlock, robotId } =
-    useProgrammingInspector();
+  const {
+    workspace,
+    onDrop,
+    onTouchDrop,
+    onUpdateBlock,
+    onRemoveBlock,
+    robotId,
+    runProgram,
+    diagnostics,
+  } = useProgrammingInspector();
   const { status, stopProgram } = useSimulationRuntime(robotId);
 
   const installedModules = useMemo(() => {
@@ -124,6 +132,8 @@ const RobotProgrammingInspector = ({ entity }: InspectorProps): JSX.Element => {
       moduleWarnings={moduleWarnings}
       activeBlockId={activeBlockId}
       warningBlockIds={warningBlockIds}
+      diagnostics={diagnostics}
+      onRunProgram={runProgram}
     />
   );
 };

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -12,11 +12,12 @@ const extractLiteral = (value: number | null | undefined): number => {
 };
 
 describe('compileWorkspaceProgram', () => {
-  it('warns when no start block is present', () => {
+  it('reports an error when no start block is present', () => {
     const result = compileWorkspaceProgram(buildWorkspace(createBlockInstance('move')));
 
     expect(result.program.instructions).toHaveLength(0);
-    expect(result.diagnostics.some((diag) => diag.message.includes('When Started'))).toBe(true);
+    const error = result.diagnostics.find((diag) => diag.message.includes('When Started'));
+    expect(error?.severity).toBe('error');
   });
 
   it('compiles a simple move routine with literal metadata', () => {

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -1016,7 +1016,7 @@ export const compileWorkspaceProgram = (workspace: WorkspaceState): CompilationR
   const startBlocks = workspace.filter((block) => block.type === 'start');
   if (startBlocks.length === 0) {
     diagnostics.push({
-      severity: 'warning',
+      severity: 'error',
       message: 'Add a "When Started" block to trigger the routine.',
     });
     return { program: { instructions: [] }, diagnostics };

--- a/src/simulation/runtime/blockProgramRunner.ts
+++ b/src/simulation/runtime/blockProgramRunner.ts
@@ -14,7 +14,7 @@ import type {
 } from './blockProgram';
 import { SimpleNavigator } from '../robot/modules/navigator';
 
-export type ProgramRunnerStatus = 'idle' | 'running' | 'completed';
+export type ProgramRunnerStatus = 'idle' | 'running' | 'completed' | 'error';
 
 const MOVEMENT_MODULE_ID = 'core.movement';
 const SCANNER_MODULE_ID = 'sensor.survey';

--- a/src/state/ProgrammingInspectorContext.tsx
+++ b/src/state/ProgrammingInspectorContext.tsx
@@ -5,6 +5,13 @@ import type {
   DropTarget,
   WorkspaceState,
 } from '../types/blocks';
+import type { Diagnostic } from '../simulation/runtime/blockProgram';
+
+export interface RunProgramResult {
+  diagnostics: Diagnostic[];
+  stepCount: number;
+  blocked: boolean;
+}
 
 interface ProgrammingInspectorContextValue {
   workspace: WorkspaceState;
@@ -13,6 +20,8 @@ interface ProgrammingInspectorContextValue {
   onUpdateBlock: (instanceId: string, updater: (block: BlockInstance) => BlockInstance) => void;
   onRemoveBlock: (instanceId: string) => void;
   robotId: string;
+  runProgram: () => RunProgramResult;
+  diagnostics: Diagnostic[];
 }
 
 const ProgrammingInspectorContext = createContext<ProgrammingInspectorContextValue | undefined>(

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -150,6 +150,25 @@ describe('simulationRuntime', () => {
     simulationRuntime.unregisterScene(scene);
   });
 
+  it('updates status to error when compile diagnostics include blocking failures', () => {
+    const statuses: ProgramRunnerStatus[] = [];
+    simulationRuntime.subscribeStatus(DEFAULT_ROBOT_ID, (status) => {
+      statuses.push(status);
+    });
+
+    simulationRuntime.reportCompileDiagnostics(DEFAULT_ROBOT_ID, [
+      { severity: 'error', message: 'Add a "When Started" block to trigger the routine.' },
+    ]);
+
+    expect(simulationRuntime.getStatus(DEFAULT_ROBOT_ID)).toBe('error');
+    expect(statuses).toContain('error');
+
+    simulationRuntime.reportCompileDiagnostics(DEFAULT_ROBOT_ID, []);
+
+    expect(simulationRuntime.getStatus(DEFAULT_ROBOT_ID)).toBe('idle');
+    expect(statuses[statuses.length - 1]).toBe('idle');
+  });
+
   it('tracks program status per robot independently', () => {
     const scene = createSceneStub();
     simulationRuntime.registerScene(scene);

--- a/src/state/simulationRuntime.ts
+++ b/src/state/simulationRuntime.ts
@@ -1,5 +1,5 @@
 import type { RootScene } from '../simulation/rootScene';
-import type { CompiledProgram } from '../simulation/runtime/blockProgram';
+import type { CompiledProgram, Diagnostic } from '../simulation/runtime/blockProgram';
 import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
 import { DEFAULT_STARTUP_PROGRAM } from '../simulation/runtime/defaultProgram';
 import { DEFAULT_ROBOT_ID } from '../simulation/runtime/simulationWorld';
@@ -179,6 +179,19 @@ class SimulationRuntime {
     if (this.scene) {
       this.scene.stopProgram(targetRobotId);
     } else {
+      this.updateStatus(targetRobotId, 'idle');
+    }
+  }
+
+  reportCompileDiagnostics(robotId: string, diagnostics: Diagnostic[]): void {
+    const targetRobotId = this.normaliseRobotId(robotId);
+    const hasErrors = diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+    if (hasErrors) {
+      this.pendingPrograms.delete(targetRobotId);
+      this.updateStatus(targetRobotId, 'error');
+      return;
+    }
+    if (this.statusByRobot.get(targetRobotId) === 'error') {
       this.updateStatus(targetRobotId, 'idle');
     }
   }

--- a/src/styles/RobotProgrammingPanel.module.css
+++ b/src/styles/RobotProgrammingPanel.module.css
@@ -183,6 +183,38 @@
   font-size: var(--font-size-sm);
 }
 
+.errorPanel {
+  background: rgba(255, 108, 249, 0.12);
+  border: 1px solid rgba(255, 108, 249, 0.4);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.errorTitle {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-accent-pink);
+}
+
+.errorDescription {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.errorList {
+  margin: 0;
+  padding-left: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+}
+
 .autosaveHint {
   margin: 0;
   color: var(--color-text-muted);

--- a/src/styles/RuntimeControls.module.css
+++ b/src/styles/RuntimeControls.module.css
@@ -84,6 +84,12 @@
   color: var(--color-text-warning);
 }
 
+.diagnosticItem[data-severity='error'] {
+  border-left-color: var(--color-accent-pink);
+  background: rgba(255, 108, 249, 0.12);
+  color: var(--color-text-primary);
+}
+
 .diagnosticIcon {
   font-size: 1rem;
 }

--- a/src/types/overlay.ts
+++ b/src/types/overlay.ts
@@ -1,4 +1,6 @@
 import type { EntityId } from '../simulation/ecs/world';
+import type { ProgramRunnerStatus } from '../simulation/runtime/blockProgramRunner';
+import type { Diagnostic } from '../simulation/runtime/blockProgram';
 import type { SlotSchema } from './slots';
 
 export type OverlayType = 'complex' | 'simple';
@@ -22,6 +24,8 @@ export interface EntityOverlayData {
   programState?: {
     isRunning: boolean;
     activeBlockId?: string | null;
+    status?: ProgramRunnerStatus;
+    diagnostics?: Diagnostic[];
   };
   properties?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- surface compile diagnostics in overlay program state and add an error status to the simulation runtime
- show blocking compile errors inside the robot programming tab while keeping non-blocking messages in the controls footer
- exercise the new behaviour with unit tests and an end-to-end check that persists errors across tab changes

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d69308b274832ead7ee8fa5cf202fb