### PR TITLE
Refactor ECS to entity-based architecture

### DIFF
--- a/src/simulation/ecs/__tests__/world.test.ts
+++ b/src/simulation/ecs/__tests__/world.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { ECSWorld } from '../world';
+import { ECSWorld, Entity } from '../index';
 
 describe('ECSWorld', () => {
   it('creates and destroys entities', () => {
@@ -8,36 +8,70 @@ describe('ECSWorld', () => {
     const first = world.createEntity();
     const second = world.createEntity();
 
+    expect(first).toBeInstanceOf(Entity);
+    expect(second).toBeInstanceOf(Entity);
     expect(first).not.toBe(second);
+    expect(first.id).not.toBe(second.id);
+
     expect(world.hasEntity(first)).toBe(true);
     expect(world.hasEntity(second)).toBe(true);
+    expect(world.getEntityById(first.id)).toBe(first);
 
     world.destroyEntity(first);
 
     expect(world.hasEntity(first)).toBe(false);
+    expect(first.isDestroyed).toBe(true);
     expect(world.hasEntity(second)).toBe(true);
+    expect(world.getEntityById(first.id)).toBeUndefined();
   });
 
-  it('manages components for entities', () => {
+  it('manages components and entity helpers', () => {
     const world = new ECSWorld();
-    const position = world.defineComponent<{ x: number; y: number }>('position');
+    const stats = world.defineComponent<number>('stats');
     const entity = world.createEntity();
 
-    position.set(entity, { x: 4, y: 9 });
+    entity.addComponent(stats, 5);
+    expect(stats.get(entity)).toBe(5);
 
-    expect(position.get(entity)).toEqual({ x: 4, y: 9 });
+    entity.setComponent(stats, 8);
+    expect(stats.get(entity)).toBe(8);
+
+    stats.remove(entity);
+    expect(stats.has(entity)).toBe(false);
 
     world.destroyEntity(entity);
-
-    expect(position.has(entity)).toBe(false);
-    expect(position.get(entity)).toBeUndefined();
-
-    expect(() => position.set(entity, { x: 0, y: 0 })).toThrowError(
-      `Entity ${entity} does not exist in this world.`,
+    expect(() => stats.set(entity, 1)).toThrowError(
+      `Entity ${entity.id} does not exist in this world.`,
     );
   });
 
-  it('filters query results to matching component sets', () => {
+  it('emits component lifecycle events and tracks component versions', () => {
+    const world = new ECSWorld();
+    const counter = world.defineComponent<number>('counter');
+    const entity = world.createEntity();
+
+    const added = vi.fn();
+    const changed = vi.fn();
+    const removed = vi.fn();
+
+    entity.componentAdded.connect(({ value }) => added(value));
+    entity.componentChanged.connect(({ previous, value }) => changed(previous, value));
+    entity.componentRemoved.connect(({ previous }) => removed(previous));
+
+    counter.set(entity, 1);
+    expect(added).toHaveBeenCalledWith(1);
+    expect(world.getComponentVersion(counter)).toBe(1);
+
+    counter.set(entity, 3);
+    expect(changed).toHaveBeenCalledWith(1, 3);
+    expect(world.getComponentVersion(counter)).toBe(2);
+
+    counter.remove(entity);
+    expect(removed).toHaveBeenCalledWith(3);
+    expect(world.getComponentVersion(counter)).toBe(3);
+  });
+
+  it('filters query results to matching component sets and respects enable state', () => {
     const world = new ECSWorld();
     const position = world.defineComponent<{ x: number; y: number }>('position');
     const velocity = world.defineComponent<{ x: number; y: number }>('velocity');
@@ -49,14 +83,17 @@ describe('ECSWorld', () => {
     velocity.set(walker, { x: 1, y: 0 });
     position.set(statue, { x: 5, y: 5 });
 
-    const positionOnly = world.query(position);
-    const moving = world.query(position, velocity);
-
-    expect(positionOnly).toEqual([
+    expect(world.query(position)).toEqual([
       [walker, { x: 1, y: 1 }],
       [statue, { x: 5, y: 5 }],
     ]);
-    expect(moving).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
+    expect(world.query(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
+
+    walker.disable();
+    expect(world.query(position, velocity)).toEqual([]);
+
+    walker.enable();
+    expect(world.query(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
   });
 
   it('runs systems against matching entities', () => {
@@ -88,5 +125,36 @@ describe('ECSWorld', () => {
 
     expect(position.get(mover)).toEqual({ x: 1, y: -0.5 });
     expect(position.get(parked)).toEqual({ x: 10, y: 10 });
+  });
+
+  it('maintains parent and child relationships', () => {
+    const world = new ECSWorld();
+    const parent = world.createEntity();
+    const child = world.createEntity();
+
+    const parentChanged = vi.fn();
+    const childAdded = vi.fn();
+    const childRemoved = vi.fn();
+
+    child.parentChanged.connect(({ previous, next }) => parentChanged(previous, next));
+    parent.childAdded.connect(({ child: nextChild }) => childAdded(nextChild));
+    parent.childRemoved.connect(({ child: removedChild }) => childRemoved(removedChild));
+
+    child.setParent(parent);
+    expect(child.parent).toBe(parent);
+    expect(parent.children.has(child)).toBe(true);
+    expect(parentChanged).toHaveBeenLastCalledWith(null, parent);
+    expect(childAdded).toHaveBeenCalledWith(child);
+
+    expect(() => parent.setParent(child)).toThrowError('Cannot parent an entity to its descendant.');
+    expect(() => parent.setParent(parent)).toThrowError('An entity cannot be its own parent.');
+
+    child.setParent(null);
+    expect(child.parent).toBeNull();
+    expect(parent.children.has(child)).toBe(false);
+    expect(parentChanged).toHaveBeenLastCalledWith(parent, null);
+    expect(childRemoved).toHaveBeenCalledWith(child);
+
+    expect(() => child.setParent(child)).toThrowError('An entity cannot be its own parent.');
   });
 });

--- a/src/simulation/ecs/entity.ts
+++ b/src/simulation/ecs/entity.ts
@@ -1,0 +1,242 @@
+import type { ComponentHandle } from './world';
+import { Signal } from './signal';
+
+export interface ComponentRecord<TValue = unknown> {
+  component: ComponentHandle<TValue>;
+  value: TValue;
+}
+
+export interface ComponentAddedPayload<TValue = unknown> extends ComponentRecord<TValue> {
+  entity: Entity;
+}
+
+export interface ComponentChangedPayload<TValue = unknown> extends ComponentAddedPayload<TValue> {
+  previous: TValue;
+}
+
+export interface ComponentRemovedPayload<TValue = unknown> {
+  entity: Entity;
+  component: ComponentHandle<TValue>;
+  previous: TValue;
+}
+
+export interface EnabledChangedPayload {
+  entity: Entity;
+  enabled: boolean;
+}
+
+export interface ParentChangedPayload {
+  entity: Entity;
+  previous: Entity | null;
+  next: Entity | null;
+}
+
+export interface ChildPayload {
+  entity: Entity;
+  child: Entity;
+}
+
+export interface EntityHost {
+  attachComponent<TValue>(entity: Entity, component: ComponentHandle<TValue>, value: TValue): void;
+  detachComponent<TValue>(entity: Entity, component: ComponentHandle<TValue>): void;
+  destroyEntity(entity: Entity): void;
+}
+
+export class Entity {
+  readonly componentAdded = new Signal<ComponentAddedPayload>();
+  readonly componentChanged = new Signal<ComponentChangedPayload>();
+  readonly componentRemoved = new Signal<ComponentRemovedPayload>();
+  readonly enabledChanged = new Signal<EnabledChangedPayload>();
+  readonly parentChanged = new Signal<ParentChangedPayload>();
+  readonly childAdded = new Signal<ChildPayload>();
+  readonly childRemoved = new Signal<ChildPayload>();
+  readonly destroyed = new Signal<Entity>();
+
+  private readonly componentMap = new Map<symbol, ComponentRecord>();
+  private _enabled = true;
+  private _destroyed = false;
+  private _parent: Entity | null = null;
+  private readonly _children = new Set<Entity>();
+
+  constructor(private readonly host: EntityHost, readonly id: number) {}
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  get isDestroyed(): boolean {
+    return this._destroyed;
+  }
+
+  get parent(): Entity | null {
+    return this._parent;
+  }
+
+  get children(): ReadonlySet<Entity> {
+    return this._children;
+  }
+
+  addComponent<TValue>(component: ComponentHandle<TValue>, value: TValue): void {
+    this.assertAlive('add components');
+    this.host.attachComponent(this, component, value);
+  }
+
+  setComponent<TValue>(component: ComponentHandle<TValue>, value: TValue): void {
+    this.addComponent(component, value);
+  }
+
+  removeComponent(component: ComponentHandle<unknown>): void {
+    this.assertAlive('remove components');
+    this.host.detachComponent(this, component);
+  }
+
+  hasComponent(component: ComponentHandle<unknown>): boolean {
+    return this.componentMap.has(component.id);
+  }
+
+  getComponent<TValue>(component: ComponentHandle<TValue>): TValue | undefined {
+    return this.componentMap.get(component.id)?.value as TValue | undefined;
+  }
+
+  enable(): void {
+    this.setEnabled(true);
+  }
+
+  disable(): void {
+    this.setEnabled(false);
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.assertAlive('toggle enabled state');
+    if (this._enabled === enabled) {
+      return;
+    }
+    this._enabled = enabled;
+    this.enabledChanged.emit({ entity: this, enabled });
+  }
+
+  setParent(next: Entity | null): void {
+    this.assertAlive('change parent');
+    if (next === this) {
+      throw new Error('An entity cannot be its own parent.');
+    }
+    if (next && next.host !== this.host) {
+      throw new Error('Parent must belong to the same world.');
+    }
+    if (next && next.isDescendantOf(this)) {
+      throw new Error('Cannot parent an entity to its descendant.');
+    }
+    if (this._parent === next) {
+      return;
+    }
+
+    const previous = this._parent;
+    if (previous) {
+      previous._children.delete(this);
+      previous.childRemoved.emit({ entity: previous, child: this });
+    }
+
+    this._parent = next;
+
+    if (next) {
+      next._children.add(this);
+      next.childAdded.emit({ entity: next, child: this });
+    }
+
+    this.parentChanged.emit({ entity: this, previous, next });
+  }
+
+  addChild(child: Entity): void {
+    child.setParent(this);
+  }
+
+  removeChild(child: Entity): void {
+    if (child.parent !== this) {
+      return;
+    }
+    child.setParent(null);
+  }
+
+  destroy(): void {
+    if (this._destroyed) {
+      return;
+    }
+    this.host.destroyEntity(this);
+  }
+
+  /** @internal */
+  receiveComponentSet<TValue>(
+    component: ComponentHandle<TValue>,
+    value: TValue,
+    previous: TValue | undefined,
+    hadPrevious: boolean,
+  ): void {
+    const record: ComponentRecord<TValue> = { component, value };
+    this.componentMap.set(component.id, record);
+    if (hadPrevious) {
+      this.componentChanged.emit({
+        entity: this,
+        component,
+        value,
+        previous: previous as TValue,
+      });
+    } else {
+      this.componentAdded.emit({ entity: this, component, value });
+    }
+  }
+
+  /** @internal */
+  receiveComponentRemoval<TValue>(component: ComponentHandle<TValue>, previous: TValue): void {
+    this.componentMap.delete(component.id);
+    this.componentRemoved.emit({ entity: this, component, previous });
+  }
+
+  /** @internal */
+  markDestroyed(): void {
+    if (this._destroyed) {
+      return;
+    }
+    this._destroyed = true;
+    this.destroyed.emit(this);
+    this.destroyed.clear();
+    this.componentAdded.clear();
+    this.componentChanged.clear();
+    this.componentRemoved.clear();
+    this.enabledChanged.clear();
+    this.parentChanged.clear();
+    this.childAdded.clear();
+    this.childRemoved.clear();
+    this.componentMap.clear();
+    this._children.clear();
+    this._parent = null;
+  }
+
+  /** @internal */
+  isOwnedBy(host: EntityHost): boolean {
+    return this.host === host;
+  }
+
+  /** @internal */
+  *iterateComponents(): IterableIterator<ComponentRecord> {
+    for (const record of this.componentMap.values()) {
+      yield record;
+    }
+  }
+
+  private isDescendantOf(target: Entity): boolean {
+    let current: Entity | null = this._parent;
+    while (current) {
+      if (current === target) {
+        return true;
+      }
+      current = current._parent;
+    }
+    return false;
+  }
+
+  private assertAlive(action: string): void {
+    if (this._destroyed) {
+      throw new Error(`Cannot ${action} on a destroyed entity.`);
+    }
+  }
+}

--- a/src/simulation/ecs/index.ts
+++ b/src/simulation/ecs/index.ts
@@ -1,2 +1,4 @@
 export * from './world';
 export * from './systems';
+export * from './entity';
+export * from './signal';

--- a/src/simulation/ecs/signal.ts
+++ b/src/simulation/ecs/signal.ts
@@ -1,0 +1,30 @@
+export type SignalListener<TPayload> = (payload: TPayload) => void;
+
+export class Signal<TPayload> {
+  private readonly listeners = new Set<SignalListener<TPayload>>();
+
+  connect(listener: SignalListener<TPayload>): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  disconnect(listener: SignalListener<TPayload>): void {
+    this.listeners.delete(listener);
+  }
+
+  clear(): void {
+    this.listeners.clear();
+  }
+
+  emit(payload: TPayload): void {
+    for (const listener of [...this.listeners]) {
+      listener(payload);
+    }
+  }
+
+  get size(): number {
+    return this.listeners.size;
+  }
+}

--- a/src/simulation/ecs/systems/debugOverlaySystem.ts
+++ b/src/simulation/ecs/systems/debugOverlaySystem.ts
@@ -24,7 +24,8 @@ import type {
 } from '../../runtime/blockProgramRunner';
 import type { BlockProgramRunner } from '../../runtime/blockProgramRunner';
 import type { MechanismChassis } from '../../mechanism';
-import type { ComponentHandle, EntityId, System } from '../world';
+import type { ComponentHandle, System } from '../world';
+import type { Entity } from '../entity';
 
 interface DebugOverlaySystemDependencies
   extends Pick<
@@ -52,7 +53,7 @@ export function createDebugOverlaySystem(
     name: 'DebugOverlaySystem',
     components: [MechanismCore, ProgramRunner, SpriteRef, DebugOverlay],
     update: (_world, entities) => {
-      const processed = new Set<EntityId>();
+      const processed = new Set<Entity>();
 
       for (const [entity, overlay] of DebugOverlay.entries()) {
         overlay.container.visible = false;

--- a/src/simulation/ecs/systems/resourceFieldViewSystem.ts
+++ b/src/simulation/ecs/systems/resourceFieldViewSystem.ts
@@ -4,7 +4,8 @@ import type {
   ResourceFieldViewComponent,
   SimulationWorldComponents,
 } from '../../runtime/simulationWorld';
-import type { ComponentHandle, EntityId, System } from '../world';
+import type { ComponentHandle, System } from '../world';
+import type { Entity } from '../entity';
 
 interface ResourceFieldViewSystemDependencies
   extends Pick<SimulationWorldComponents, 'ResourceFieldView'> {}
@@ -18,13 +19,13 @@ export function createResourceFieldViewSystem(
   { ResourceFieldView }: ResourceFieldViewSystemDependencies,
   { renderer, container }: ResourceFieldViewSystemOptions,
 ): System<[ComponentHandle<ResourceFieldViewComponent>]> {
-  const layers = new Map<EntityId, ResourceLayer>();
+  const layers = new Map<Entity, ResourceLayer>();
 
   return {
     name: 'ResourceFieldViewSystem',
     components: [ResourceFieldView],
     update: (world, entities) => {
-      const activeEntities = new Set<EntityId>();
+      const activeEntities = new Set<Entity>();
 
       for (const [entity, view] of entities) {
         activeEntities.add(entity);

--- a/src/simulation/ecs/systems/selectableSystem.ts
+++ b/src/simulation/ecs/systems/selectableSystem.ts
@@ -3,7 +3,8 @@ import type {
   SelectableComponent,
   SimulationWorldComponents,
 } from '../../runtime/simulationWorld';
-import type { ComponentHandle, EntityId, System } from '../world';
+import type { ComponentHandle, System } from '../world';
+import type { Entity } from '../entity';
 
 interface SelectableSystemDependencies
   extends Pick<SimulationWorldComponents, 'Selectable' | 'SpriteRef'> {}
@@ -36,13 +37,13 @@ export function createSelectableSystem({
   ComponentHandle<SelectableComponent>,
   ComponentHandle<Sprite>,
 ]> {
-  const listeners = new Map<EntityId, ListenerEntry>();
+  const listeners = new Map<Entity, ListenerEntry>();
 
   return {
     name: 'SelectableSystem',
     components: [Selectable, SpriteRef],
     update: (world, entities) => {
-      const active = new Set<EntityId>();
+      const active = new Set<Entity>();
 
       for (const [entity, _selectable, sprite] of entities) {
         active.add(entity);

--- a/src/simulation/ecs/world.ts
+++ b/src/simulation/ecs/world.ts
@@ -1,97 +1,157 @@
+import { Entity, type EntityHost } from './entity';
+
 export type EntityId = number;
 
 export interface ComponentHandle<TValue> {
   readonly id: symbol;
   readonly name: string;
-  get(entity: EntityId): TValue | undefined;
-  set(entity: EntityId, value: TValue): void;
-  remove(entity: EntityId): void;
-  has(entity: EntityId): boolean;
-  entries(): IterableIterator<[EntityId, TValue]>;
+  get(entity: Entity): TValue | undefined;
+  set(entity: Entity, value: TValue): void;
+  remove(entity: Entity): void;
+  has(entity: Entity): boolean;
+  entries(): IterableIterator<[Entity, TValue]>;
 }
 
 export type ComponentTuple = readonly ComponentHandle<unknown>[];
 
 type ComponentValueTuple<TComponents extends ComponentTuple> = {
-  [Index in keyof TComponents]: TComponents[Index] extends ComponentHandle<infer TValue> ? TValue : never;
+  [Index in keyof TComponents]: TComponents[Index] extends ComponentHandle<infer TValue>
+    ? TValue
+    : never;
 } extends infer Values
   ? Values extends readonly unknown[]
     ? Values
     : never
   : never;
 
-export type QueryResult<TComponents extends ComponentTuple> = [
-  EntityId,
-  ...ComponentValueTuple<TComponents>,
-];
+export type QueryResult<TComponents extends ComponentTuple> = [Entity, ...ComponentValueTuple<TComponents>];
 
 export interface System<TComponents extends ComponentTuple = ComponentTuple> {
   readonly name?: string;
+  readonly group?: string;
   readonly components: TComponents;
   update(world: ECSWorld, entities: Iterable<QueryResult<TComponents>>, delta: number): void;
 }
 
 interface ComponentStore<TValue> extends ComponentHandle<TValue> {
-  readonly store: Map<EntityId, TValue>;
+  readonly store: Map<Entity, TValue>;
 }
 
-export class ECSWorld {
-  private nextEntityId = 1 as EntityId;
-  private readonly entities = new Set<EntityId>();
-  private readonly components = new Map<symbol, ComponentStore<unknown>>();
-  private readonly systems: System[] = [];
+const EMPTY_ENTITY_SET: ReadonlySet<Entity> = new Set();
 
-  createEntity(): EntityId {
-    const entity = this.nextEntityId++;
+export class ECSWorld implements EntityHost {
+  private nextEntityId = 1 as EntityId;
+  readonly entities = new Set<Entity>();
+  readonly systemsByGroup = new Map<string, System[]>();
+
+  private readonly entityLookup = new Map<EntityId, Entity>();
+  private readonly components = new Map<symbol, ComponentStore<unknown>>();
+  private readonly componentIndex = new Map<ComponentHandle<unknown>, Set<Entity>>();
+  private readonly componentVersions = new Map<ComponentHandle<unknown>, number>();
+  private readonly systems: System[] = [];
+  private readonly entitySubscriptions = new Map<Entity, Array<() => void>>();
+
+  createEntity(): Entity {
+    const entity = new Entity(this, this.nextEntityId++);
     this.entities.add(entity);
+    this.entityLookup.set(entity.id as EntityId, entity);
+    this.trackEntity(entity);
     return entity;
   }
 
-  destroyEntity(entity: EntityId): void {
+  destroyEntity(entity: Entity): void {
     if (!this.entities.delete(entity)) {
       return;
     }
-    for (const component of this.components.values()) {
-      component.remove(entity);
+
+    this.entityLookup.delete(entity.id as EntityId);
+
+    const subscriptions = this.entitySubscriptions.get(entity);
+    if (subscriptions) {
+      for (const unsubscribe of subscriptions) {
+        unsubscribe();
+      }
+      this.entitySubscriptions.delete(entity);
     }
+
+    if (entity.parent) {
+      entity.setParent(null);
+    }
+    for (const child of [...entity.children]) {
+      child.setParent(null);
+    }
+
+    for (const component of this.components.values()) {
+      if (component.store.has(entity)) {
+        this.detachComponent(entity, component);
+      }
+    }
+
+    entity.markDestroyed();
   }
 
-  hasEntity(entity: EntityId): boolean {
+  hasEntity(entity: Entity): boolean {
     return this.entities.has(entity);
+  }
+
+  getEntityById(id: EntityId): Entity | undefined {
+    return this.entityLookup.get(id) ?? undefined;
   }
 
   defineComponent<TValue>(name: string): ComponentHandle<TValue> {
     if (!name.trim()) {
       throw new Error('Component names must be non-empty.');
     }
+
     const existing = Array.from(this.components.values()).find((component) => component.name === name);
     if (existing) {
       throw new Error(`Component ${name} already defined on this world.`);
     }
 
-    const store = new Map<EntityId, TValue>();
+    const store = new Map<Entity, TValue>();
     const component: ComponentStore<TValue> = {
       id: Symbol(name),
       name,
       store,
-      get: (entity) => store.get(entity),
+      get: (entity) => {
+        this.assertOwnership(entity);
+        if (!this.entities.has(entity)) {
+          return undefined;
+        }
+        return store.get(entity);
+      },
       set: (entity, value) => {
         this.assertEntityExists(entity);
-        store.set(entity, value);
+        this.attachComponent(entity, component, value);
       },
       remove: (entity) => {
-        store.delete(entity);
+        this.assertOwnership(entity);
+        if (!this.entities.has(entity)) {
+          return;
+        }
+        this.detachComponent(entity, component);
       },
-      has: (entity) => store.has(entity),
+      has: (entity) => {
+        this.assertOwnership(entity);
+        return this.entities.has(entity) && store.has(entity);
+      },
       entries: () => store.entries(),
     };
 
     this.components.set(component.id, component as ComponentStore<unknown>);
+    this.componentVersions.set(component, 0);
     return component;
   }
 
   addSystem<TComponents extends ComponentTuple>(system: System<TComponents>): void {
     this.systems.push(system);
+    const group = system.group ?? 'default';
+    let bucket = this.systemsByGroup.get(group);
+    if (!bucket) {
+      bucket = [];
+      this.systemsByGroup.set(group, bucket);
+    }
+    bucket.push(system);
   }
 
   runSystems(delta: number): void {
@@ -101,10 +161,34 @@ export class ECSWorld {
     }
   }
 
-  query<TComponents extends ComponentTuple>(
-    ...components: TComponents
-  ): QueryResult<TComponents>[] {
+  query<TComponents extends ComponentTuple>(...components: TComponents): QueryResult<TComponents>[] {
     return Array.from(this.iterateQuery(components));
+  }
+
+  getEntitiesWith(component: ComponentHandle<unknown>): ReadonlySet<Entity> {
+    return this.componentIndex.get(component) ?? EMPTY_ENTITY_SET;
+  }
+
+  getComponentVersion(component: ComponentHandle<unknown>): number {
+    return this.componentVersions.get(component) ?? 0;
+  }
+
+  attachComponent<TValue>(entity: Entity, component: ComponentHandle<TValue>, value: TValue): void {
+    const store = this.getComponentStore(component);
+    const hadPrevious = store.store.has(entity);
+    const previous = store.store.get(entity);
+    store.store.set(entity, value);
+    entity.receiveComponentSet(component, value, previous as TValue | undefined, hadPrevious);
+  }
+
+  detachComponent<TValue>(entity: Entity, component: ComponentHandle<TValue>): void {
+    const store = this.getComponentStore(component);
+    if (!store.store.has(entity)) {
+      return;
+    }
+    const previous = store.store.get(entity) as TValue;
+    store.store.delete(entity);
+    entity.receiveComponentRemoval(component, previous);
   }
 
   private *iterateQuery<TComponents extends ComponentTuple>(
@@ -112,15 +196,48 @@ export class ECSWorld {
   ): IterableIterator<QueryResult<TComponents>> {
     if (components.length === 0) {
       for (const entity of this.entities) {
+        if (!entity.enabled) {
+          continue;
+        }
         yield [entity] as unknown as QueryResult<TComponents>;
       }
       return;
     }
 
     const [first, ...rest] = components;
+    const indexed = this.componentIndex.get(first);
+
+    if (indexed) {
+      for (const entity of indexed) {
+        if (!this.entities.has(entity) || !entity.enabled) {
+          continue;
+        }
+
+        const collected: unknown[] = [];
+
+        if (!first.has(entity)) {
+          continue;
+        }
+        collected.push(first.get(entity));
+
+        let missing = false;
+        for (const component of rest) {
+          if (!component.has(entity)) {
+            missing = true;
+            break;
+          }
+          collected.push(component.get(entity));
+        }
+
+        if (!missing) {
+          yield [entity, ...collected] as unknown as QueryResult<TComponents>;
+        }
+      }
+      return;
+    }
 
     for (const [entity, firstValue] of first.entries()) {
-      if (!this.entities.has(entity)) {
+      if (!this.entities.has(entity) || !entity.enabled) {
         continue;
       }
 
@@ -132,7 +249,7 @@ export class ECSWorld {
           missing = true;
           break;
         }
-        collected.push(component.get(entity)!);
+        collected.push(component.get(entity));
       }
 
       if (!missing) {
@@ -141,9 +258,93 @@ export class ECSWorld {
     }
   }
 
-  private assertEntityExists(entity: EntityId): void {
+  private getComponentStore<TValue>(component: ComponentHandle<TValue>): ComponentStore<TValue> {
+    const store = this.components.get(component.id) as ComponentStore<TValue> | undefined;
+    if (!store) {
+      throw new Error('Component does not belong to this world.');
+    }
+    return store;
+  }
+
+  private trackEntity(entity: Entity): void {
+    const subscriptions: Array<() => void> = [];
+
+    subscriptions.push(
+      entity.componentAdded.connect(({ component }) => {
+        if (entity.enabled) {
+          this.addToComponentIndex(component, entity);
+        }
+        this.bumpComponentVersion(component);
+      }),
+    );
+
+    subscriptions.push(
+      entity.componentRemoved.connect(({ component }) => {
+        this.removeFromComponentIndex(component, entity);
+        this.bumpComponentVersion(component);
+      }),
+    );
+
+    subscriptions.push(
+      entity.componentChanged.connect(({ component }) => {
+        this.bumpComponentVersion(component);
+      }),
+    );
+
+    subscriptions.push(
+      entity.enabledChanged.connect(({ enabled }) => {
+        for (const { component } of entity.iterateComponents()) {
+          if (enabled) {
+            this.addToComponentIndex(component, entity);
+          } else {
+            this.removeFromComponentIndex(component, entity);
+          }
+          this.bumpComponentVersion(component);
+        }
+      }),
+    );
+
+    this.entitySubscriptions.set(entity, subscriptions);
+  }
+
+  private addToComponentIndex(component: ComponentHandle<unknown>, entity: Entity): void {
+    if (!entity.enabled) {
+      return;
+    }
+    let index = this.componentIndex.get(component);
+    if (!index) {
+      index = new Set<Entity>();
+      this.componentIndex.set(component, index);
+    }
+    index.add(entity);
+  }
+
+  private removeFromComponentIndex(component: ComponentHandle<unknown>, entity: Entity): void {
+    const index = this.componentIndex.get(component);
+    if (!index) {
+      return;
+    }
+    index.delete(entity);
+    if (index.size === 0) {
+      this.componentIndex.delete(component);
+    }
+  }
+
+  private bumpComponentVersion(component: ComponentHandle<unknown>): void {
+    const current = this.componentVersions.get(component) ?? 0;
+    this.componentVersions.set(component, current + 1);
+  }
+
+  private assertOwnership(entity: Entity): void {
+    if (!entity.isOwnedBy(this)) {
+      throw new Error('Entity does not belong to this world.');
+    }
+  }
+
+  private assertEntityExists(entity: Entity): void {
+    this.assertOwnership(entity);
     if (!this.entities.has(entity)) {
-      throw new Error(`Entity ${entity} does not exist in this world.`);
+      throw new Error(`Entity ${entity.id} does not exist in this world.`);
     }
   }
 }

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -425,10 +425,11 @@ export class RootScene {
 
   subscribeMechanismSelection(listener: MechanismSelectionListener): () => void {
     this.selectionListeners.add(listener);
-    const entityId =
+    const entity =
       this.pendingSelection && this.context
         ? this.context.getMechanismEntity(this.pendingSelection) ?? null
         : null;
+    const entityId = entity ? (entity.id as EntityId) : null;
     listener(this.pendingSelection, entityId);
     return () => {
       this.selectionListeners.delete(listener);
@@ -598,8 +599,9 @@ export class RootScene {
         }
       }
     }
-    const entityId =
+    const entity =
       mechanismId && this.context ? this.context.getMechanismEntity(mechanismId) ?? null : null;
+    const entityId = entity ? (entity.id as EntityId) : null;
     for (const listener of this.selectionListeners) {
       listener(mechanismId, entityId);
     }

--- a/src/simulation/runtime/simulationWorld.ts
+++ b/src/simulation/runtime/simulationWorld.ts
@@ -1,7 +1,7 @@
 import { Container, Graphics, Sprite, Text, type Renderer } from 'pixi.js';
 import type { Viewport } from 'pixi-viewport';
 import { assetService } from '../assetService';
-import { ECSWorld, type ComponentHandle, type EntityId } from '../ecs';
+import { ECSWorld, type ComponentHandle, type Entity } from '../ecs';
 import {
   createDebugOverlaySystem,
   createProgramRunnerSystem,
@@ -74,8 +74,8 @@ export interface SimulationWorldComponents {
 }
 
 export interface SimulationWorldEntities {
-  mechanisms: Map<string, EntityId>;
-  selection: EntityId;
+  mechanisms: Map<string, Entity>;
+  selection: Entity;
 }
 
 export interface SimulationWorldContext {
@@ -89,8 +89,8 @@ export interface SimulationWorldContext {
   getSprite(mechanismId?: string): Sprite | null;
   getTransform(mechanismId?: string): TransformComponent | null;
   setTransform(mechanismId: string, transform: TransformComponent): void;
-  getMechanismId(entity: EntityId): string | null;
-  getMechanismEntity(mechanismId: string): EntityId | null;
+  getMechanismId(entity: Entity): string | null;
+  getMechanismEntity(mechanismId: string): Entity | null;
   selectMechanism(mechanismId: string | null): void;
   getSelectedMechanism(): string | null;
 }
@@ -146,7 +146,7 @@ export async function createSimulationWorld({
 
   const chassisTexture = await assetService.loadTexture('mechanism/chassis', renderer);
 
-  const mechanisms = new Map<string, EntityId>();
+  const mechanisms = new Map<string, Entity>();
 
   const applySelection = (mechanismId: string | null): void => {
     const current = SelectionState.get(selectionEntity)?.mechanismId ?? null;
@@ -278,7 +278,7 @@ export async function createSimulationWorld({
     return SelectionState.get(selectionEntity)?.mechanismId ?? null;
   };
 
-  const resolveMechanismEntity = (mechanismId?: string): EntityId | null => {
+  const resolveMechanismEntity = (mechanismId?: string): Entity | null => {
     if (mechanismId) {
       return mechanisms.get(mechanismId) ?? null;
     }


### PR DESCRIPTION
## Summary
- introduce an Entity class with lifecycle signals, relationship helpers, and a reusable Signal utility
- refactor the ECS world and dependent systems to operate on entity instances while maintaining component indices and versions
- update simulation runtime consumers and extend ECS tests to cover component lifecycle, enable/disable behaviour, and relationships

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d6ec26c710832eba2f01f573648208