### PR TITLE
Surface runtime block debug metadata in the UI

### DIFF
--- a/src/components/inspectors/__tests__/MechanismProgrammingInspector.test.tsx
+++ b/src/components/inspectors/__tests__/MechanismProgrammingInspector.test.tsx
@@ -73,11 +73,14 @@ const renderInspector = (
     diagnostics,
   };
 
-  return render(
-    <ProgrammingInspectorProvider value={contextValue}>
-      <MechanismProgrammingInspector entity={entity} onClose={() => {}} />
-    </ProgrammingInspectorProvider>,
-  );
+  return {
+    contextValue,
+    ...render(
+      <ProgrammingInspectorProvider value={contextValue}>
+        <MechanismProgrammingInspector entity={entity} onClose={() => {}} />
+      </ProgrammingInspectorProvider>,
+    ),
+  };
 };
 
 beforeEach(() => {
@@ -138,5 +141,27 @@ describe('MechanismProgrammingInspector', () => {
     expect(errorPanel).toHaveTextContent(/resolve compile errors/i);
     expect(errorPanel).toHaveTextContent(/fix the issues below/i);
     expect(errorPanel).toHaveTextContent(/When Started/i);
+  });
+
+  it('updates the active block highlight when the program state changes', () => {
+    mockStatus = 'running';
+    const workspace = createWorkspaceWithMoveBlock();
+    const moveBlockId = workspace[0]?.slots?.do?.[0]?.instanceId ?? null;
+    const baseEntity = createEntity({ programState: { isRunning: true, activeBlockId: null } });
+
+    const { rerender, contextValue } = renderInspector(baseEntity, workspace);
+
+    const moveBlock = screen.getByTestId('block-move');
+    expect(moveBlock).not.toHaveAttribute('data-state-active', 'true');
+
+    const updatedEntity = createEntity({ programState: { isRunning: true, activeBlockId: moveBlockId } });
+
+    rerender(
+      <ProgrammingInspectorProvider value={contextValue}>
+        <MechanismProgrammingInspector entity={updatedEntity} onClose={() => {}} />
+      </ProgrammingInspectorProvider>,
+    );
+
+    expect(screen.getByTestId('block-move')).toHaveAttribute('data-state-active', 'true');
   });
 });

