### PR TITLE
Refactor runtime state management into modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useBlockWorkspace } from './hooks/useBlockWorkspace';
 import OnboardingFlow from './onboarding/OnboardingFlow';
 import { useMechanismSelection } from './hooks/useMechanismSelection';
 import { simulationRuntime } from './state/simulationRuntime';
+import { chassisState, inventoryState } from './state/runtime';
 import {
   EntityOverlayManagerProvider,
   useEntityOverlayManager,
@@ -148,15 +149,15 @@ const AppContent = (): JSX.Element => {
     () => selectedMechanismId ?? DEFAULT_MECHANISM_ID,
   );
   const [chassisSnapshot, setChassisSnapshot] = useState<ChassisSnapshot>(() =>
-    simulationRuntime.getChassisSnapshot(selectedMechanismId ?? DEFAULT_MECHANISM_ID),
+    chassisState.getSnapshot(),
   );
   const [inventoryOverlay, setInventoryOverlay] = useState<InventoryOverlayView>(() =>
-    buildInventoryOverlayData(simulationRuntime.getInventorySnapshot()),
+    buildInventoryOverlayData(inventoryState.getSnapshot()),
   );
   const [debugStatesByMechanism, setDebugStatesByMechanism] = useState<Record<string, ProgramDebugState>>({});
 
   const activeMechanismId = useMemo(() => selectedMechanismId ?? DEFAULT_MECHANISM_ID, [selectedMechanismId]);
-  useEffect(() => simulationRuntime.subscribeChassis(setChassisSnapshot), []);
+  useEffect(() => chassisState.subscribe(setChassisSnapshot), []);
 
   useEffect(() => {
     const nextState = simulationRuntime.getProgramDebugState(activeMechanismId);
@@ -185,7 +186,7 @@ const AppContent = (): JSX.Element => {
 
   useEffect(
     () =>
-      simulationRuntime.subscribeInventory((snapshot) => {
+      inventoryState.subscribe((snapshot) => {
         setInventoryOverlay((current) => {
           const next = buildInventoryOverlayData(snapshot);
           if (areInventoryOverlaysEqual(current, next)) {
@@ -198,7 +199,7 @@ const AppContent = (): JSX.Element => {
   );
 
   useEffect(() => {
-    setChassisSnapshot(simulationRuntime.getChassisSnapshot(selectedMechanismId));
+    setChassisSnapshot(chassisState.getSnapshot());
   }, [selectedMechanismId]);
 
   const getWorkspaceForMechanism = useCallback(

--- a/src/components/__tests__/BlockParameterEditors.test.tsx
+++ b/src/components/__tests__/BlockParameterEditors.test.tsx
@@ -6,6 +6,7 @@ import { BLOCK_MAP, createBlockInstance } from '../../blocks/library';
 import type { BlockInstance } from '../../types/blocks';
 import useMechanismTelemetry from '../../hooks/useMechanismTelemetry';
 import { simulationRuntime } from '../../state/simulationRuntime';
+import { telemetryState } from '../../state/runtime';
 import type { SimulationTelemetrySnapshot } from '../../simulation/runtime/ecsBlackboard';
 
 afterEach(() => {
@@ -161,8 +162,8 @@ describe('Block parameter editors', () => {
     let telemetryListener: ((snapshot: SimulationTelemetrySnapshot, mechanismId: string | null) => void) | null = null;
 
     vi.spyOn(simulationRuntime, 'getSelectedMechanism').mockReturnValue('MF-01');
-    vi.spyOn(simulationRuntime, 'getTelemetrySnapshot').mockReturnValue(initialSnapshot);
-    vi.spyOn(simulationRuntime, 'subscribeTelemetry').mockImplementation((listener) => {
+    vi.spyOn(telemetryState, 'getSnapshot').mockReturnValue(initialSnapshot);
+    vi.spyOn(telemetryState, 'subscribe').mockImplementation((listener) => {
       telemetryListener = listener;
       listener(initialSnapshot, 'MF-01');
       return () => {};

--- a/src/hooks/useInventoryTelemetry.ts
+++ b/src/hooks/useInventoryTelemetry.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import type { InventorySnapshot } from '../simulation/mechanism/inventory';
-import { simulationRuntime } from '../state/simulationRuntime';
+import { inventoryState } from '../state/runtime';
 
 export const useInventoryTelemetry = (): InventorySnapshot => {
-  const [snapshot, setSnapshot] = useState<InventorySnapshot>(simulationRuntime.getInventorySnapshot());
+  const [snapshot, setSnapshot] = useState<InventorySnapshot>(inventoryState.getSnapshot());
 
-  useEffect(() => simulationRuntime.subscribeInventory(setSnapshot), []);
+  useEffect(() => inventoryState.subscribe(setSnapshot), []);
 
   return snapshot;
 };

--- a/src/hooks/useMechanismTelemetry.ts
+++ b/src/hooks/useMechanismTelemetry.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { SimulationTelemetrySnapshot } from '../simulation/runtime/ecsBlackboard';
 import { MODULE_LIBRARY } from '../simulation/mechanism/modules/moduleLibrary';
 import { simulationRuntime } from '../state/simulationRuntime';
+import { telemetryState } from '../state/runtime';
 
 interface TelemetryValueMetadata {
   label?: string;
@@ -110,13 +111,13 @@ const EMPTY_TELEMETRY: SimulationTelemetrySnapshot = { values: {}, actions: {} }
 export const useMechanismTelemetry = (): MechanismTelemetryData => {
   const [state, setState] = useState<{ mechanismId: string | null; snapshot: SimulationTelemetrySnapshot }>(() => {
     const mechanismId = simulationRuntime.getSelectedMechanism();
-    const snapshot = simulationRuntime.getTelemetrySnapshot(mechanismId ?? null);
+    const snapshot = telemetryState.getSnapshot(mechanismId ?? null);
     return { mechanismId, snapshot };
   });
 
   useEffect(
     () =>
-      simulationRuntime.subscribeTelemetry((snapshot, mechanismId) => {
+      telemetryState.subscribe((snapshot, mechanismId) => {
         setState((current) => ({ mechanismId: mechanismId ?? current.mechanismId ?? null, snapshot }));
       }),
     [],

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { simulationRuntime } from '../simulationRuntime';
+import { chassisState, inventoryState, telemetryState } from '../runtime';
 import { DEFAULT_STARTUP_PROGRAM } from '../../simulation/runtime/defaultProgram';
 import { DEFAULT_MECHANISM_ID } from '../../simulation/runtime/simulationWorld';
 import { createNumberLiteralBinding, type CompiledProgram } from '../../simulation/runtime/blockProgram';
@@ -132,6 +133,9 @@ describe('simulationRuntime', () => {
     simulationRuntime.stopProgram(DEFAULT_MECHANISM_ID);
     simulationRuntime.stopProgram('MF-02');
     simulationRuntime.clearSelectedMechanism();
+    inventoryState.clear();
+    chassisState.clear();
+    telemetryState.clear();
   });
 
   it('runs the default startup program when a scene registers', () => {

--- a/src/state/overlayPersistence.ts
+++ b/src/state/overlayPersistence.ts
@@ -1,6 +1,6 @@
 import type { EntityId } from '../simulation/ecs/world';
-import { simulationRuntime } from './simulationRuntime';
 import type { EntityOverlayData } from '../types/overlay';
+import { chassisState, inventoryState } from './runtime';
 
 export interface OverlayPersistenceAdapter {
   saveEntity: (next: EntityOverlayData, previous: EntityOverlayData | undefined) => Promise<void>;
@@ -13,10 +13,10 @@ const defaultAdapter: OverlayPersistenceAdapter = {
       return;
     }
     if (next.chassis) {
-      simulationRuntime.applyChassisOverlayUpdate(next.chassis);
+      chassisState.applyOverlayUpdate(next.chassis);
     }
     if (next.inventory) {
-      simulationRuntime.applyInventoryOverlayUpdate(next.inventory);
+      inventoryState.applyOverlayUpdate(next.inventory);
     }
   },
   async removeEntity() {

--- a/src/state/runtime/__tests__/chassisState.test.ts
+++ b/src/state/runtime/__tests__/chassisState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ChassisState, EMPTY_CHASSIS_SNAPSHOT } from '../chassisState';
+import type { SlotSchema } from '../../../types/slots';
+
+const createSlot = (overrides: Partial<SlotSchema> = {}): SlotSchema => ({
+  id: 'slot-0',
+  index: 0,
+  occupantId: null,
+  metadata: { stackable: true, moduleSubtype: undefined, locked: false },
+  stackCount: 1,
+  ...overrides,
+});
+
+describe('ChassisState', () => {
+  it('updates slots based on overlay data', () => {
+    const state = new ChassisState();
+    const snapshots: typeof EMPTY_CHASSIS_SNAPSHOT[] = [];
+
+    state.subscribe((snapshot) => {
+      snapshots.push(snapshot);
+    });
+
+    state.applyOverlayUpdate({
+      capacity: 3,
+      slots: [createSlot({ index: 2 }), createSlot({ index: 0 }), createSlot({ index: 1 })],
+    });
+
+    expect(snapshots).toHaveLength(2);
+    const [initial, updated] = snapshots;
+    expect(initial).toEqual(EMPTY_CHASSIS_SNAPSHOT);
+    expect(updated.capacity).toBe(3);
+    expect(updated.slots.map((slot) => slot.index)).toEqual([0, 1, 2]);
+  });
+
+  it('runs activation handlers when listeners attach', () => {
+    const state = new ChassisState();
+    const onActive = vi.fn();
+    const onInactive = vi.fn();
+
+    state.setActivationHandlers({ onActive, onInactive });
+    const unsubscribe = state.subscribe(() => {});
+
+    expect(onActive).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    expect(onInactive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/state/runtime/__tests__/inventoryState.test.ts
+++ b/src/state/runtime/__tests__/inventoryState.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InventoryState, EMPTY_INVENTORY_SNAPSHOT } from '../inventoryState';
+import type { SlotSchema } from '../../../types/slots';
+
+const createSlot = (overrides: Partial<SlotSchema> = {}): SlotSchema => ({
+  id: 'slot-0',
+  index: 0,
+  occupantId: 'MF-RESOURCE',
+  metadata: { stackable: true, moduleSubtype: undefined, locked: false },
+  stackCount: 1,
+  ...overrides,
+});
+
+describe('InventoryState', () => {
+  it('notifies listeners with overlay updates', () => {
+    const state = new InventoryState();
+    const snapshots: typeof EMPTY_INVENTORY_SNAPSHOT[] = [];
+
+    state.subscribe((snapshot) => {
+      snapshots.push(snapshot);
+    });
+
+    state.applyOverlayUpdate({
+      capacity: 4,
+      slots: [
+        createSlot({ index: 2, occupantId: 'ORE', stackCount: 3 }),
+        createSlot({ index: 0, occupantId: 'ORE', stackCount: 2 }),
+        createSlot({ index: 1, occupantId: 'CRYSTAL', stackCount: 1 }),
+      ],
+    });
+
+    expect(snapshots).toHaveLength(2);
+    const [initial, updated] = snapshots;
+    expect(initial).toEqual(EMPTY_INVENTORY_SNAPSHOT);
+    expect(updated.capacity).toBe(6);
+    expect(updated.used).toBe(6);
+    expect(updated.available).toBe(0);
+    const sortedEntries = [...updated.entries].sort((a, b) => a.resource.localeCompare(b.resource));
+    expect(sortedEntries).toEqual([
+      { resource: 'CRYSTAL', quantity: 1 },
+      { resource: 'ORE', quantity: 5 },
+    ]);
+    expect(updated.slots.map((slot) => slot.index)).toEqual([0, 1, 2]);
+  });
+
+  it('invokes activation handlers when listeners change', () => {
+    const state = new InventoryState();
+    const onActive = vi.fn();
+    const onInactive = vi.fn();
+
+    state.setActivationHandlers({ onActive, onInactive });
+
+    const unsubscribe = state.subscribe(() => {});
+    expect(onActive).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    expect(onInactive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/state/runtime/__tests__/telemetryState.test.ts
+++ b/src/state/runtime/__tests__/telemetryState.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TelemetryState, EMPTY_TELEMETRY_SNAPSHOT } from '../telemetryState';
+
+const createValueEntry = (value: unknown) => ({
+  value,
+  metadata: {},
+  revision: 1,
+});
+
+const createActionEntry = () => ({
+  metadata: {},
+  revision: 1,
+});
+
+const createSnapshot = (overrides: Partial<typeof EMPTY_TELEMETRY_SNAPSHOT> = {}) => ({
+  values: {},
+  actions: {},
+  ...overrides,
+});
+
+describe('TelemetryState', () => {
+  it('tracks the active mechanism snapshot', () => {
+    const state = new TelemetryState();
+    const listener = vi.fn();
+    state.subscribe(listener);
+
+    const nextSnapshot = createSnapshot({ values: { core: { signal: createValueEntry(42) } } });
+    state.setActiveSnapshot(nextSnapshot, 'MF-01');
+
+    expect(listener).toHaveBeenLastCalledWith(nextSnapshot, 'MF-01');
+    expect(state.getSnapshot('MF-01')).toEqual(nextSnapshot);
+  });
+
+  it('stores snapshots for inactive mechanisms', () => {
+    const state = new TelemetryState();
+    const listener = vi.fn();
+    state.subscribe(listener);
+
+    const cachedSnapshot = createSnapshot({ actions: { drive: { thrust: createActionEntry() } } });
+    state.storeSnapshot(cachedSnapshot, 'MF-02');
+
+    expect(listener).toHaveBeenLastCalledWith(cachedSnapshot, 'MF-02');
+    expect(state.getSnapshot('MF-02')).toEqual(cachedSnapshot);
+  });
+
+  it('activates cached snapshots before fetching', () => {
+    const state = new TelemetryState();
+    const cachedSnapshot = createSnapshot({ values: { core: { power: createValueEntry(12) } } });
+    state.storeSnapshot(cachedSnapshot, 'MF-03');
+
+    const fetchSnapshot = vi.fn(() => createSnapshot({ values: { core: { power: createValueEntry(8) } } }));
+    state.activateMechanism('MF-03', fetchSnapshot);
+
+    expect(fetchSnapshot).not.toHaveBeenCalled();
+    expect(state.getSnapshot('MF-03')).toEqual(cachedSnapshot);
+
+    state.activateMechanism('MF-04', fetchSnapshot);
+    expect(fetchSnapshot).toHaveBeenCalledWith('MF-04');
+    expect(state.getSnapshot('MF-04')).toEqual(fetchSnapshot.mock.results[0].value);
+  });
+
+  it('clears cached telemetry when requested', () => {
+    const state = new TelemetryState();
+    const listener = vi.fn();
+    state.subscribe(listener);
+
+    state.setActiveSnapshot(createSnapshot({ values: { core: { signal: createValueEntry(1) } } }), 'MF-01');
+    state.storeSnapshot(createSnapshot({ values: { core: { signal: createValueEntry(2) } } }), 'MF-02');
+
+    state.clear();
+
+    expect(listener).toHaveBeenLastCalledWith(EMPTY_TELEMETRY_SNAPSHOT, null);
+    expect(state.getSnapshot('MF-01')).toEqual(EMPTY_TELEMETRY_SNAPSHOT);
+    expect(state.getSnapshot('MF-02')).toEqual(EMPTY_TELEMETRY_SNAPSHOT);
+  });
+});

--- a/src/state/runtime/chassisState.ts
+++ b/src/state/runtime/chassisState.ts
@@ -1,0 +1,89 @@
+import type { ChassisSnapshot } from '../../simulation/mechanism';
+import type { SlotSchema } from '../../types/slots';
+
+export type ChassisListener = (snapshot: ChassisSnapshot) => void;
+
+export interface ChassisOverlayUpdate {
+  capacity: number;
+  slots: SlotSchema[];
+}
+
+export interface ChassisActivationHandlers {
+  onActive?: () => void;
+  onInactive?: () => void;
+}
+
+const EMPTY_CHASSIS_SNAPSHOT_INTERNAL: ChassisSnapshot = {
+  capacity: 0,
+  slots: [],
+};
+
+export const EMPTY_CHASSIS_SNAPSHOT: ChassisSnapshot = EMPTY_CHASSIS_SNAPSHOT_INTERNAL;
+
+const normaliseSlot = (slot: SlotSchema): SlotSchema => ({
+  ...slot,
+  metadata: { ...slot.metadata },
+});
+
+export class ChassisState {
+  private snapshot: ChassisSnapshot = EMPTY_CHASSIS_SNAPSHOT_INTERNAL;
+  private readonly listeners = new Set<ChassisListener>();
+  private onActive: (() => void) | undefined;
+  private onInactive: (() => void) | undefined;
+
+  setActivationHandlers(handlers: ChassisActivationHandlers): void {
+    this.onActive = handlers.onActive;
+    this.onInactive = handlers.onInactive;
+    if (this.listeners.size > 0) {
+      this.onActive?.();
+    }
+  }
+
+  subscribe(listener: ChassisListener): () => void {
+    this.listeners.add(listener);
+    if (this.listeners.size === 1) {
+      this.onActive?.();
+    }
+    listener(this.snapshot);
+    return () => {
+      if (!this.listeners.delete(listener)) {
+        return;
+      }
+      if (this.listeners.size === 0) {
+        this.onInactive?.();
+      }
+    };
+  }
+
+  hasListeners(): boolean {
+    return this.listeners.size > 0;
+  }
+
+  getSnapshot(): ChassisSnapshot {
+    return this.snapshot;
+  }
+
+  setSnapshot(snapshot: ChassisSnapshot): void {
+    this.snapshot = snapshot;
+    this.notify();
+  }
+
+  applyOverlayUpdate(update: ChassisOverlayUpdate): void {
+    const slots = update.slots.map((slot) => normaliseSlot(slot)).sort((a, b) => a.index - b.index);
+    const snapshot: ChassisSnapshot = {
+      capacity: Math.max(update.capacity, 0),
+      slots,
+    };
+    this.setSnapshot(snapshot);
+  }
+
+  clear(): void {
+    this.setSnapshot(EMPTY_CHASSIS_SNAPSHOT_INTERNAL);
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}

--- a/src/state/runtime/index.ts
+++ b/src/state/runtime/index.ts
@@ -1,0 +1,11 @@
+export { InventoryState, type InventoryListener, type InventoryOverlayUpdate, EMPTY_INVENTORY_SNAPSHOT } from './inventoryState';
+export { ChassisState, type ChassisListener, type ChassisOverlayUpdate, EMPTY_CHASSIS_SNAPSHOT } from './chassisState';
+export { TelemetryState, type TelemetryListener, EMPTY_TELEMETRY_SNAPSHOT } from './telemetryState';
+
+import { InventoryState } from './inventoryState';
+import { ChassisState } from './chassisState';
+import { TelemetryState } from './telemetryState';
+
+export const inventoryState = new InventoryState();
+export const chassisState = new ChassisState();
+export const telemetryState = new TelemetryState();

--- a/src/state/runtime/inventoryState.ts
+++ b/src/state/runtime/inventoryState.ts
@@ -1,0 +1,127 @@
+import type { InventoryEntry, InventorySnapshot } from '../../simulation/mechanism/inventory';
+import type { SlotSchema } from '../../types/slots';
+
+export type InventoryListener = (snapshot: InventorySnapshot) => void;
+
+export interface InventoryOverlayUpdate {
+  capacity: number;
+  slots: SlotSchema[];
+}
+
+export interface InventoryActivationHandlers {
+  onActive?: () => void;
+  onInactive?: () => void;
+}
+
+const EMPTY_INVENTORY_SNAPSHOT_INTERNAL: InventorySnapshot = {
+  capacity: 0,
+  used: 0,
+  available: 0,
+  entries: [],
+  slots: [],
+  slotCapacity: 0,
+};
+
+export const EMPTY_INVENTORY_SNAPSHOT: InventorySnapshot = EMPTY_INVENTORY_SNAPSHOT_INTERNAL;
+
+const normaliseSlot = (slot: SlotSchema): SlotSchema => ({
+  ...slot,
+  metadata: { ...slot.metadata },
+});
+
+const resolveStackCount = (slot: SlotSchema): number => {
+  if (!slot.occupantId) {
+    return 0;
+  }
+  const stackCount = Number.isFinite(slot.stackCount) ? Math.floor(slot.stackCount ?? 0) : 0;
+  if (stackCount <= 0) {
+    return 1;
+  }
+  return stackCount;
+};
+
+const buildInventoryEntries = (slots: SlotSchema[]): InventoryEntry[] => {
+  const totals = new Map<string, number>();
+  for (const slot of slots) {
+    if (!slot.occupantId) {
+      continue;
+    }
+    const quantity = resolveStackCount(slot);
+    if (quantity <= 0) {
+      continue;
+    }
+    const current = totals.get(slot.occupantId) ?? 0;
+    totals.set(slot.occupantId, current + quantity);
+  }
+  return Array.from(totals.entries()).map(([resource, quantity]) => ({ resource, quantity }));
+};
+
+export class InventoryState {
+  private snapshot: InventorySnapshot = EMPTY_INVENTORY_SNAPSHOT_INTERNAL;
+  private readonly listeners = new Set<InventoryListener>();
+  private onActive: (() => void) | undefined;
+  private onInactive: (() => void) | undefined;
+
+  setActivationHandlers(handlers: InventoryActivationHandlers): void {
+    this.onActive = handlers.onActive;
+    this.onInactive = handlers.onInactive;
+    if (this.listeners.size > 0) {
+      this.onActive?.();
+    }
+  }
+
+  subscribe(listener: InventoryListener): () => void {
+    this.listeners.add(listener);
+    if (this.listeners.size === 1) {
+      this.onActive?.();
+    }
+    listener(this.snapshot);
+    return () => {
+      if (!this.listeners.delete(listener)) {
+        return;
+      }
+      if (this.listeners.size === 0) {
+        this.onInactive?.();
+      }
+    };
+  }
+
+  hasListeners(): boolean {
+    return this.listeners.size > 0;
+  }
+
+  getSnapshot(): InventorySnapshot {
+    return this.snapshot;
+  }
+
+  setSnapshot(snapshot: InventorySnapshot): void {
+    this.snapshot = snapshot;
+    this.notify();
+  }
+
+  applyOverlayUpdate(update: InventoryOverlayUpdate): void {
+    const normalisedSlots = update.slots.map((slot) => normaliseSlot(slot)).sort((a, b) => a.index - b.index);
+    const entries = buildInventoryEntries(normalisedSlots);
+    const used = entries.reduce((total, entry) => total + Math.max(entry.quantity, 0), 0);
+    const capacity = Math.max(update.capacity, used, 0);
+    const snapshot: InventorySnapshot = {
+      capacity,
+      used,
+      available: Math.max(capacity - used, 0),
+      entries,
+      slots: normalisedSlots,
+      slotCapacity: Math.max(update.capacity, 0),
+    };
+    this.setSnapshot(snapshot);
+  }
+
+  clear(): void {
+    this.setSnapshot(EMPTY_INVENTORY_SNAPSHOT_INTERNAL);
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}

--- a/src/state/runtime/telemetryState.ts
+++ b/src/state/runtime/telemetryState.ts
@@ -1,0 +1,84 @@
+import type { SimulationTelemetrySnapshot } from '../../simulation/runtime/ecsBlackboard';
+
+export type TelemetryListener = (snapshot: SimulationTelemetrySnapshot, mechanismId: string | null) => void;
+
+const EMPTY_TELEMETRY_SNAPSHOT_INTERNAL: SimulationTelemetrySnapshot = {
+  values: {},
+  actions: {},
+};
+
+export const EMPTY_TELEMETRY_SNAPSHOT: SimulationTelemetrySnapshot = EMPTY_TELEMETRY_SNAPSHOT_INTERNAL;
+
+export class TelemetryState {
+  private activeSnapshot: SimulationTelemetrySnapshot = EMPTY_TELEMETRY_SNAPSHOT_INTERNAL;
+  private activeMechanismId: string | null = null;
+  private readonly snapshots = new Map<string, SimulationTelemetrySnapshot>();
+  private readonly listeners = new Set<TelemetryListener>();
+
+  subscribe(listener: TelemetryListener): () => void {
+    this.listeners.add(listener);
+    if (this.snapshots.size > 0) {
+      for (const [mechanismId, snapshot] of this.snapshots) {
+        listener(snapshot, mechanismId);
+      }
+    } else {
+      listener(this.activeSnapshot, this.activeMechanismId);
+    }
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getSnapshot(mechanismId: string | null = this.activeMechanismId): SimulationTelemetrySnapshot {
+    if (mechanismId) {
+      if (mechanismId === this.activeMechanismId) {
+        return this.activeSnapshot;
+      }
+      return this.snapshots.get(mechanismId) ?? EMPTY_TELEMETRY_SNAPSHOT_INTERNAL;
+    }
+    return this.activeSnapshot;
+  }
+
+  setActiveSnapshot(snapshot: SimulationTelemetrySnapshot, mechanismId: string | null): void {
+    this.activeSnapshot = snapshot;
+    this.activeMechanismId = mechanismId;
+    if (mechanismId) {
+      this.snapshots.set(mechanismId, snapshot);
+    }
+    this.notify(snapshot, mechanismId);
+  }
+
+  storeSnapshot(snapshot: SimulationTelemetrySnapshot, mechanismId: string): void {
+    if (mechanismId === this.activeMechanismId) {
+      this.setActiveSnapshot(snapshot, mechanismId);
+      return;
+    }
+    this.snapshots.set(mechanismId, snapshot);
+    this.notify(snapshot, mechanismId);
+  }
+
+  activateMechanism(
+    mechanismId: string | null,
+    fetchSnapshot: (mechanismId: string | null) => SimulationTelemetrySnapshot,
+  ): void {
+    if (mechanismId && this.snapshots.has(mechanismId)) {
+      this.setActiveSnapshot(this.snapshots.get(mechanismId) ?? EMPTY_TELEMETRY_SNAPSHOT_INTERNAL, mechanismId);
+      return;
+    }
+    const snapshot = fetchSnapshot(mechanismId);
+    this.setActiveSnapshot(snapshot, mechanismId);
+  }
+
+  clear(): void {
+    this.activeSnapshot = EMPTY_TELEMETRY_SNAPSHOT_INTERNAL;
+    this.activeMechanismId = null;
+    this.snapshots.clear();
+    this.notify(this.activeSnapshot, this.activeMechanismId);
+  }
+
+  private notify(snapshot: SimulationTelemetrySnapshot, mechanismId: string | null): void {
+    for (const listener of this.listeners) {
+      listener(snapshot, mechanismId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce dedicated runtime state modules for inventory, chassis, and telemetry with unit tests
- refactor the simulation runtime orchestrator to compose the new state modules and simplify overlay updates
- update hooks, app wiring, and overlay persistence to subscribe through the shared runtime states

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d6d23a7140832ea3707e72b06be458