### PR TITLE
Relax simulation overlay width clamp

### DIFF
--- a/src/styles/SimulationOverlay.module.css
+++ b/src/styles/SimulationOverlay.module.css
@@ -20,7 +20,7 @@
 .dialog {
   position: relative;
   z-index: 1;
-  width: min(1160px, 100%);
+  width: clamp(320px, calc(100vw - 12vw), 1400px);
   max-height: calc(100vh - var(--space-6));
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- widen the simulation overlay dialog width using a clamp that preserves the 6vw margin so it scales with large viewports

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d6b90bde68832eba7148240e2e97cc