--- a/src/simulation/ecs/systems/__tests__/systems.test.ts
+++ b/src/simulation/ecs/systems/__tests__/systems.test.ts
@@ -343,6 +343,7 @@ describe('simulation systems', () => {
       {
         kind: 'wait',
         duration: createNumberLiteralBinding(1, { label: 'Debug → wait' }),
+        sourceBlockId: 'debug-wait',
       },
       {
         kind: 'loop',
@@ -352,8 +353,10 @@ describe('simulation systems', () => {
             kind: 'gather',
             duration: createNumberLiteralBinding(2, { label: 'Debug → gather' }),
             target: 'auto',
+            sourceBlockId: 'debug-gather',
           },
         ],
+        sourceBlockId: 'debug-loop',
       },
     ];
 
@@ -364,6 +367,7 @@ describe('simulation systems', () => {
         kind: 'move',
         duration: createNumberLiteralBinding(2, { label: 'Debug → move duration' }),
         speed: createNumberLiteralBinding(3, { label: 'Debug → move speed' }),
+        sourceBlockId: 'debug-move',
       },
       timeRemaining: 1.25,
       frames: [{ kind: 'sequence', index: 0, length: 2 }],

--- a/src/simulation/runtime/__tests__/blockProgram.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgram.test.ts
@@ -33,11 +33,13 @@ describe('compileWorkspaceProgram', () => {
     if (moveInstruction.kind !== 'move') {
       throw new Error('Expected the first instruction to be a move.');
     }
+    expect(moveInstruction.sourceBlockId).toBe(move.instanceId);
     expect(extractLiteral(moveInstruction.duration.literal?.value)).toBeCloseTo(1);
     expect(extractLiteral(moveInstruction.speed.literal?.value)).toBeGreaterThan(0);
     if (waitInstruction.kind !== 'wait') {
       throw new Error('Expected the second instruction to be a wait.');
     }
+    expect(waitInstruction.sourceBlockId).toBe(wait.instanceId);
     expect(extractLiteral(waitInstruction.duration.literal?.value)).toBeCloseTo(1);
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -61,6 +63,7 @@ describe('compileWorkspaceProgram', () => {
     if (instruction.kind !== 'move-to') {
       throw new Error('Expected a move-to instruction.');
     }
+    expect(instruction.sourceBlockId).toBe(moveTo.instanceId);
     expect(instruction.target.useScanHit.literal?.value).toBe(false);
     expect(instruction.target.useScanHit.literal?.source).toBe('user');
     expect(instruction.target.scanHitIndex.literal?.value).toBe(2);
@@ -81,10 +84,12 @@ describe('compileWorkspaceProgram', () => {
     const [scanInstruction, gatherInstruction] = result.program.instructions;
     expect(scanInstruction).toMatchObject({ kind: 'scan', filter: null });
     if (scanInstruction.kind === 'scan') {
+      expect(scanInstruction.sourceBlockId).toBe(scan.instanceId);
       expect(extractLiteral(scanInstruction.duration.literal?.value)).toBeGreaterThan(0);
     }
     expect(gatherInstruction).toMatchObject({ kind: 'gather', target: 'auto' });
     if (gatherInstruction.kind === 'gather') {
+      expect(gatherInstruction.sourceBlockId).toBe(gather.instanceId);
       expect(extractLiteral(gatherInstruction.duration.literal?.value)).toBeGreaterThan(0);
     }
   });
@@ -103,6 +108,7 @@ describe('compileWorkspaceProgram', () => {
     if (statusInstruction.kind !== 'status-set') {
       throw new Error('Expected a status-set instruction.');
     }
+    expect(statusInstruction.sourceBlockId).toBe(setStatus.instanceId);
     expect(statusInstruction.duration.literal?.value).toBe(0);
     expect(statusInstruction.value.literal?.value).toBe(false);
     expect(statusInstruction.value.literal?.source).toBe('user');
@@ -122,9 +128,11 @@ describe('compileWorkspaceProgram', () => {
     if (loop.kind !== 'loop') {
       throw new Error('Expected a loop instruction to be emitted.');
     }
+    expect(loop.sourceBlockId).toBe(forever.instanceId);
     expect(loop.mode).toBe('forever');
     expect(loop.instructions).toHaveLength(1);
     expect(loop.instructions[0]).toMatchObject({ kind: 'gather', target: 'auto' });
+    expect(loop.instructions[0]?.sourceBlockId).toBe(gather.instanceId);
   });
 
   it('compiles repeat blocks into counted loops with defaults', () => {
@@ -144,6 +152,7 @@ describe('compileWorkspaceProgram', () => {
     if (instruction.mode !== 'counted') {
       throw new Error('Expected a counted loop.');
     }
+    expect(instruction.sourceBlockId).toBe(repeat.instanceId);
     expect(extractLiteral(instruction.iterations.literal?.value)).toBe(3);
     expect(instruction.iterations.literal?.source).toBe('default');
     expect(result.diagnostics).toHaveLength(0);
@@ -164,6 +173,7 @@ describe('compileWorkspaceProgram', () => {
     if (instruction.kind !== 'loop' || instruction.mode !== 'counted') {
       throw new Error('Expected a counted loop instruction.');
     }
+    expect(instruction.sourceBlockId).toBe(repeat.instanceId);
     expect(instruction.iterations.literal?.value).toBe(5);
     expect(instruction.iterations.literal?.source).toBe('user');
   });
@@ -186,8 +196,11 @@ describe('compileWorkspaceProgram', () => {
     if (branch.kind !== 'branch') {
       throw new Error('Expected a branch instruction.');
     }
+    expect(branch.sourceBlockId).toBe(conditional.instanceId);
     expect(branch.whenTrue).toHaveLength(1);
     expect(branch.whenFalse).toHaveLength(1);
+    expect(branch.whenTrue[0]?.sourceBlockId).toBe(thenTurn.instanceId);
+    expect(branch.whenFalse[0]?.sourceBlockId).toBe(elseMove.instanceId);
     expect(branch.condition.literal?.value).toBe(false);
     expect(branch.condition.literal?.source).toBe('user');
     expect(result.diagnostics).toHaveLength(0);

--- a/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
@@ -37,6 +37,7 @@ describe('BlockProgramRunner', () => {
           kind: 'move',
           duration: createNumberLiteralBinding(1, { label: 'Test → move duration' }),
           speed: createNumberLiteralBinding(40, { label: 'Test → move speed' }),
+          sourceBlockId: 'test-move',
         },
       ],
     };
@@ -73,6 +74,7 @@ describe('BlockProgramRunner', () => {
           kind: 'turn',
           duration: createNumberLiteralBinding(0.5, { label: 'Test → turn duration' }),
           angularVelocity: createNumberLiteralBinding(Math.PI, { label: 'Test → turn rate' }),
+          sourceBlockId: 'test-turn',
         },
       ],
     };
@@ -103,11 +105,13 @@ describe('BlockProgramRunner', () => {
           kind: 'scan',
           duration: createNumberLiteralBinding(1, { label: 'Test → scan duration' }),
           filter: null,
+          sourceBlockId: 'test-scan',
         },
         {
           kind: 'gather',
           duration: createNumberLiteralBinding(1.5, { label: 'Test → gather duration' }),
           target: 'auto',
+          sourceBlockId: 'test-gather',
         },
       ],
     };
@@ -177,6 +181,7 @@ describe('BlockProgramRunner', () => {
           kind: 'scan',
           duration: createNumberLiteralBinding(0.25, { label: 'Test → scan duration' }),
           filter: scanFilter,
+          sourceBlockId: 'test-scan-memory',
         },
       ],
     };
@@ -247,6 +252,7 @@ describe('BlockProgramRunner', () => {
           kind: 'scan',
           duration: createNumberLiteralBinding(1, { label: 'Test → scan duration' }),
           filter: null,
+          sourceBlockId: 'test-steer-scan',
         },
         {
           kind: 'move-to',
@@ -260,6 +266,7 @@ describe('BlockProgramRunner', () => {
               y: createNumberLiteralBinding(0, { label: 'Test → fallback Y' }),
             },
           },
+          sourceBlockId: 'test-steer-move-to',
         },
       ],
     };
@@ -326,6 +333,7 @@ describe('BlockProgramRunner', () => {
         {
           kind: 'deposit',
           duration: createNumberLiteralBinding(1, { label: 'Test → deposit duration' }),
+          sourceBlockId: 'test-deposit',
         },
       ],
     };
@@ -379,8 +387,10 @@ describe('BlockProgramRunner', () => {
               kind: 'gather',
               duration: createNumberLiteralBinding(1.5, { label: 'Test → gather duration' }),
               target: 'auto',
+              sourceBlockId: 'test-loop-gather',
             },
           ],
+          sourceBlockId: 'test-loop',
         },
       ],
     };
@@ -445,8 +455,10 @@ describe('BlockProgramRunner', () => {
               kind: 'move',
               duration: createNumberLiteralBinding(0.2, { label: 'Test → move duration' }),
               speed: createNumberLiteralBinding(10, { label: 'Test → move speed' }),
+              sourceBlockId: 'test-counted-move',
             },
           ],
+          sourceBlockId: 'test-counted-loop',
         },
       ],
     };
@@ -482,6 +494,7 @@ describe('BlockProgramRunner', () => {
               kind: 'status-set',
               duration: createNumberLiteralBinding(0, { label: 'Branch → true duration' }),
               value: createBooleanLiteralBinding(true, { label: 'Branch → true value' }),
+              sourceBlockId: 'test-branch-true',
             },
           ],
           whenFalse: [
@@ -489,8 +502,10 @@ describe('BlockProgramRunner', () => {
               kind: 'status-set',
               duration: createNumberLiteralBinding(0, { label: 'Branch → false duration' }),
               value: createBooleanLiteralBinding(false, { label: 'Branch → false value' }),
+              sourceBlockId: 'test-branch-false',
             },
           ],
+          sourceBlockId: 'test-branch',
         },
       ],
     };
@@ -518,6 +533,7 @@ describe('BlockProgramRunner', () => {
           kind: 'move',
           duration: createNumberLiteralBinding(1, { label: 'Debug → move duration' }),
           speed: createNumberLiteralBinding(20, { label: 'Debug → move speed' }),
+          sourceBlockId: 'debug-move',
         },
         {
           kind: 'loop',
@@ -527,8 +543,10 @@ describe('BlockProgramRunner', () => {
               kind: 'turn',
               duration: createNumberLiteralBinding(0.5, { label: 'Debug → turn duration' }),
               angularVelocity: createNumberLiteralBinding(Math.PI, { label: 'Debug → turn rate' }),
+              sourceBlockId: 'debug-turn',
             },
           ],
+          sourceBlockId: 'debug-loop',
         },
       ],
     };
@@ -539,6 +557,7 @@ describe('BlockProgramRunner', () => {
     expect(initialDebug.status).toBe('running');
     expect(initialDebug.program).toBe(program);
     expect(initialDebug.currentInstruction?.kind).toBe('move');
+    expect(initialDebug.currentInstruction?.sourceBlockId).toBe('debug-move');
     expect(initialDebug.frames).toHaveLength(1);
     expect(initialDebug.frames[0]).toMatchObject({ kind: 'sequence', index: 0, length: 2 });
 
@@ -547,6 +566,7 @@ describe('BlockProgramRunner', () => {
 
     const loopDebug = runner.getDebugState();
     expect(loopDebug.currentInstruction?.kind).toBe('turn');
+    expect(loopDebug.currentInstruction?.sourceBlockId).toBe('debug-turn');
     expect(loopDebug.frames).toEqual([
       expect.objectContaining({ kind: 'sequence', index: 2, length: 2 }),
       expect.objectContaining({ kind: 'loop', index: 0, length: 1 }),

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -91,69 +91,73 @@ export interface MoveToTargetMetadata {
   };
 }
 
-export interface MoveToInstruction {
+export interface BlockInstructionMetadata {
+  sourceBlockId: string;
+}
+
+export type MoveToInstruction = BlockInstructionMetadata & {
   kind: 'move-to';
   duration: NumberParameterBinding;
   speed: NumberParameterBinding;
   target: MoveToTargetMetadata;
-}
+};
 
 export type BlockInstruction =
   | MoveToInstruction
-  | {
+  | (BlockInstructionMetadata & {
       kind: 'move';
       duration: NumberParameterBinding;
       speed: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'turn';
       duration: NumberParameterBinding;
       angularVelocity: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'wait';
       duration: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'scan';
       duration: NumberParameterBinding;
       filter: string | null;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'gather';
       duration: NumberParameterBinding;
       target: 'auto';
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'deposit';
       duration: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'status-toggle';
       duration: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'status-set';
       duration: NumberParameterBinding;
       value: BooleanParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'loop';
       mode: 'forever';
       instructions: BlockInstruction[];
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'loop';
       mode: 'counted';
       instructions: BlockInstruction[];
       iterations: NumberParameterBinding;
-    }
-  | {
+    })
+  | (BlockInstructionMetadata & {
       kind: 'branch';
       condition: BooleanParameterBinding;
       whenTrue: BlockInstruction[];
       whenFalse: BlockInstruction[];
-    };
+    });
 
 export interface CompiledProgram {
   instructions: BlockInstruction[];
@@ -805,6 +809,7 @@ const compileBlock = (
   diagnostics: Diagnostic[],
   context: CompilationContext,
 ): BlockInstruction[] => {
+  const sourceBlockId = block.instanceId;
   switch (block.type) {
     case 'move':
       return [
@@ -812,6 +817,7 @@ const compileBlock = (
           kind: 'move',
           duration: createNumberLiteralBinding(1, { label: 'Move → duration' }),
           speed: createNumberLiteralBinding(MOVE_SPEED, { label: 'Move → speed' }),
+          sourceBlockId,
         },
       ];
     case 'move-to': {
@@ -851,6 +857,7 @@ const compileBlock = (
               y: targetYBinding,
             },
           },
+          sourceBlockId,
         },
       ];
     }
@@ -860,6 +867,7 @@ const compileBlock = (
           kind: 'turn',
           duration: createNumberLiteralBinding(1, { label: 'Turn → duration' }),
           angularVelocity: createNumberLiteralBinding(TURN_RATE, { label: 'Turn → rate' }),
+          sourceBlockId,
         },
       ];
     case 'wait':
@@ -867,6 +875,7 @@ const compileBlock = (
         {
           kind: 'wait',
           duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Wait → duration' }),
+          sourceBlockId,
         },
       ];
     case 'scan-resources':
@@ -875,6 +884,7 @@ const compileBlock = (
           kind: 'scan',
           duration: createNumberLiteralBinding(SCAN_DURATION, { label: 'Scan → duration' }),
           filter: null,
+          sourceBlockId,
         },
       ];
     case 'gather-resource':
@@ -883,6 +893,7 @@ const compileBlock = (
           kind: 'gather',
           duration: createNumberLiteralBinding(GATHER_DURATION, { label: 'Gather → duration' }),
           target: 'auto',
+          sourceBlockId,
         },
       ];
     case 'deposit-cargo':
@@ -890,6 +901,7 @@ const compileBlock = (
         {
           kind: 'deposit',
           duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Deposit → duration' }),
+          sourceBlockId,
         },
       ];
     case 'toggle-status':
@@ -897,6 +909,7 @@ const compileBlock = (
         {
           kind: 'status-toggle',
           duration: createNumberLiteralBinding(0, { label: 'Toggle Status → duration' }),
+          sourceBlockId,
         },
       ];
     case 'set-status': {
@@ -909,6 +922,7 @@ const compileBlock = (
           kind: 'status-set',
           duration: createNumberLiteralBinding(0, { label: 'Set Status → duration' }),
           value: valueBinding,
+          sourceBlockId,
         },
       ];
     }
@@ -933,6 +947,7 @@ const compileBlock = (
           mode: 'counted',
           iterations: countBinding,
           instructions: inner,
+          sourceBlockId,
         },
       ];
     }
@@ -965,6 +980,7 @@ const compileBlock = (
           kind: 'loop',
           mode: 'forever',
           instructions: inner,
+          sourceBlockId,
         },
       ];
     }
@@ -991,6 +1007,7 @@ const compileBlock = (
           condition: conditionBinding,
           whenTrue: thenInstructions,
           whenFalse: elseInstructions,
+          sourceBlockId,
         },
       ];
     }

--- a/src/simulation/runtime/defaultProgram.ts
+++ b/src/simulation/runtime/defaultProgram.ts
@@ -8,9 +8,18 @@ export const DEFAULT_STARTUP_PROGRAM: CompiledProgram = {
       kind: 'loop',
       mode: 'forever',
       instructions: [
-        { kind: 'status-toggle', duration: createNumberLiteralBinding(0, { label: 'Startup → toggle' }) },
-        { kind: 'wait', duration: createNumberLiteralBinding(BLINK_INTERVAL_SECONDS, { label: 'Startup → wait' }) },
+        {
+          kind: 'status-toggle',
+          duration: createNumberLiteralBinding(0, { label: 'Startup → toggle' }),
+          sourceBlockId: 'default-startup-toggle',
+        },
+        {
+          kind: 'wait',
+          duration: createNumberLiteralBinding(BLINK_INTERVAL_SECONDS, { label: 'Startup → wait' }),
+          sourceBlockId: 'default-startup-wait',
+        },
       ],
+      sourceBlockId: 'default-startup-loop',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- add sourceBlockId metadata to compiled block instructions and the default startup program so runtime steps know their origin blocks
- let BlockProgramRunner and RootScene broadcast enriched debug state, cache the latest per mechanism, and expose subscribe/get helpers from the simulation runtime
- hook the app overlays and inspector tests into the new debug feed so active blocks track the runtime state in real time

## Testing
- npm run typecheck
- npm test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d6c8475220832e9aef2dc696de9ffc