### PR TITLE
Introduce ECS query builder and migrate systems

### DIFF
--- a/src/simulation/ecs/__tests__/queryBuilder.test.ts
+++ b/src/simulation/ecs/__tests__/queryBuilder.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ECSWorld, Entity } from '../index';
+
+describe('QueryBuilder', () => {
+  it('chains filters with component predicates and enabled state handling', () => {
+    const world = new ECSWorld();
+    const Position = world.defineComponent<{ x: number; y: number }>('Position');
+    const Velocity = world.defineComponent<{ x: number; y: number }>('Velocity');
+    const Status = world.defineComponent<{ blocked: boolean }>('Status');
+
+    const runner = world.createEntity();
+    Position.set(runner, { x: 0, y: 0 });
+    Velocity.set(runner, { x: 1, y: 1 });
+
+    const blocked = world.createEntity();
+    Position.set(blocked, { x: 5, y: 5 });
+    Velocity.set(blocked, { x: 0, y: 0 });
+    Status.set(blocked, { blocked: true });
+
+    const idle = world.createEntity();
+    Position.set(idle, { x: 3, y: 7 });
+
+    const query = world.query
+      .withAll(Position, Velocity)
+      .withNone({
+        component: Status,
+        predicate: (value: unknown, _entity: Entity) => (value as { blocked: boolean }).blocked,
+      });
+
+    expect(query.collect()).toEqual([[runner, { x: 0, y: 0 }, { x: 1, y: 1 }]]);
+
+    runner.disable();
+    expect(query.collect()).toEqual([]);
+
+    query.anyEnabledState();
+    expect(query.collect()).toEqual([[runner, { x: 0, y: 0 }, { x: 1, y: 1 }]]);
+  });
+
+  it('supports any/none component filters with predicates', () => {
+    const world = new ECSWorld();
+    const Buff = world.defineComponent<{ kind: 'heal' | 'shield'; power: number }>('Buff');
+    const Debuff = world.defineComponent<{ kind: 'slow' | 'poison'; power: number }>('Debuff');
+
+    const healer = world.createEntity();
+    Buff.set(healer, { kind: 'heal', power: 5 });
+
+    const tank = world.createEntity();
+    Buff.set(tank, { kind: 'shield', power: 2 });
+
+    const rogue = world.createEntity();
+    Debuff.set(rogue, { kind: 'poison', power: 4 });
+
+    const query = world.query
+      .withAny(
+        {
+          component: Buff,
+          predicate: (value: unknown, _entity: Entity) =>
+            (value as { kind: 'heal' | 'shield'; power: number }).power >= 3,
+        },
+        {
+          component: Debuff,
+          predicate: (value: unknown, _entity: Entity) =>
+            (value as { kind: 'slow' | 'poison'; power: number }).kind === 'poison',
+        },
+      )
+      .withNone({
+        component: Buff,
+        predicate: (value: unknown, _entity: Entity) => {
+          const typed = value as { kind: 'heal' | 'shield'; power: number };
+          return typed.kind === 'shield' && typed.power < 3;
+        },
+      });
+
+    const resultEntities = [...query.iterate()].map(([entity]) => entity);
+    expect(resultEntities).toEqual([healer, rogue]);
+  });
+
+  it('filters by relationships and membership groups', () => {
+    const world = new ECSWorld();
+    const Marker = world.defineComponent<{ name: string }>('Marker');
+
+    const root = world.createEntity();
+    Marker.set(root, { name: 'root' });
+
+    const branch = world.createEntity();
+    branch.setParent(root);
+    Marker.set(branch, { name: 'branch' });
+
+    const leaf = world.createEntity();
+    leaf.setParent(branch);
+    Marker.set(leaf, { name: 'leaf' });
+
+    const outsiders: Set<Entity> = new Set();
+    outsiders.add(leaf);
+
+    const query = world.query
+      .withAll(Marker)
+      .withParent(branch)
+      .withAncestor(root)
+      .withinGroup(outsiders)
+      .where((entity) => Marker.get(entity)?.name === 'leaf');
+
+    const results = query.collect();
+    expect(results).toEqual([[leaf, { name: 'leaf' }]]);
+  });
+
+  it('caches results and invalidates when component data changes', () => {
+    const world = new ECSWorld();
+    const Stat = world.defineComponent<number>('Stat');
+
+    const actor = world.createEntity();
+    Stat.set(actor, 1);
+
+    const query = world.query.withAll(Stat);
+    const invalidate = vi.fn();
+    query.onInvalidate(invalidate);
+
+    expect(query.collect()).toEqual([[actor, 1]]);
+    expect(invalidate).not.toHaveBeenCalled();
+
+    expect(query.collect()).toEqual([[actor, 1]]);
+    expect(invalidate).not.toHaveBeenCalled();
+
+    Stat.set(actor, 2);
+    expect(query.collect()).toEqual([[actor, 2]]);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    expect(query.collect()).toEqual([[actor, 2]]);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates caches on structural changes', () => {
+    const world = new ECSWorld();
+    const Flag = world.defineComponent<boolean>('Flag');
+
+    const parent = world.createEntity();
+    Flag.set(parent, true);
+
+    const child = world.createEntity();
+    Flag.set(child, false);
+    child.setParent(parent);
+
+    const query = world.query.withAll(Flag).withParent(parent);
+    const invalidate = vi.fn();
+    query.onInvalidate(invalidate);
+
+    expect(query.collect()).toEqual([[child, false]]);
+    expect(invalidate).not.toHaveBeenCalled();
+
+    child.disable();
+    expect(query.collect()).toEqual([]);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    query.anyEnabledState();
+    expect(query.collect()).toEqual([[child, false]]);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    child.setParent(null);
+    expect(query.collect()).toEqual([]);
+    expect(invalidate).toHaveBeenCalledTimes(2);
+
+    world.destroyEntity(child);
+    expect(query.collect()).toEqual([]);
+    expect(invalidate).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/simulation/ecs/__tests__/world.test.ts
+++ b/src/simulation/ecs/__tests__/world.test.ts
@@ -83,17 +83,17 @@ describe('ECSWorld', () => {
     velocity.set(walker, { x: 1, y: 0 });
     position.set(statue, { x: 5, y: 5 });
 
-    expect(world.query(position)).toEqual([
+    expect(world.queryAll(position)).toEqual([
       [walker, { x: 1, y: 1 }],
       [statue, { x: 5, y: 5 }],
     ]);
-    expect(world.query(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
+    expect(world.queryAll(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
 
     walker.disable();
-    expect(world.query(position, velocity)).toEqual([]);
+    expect(world.queryAll(position, velocity)).toEqual([]);
 
     walker.enable();
-    expect(world.query(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
+    expect(world.queryAll(position, velocity)).toEqual([[walker, { x: 1, y: 1 }, { x: 1, y: 0 }]]);
   });
 
   it('runs systems against matching entities', () => {
@@ -110,7 +110,7 @@ describe('ECSWorld', () => {
 
     world.addSystem({
       name: 'movement',
-      components: [position, velocity],
+      createQuery: (lookup) => lookup.query.withAll(position, velocity),
       update: (_, entities, delta) => {
         for (const [entity, pos, vel] of entities) {
           position.set(entity, {

--- a/src/simulation/ecs/entity.ts
+++ b/src/simulation/ecs/entity.ts
@@ -123,7 +123,7 @@ export class Entity {
     if (next && next.host !== this.host) {
       throw new Error('Parent must belong to the same world.');
     }
-    if (next && next.isDescendantOf(this)) {
+    if (next && next.hasAncestor(this)) {
       throw new Error('Cannot parent an entity to its descendant.');
     }
     if (this._parent === next) {
@@ -223,7 +223,7 @@ export class Entity {
     }
   }
 
-  private isDescendantOf(target: Entity): boolean {
+  hasAncestor(target: Entity): boolean {
     let current: Entity | null = this._parent;
     while (current) {
       if (current === target) {

--- a/src/simulation/ecs/index.ts
+++ b/src/simulation/ecs/index.ts
@@ -2,3 +2,4 @@ export * from './world';
 export * from './systems';
 export * from './entity';
 export * from './signal';
+export * from './queryBuilder';

--- a/src/simulation/ecs/queryBuilder.ts
+++ b/src/simulation/ecs/queryBuilder.ts
@@ -1,0 +1,471 @@
+import type { Entity } from './entity';
+import type { ComponentHandle, ComponentTuple, QueryResult } from './world';
+
+type ComponentValue<THandle extends ComponentHandle<unknown>> = THandle extends ComponentHandle<infer TValue>
+  ? TValue
+  : never;
+
+export interface ComponentPredicate<THandle extends ComponentHandle<unknown>> {
+  component: THandle;
+  predicate?: (value: ComponentValue<THandle>, entity: Entity) => boolean;
+}
+
+type ComponentConstraint<THandle extends ComponentHandle<unknown>> =
+  | THandle
+  | ComponentPredicate<THandle>;
+
+type ComponentConstraintTuple<TComponents extends ComponentTuple> = {
+  [Index in keyof TComponents]: ComponentConstraint<TComponents[Index]>;
+};
+
+type MergeComponentTuples<TExisting extends ComponentTuple, TAdditional extends ComponentTuple> = [...TExisting, ...TAdditional];
+
+interface NormalisedComponentFilter {
+  readonly handle: ComponentHandle<unknown>;
+  readonly predicate?: (value: unknown, entity: Entity) => boolean;
+}
+
+interface QueryCacheSnapshot<TComponents extends ComponentTuple> {
+  readonly worldVersion: number;
+  readonly componentVersions: Map<ComponentHandle<unknown>, number>;
+  readonly results: QueryResult<TComponents>[];
+}
+
+export interface QueryableWorld {
+  readonly entities: ReadonlySet<Entity>;
+  getComponentVersion(component: ComponentHandle<unknown>): number;
+  getEntitiesWith(component: ComponentHandle<unknown>): ReadonlySet<Entity>;
+  getWorldVersion(): number;
+}
+
+function normaliseConstraint<THandle extends ComponentHandle<unknown>>(
+  constraint: ComponentConstraint<THandle>,
+): NormalisedComponentFilter {
+  if (typeof constraint === 'object' && 'component' in constraint) {
+    const { component, predicate } = constraint;
+    return {
+      handle: component,
+      predicate: predicate as ((value: unknown, entity: Entity) => boolean) | undefined,
+    };
+  }
+
+  return { handle: constraint };
+}
+
+function collectTrackedComponents(
+  required: NormalisedComponentFilter[],
+  anyGroups: NormalisedComponentFilter[][],
+  excluded: NormalisedComponentFilter[],
+): ComponentHandle<unknown>[] {
+  const handles = new Map<symbol, ComponentHandle<unknown>>();
+
+  for (const filter of required) {
+    handles.set(filter.handle.id, filter.handle);
+  }
+
+  for (const group of anyGroups) {
+    for (const filter of group) {
+      handles.set(filter.handle.id, filter.handle);
+    }
+  }
+
+  for (const filter of excluded) {
+    handles.set(filter.handle.id, filter.handle);
+  }
+
+  return [...handles.values()];
+}
+
+function entityHasComponent(filter: NormalisedComponentFilter, entity: Entity): boolean {
+  if (!filter.handle.has(entity)) {
+    return false;
+  }
+  if (!filter.predicate) {
+    return true;
+  }
+  const value = filter.handle.get(entity);
+  return filter.predicate(value, entity);
+}
+
+function entityFailsExcluded(filter: NormalisedComponentFilter, entity: Entity): boolean {
+  if (!filter.handle.has(entity)) {
+    return false;
+  }
+  if (!filter.predicate) {
+    return true;
+  }
+  const value = filter.handle.get(entity);
+  return filter.predicate(value, entity);
+}
+
+export class QueryBuilder<TComponents extends ComponentTuple = []> {
+  private readonly invalidateListeners = new Set<() => void>();
+  private cache: QueryCacheSnapshot<TComponents> | null = null;
+  private readonly required: NormalisedComponentFilter[] = [];
+  private readonly anyGroups: NormalisedComponentFilter[][] = [];
+  private readonly excluded: NormalisedComponentFilter[] = [];
+  private readonly selected: ComponentHandle<unknown>[] = [];
+  private readonly relationFilters: Array<(entity: Entity) => boolean> = [];
+  private readonly groupFilters: Array<(entity: Entity) => boolean> = [];
+  private readonly customFilters: Array<(entity: Entity) => boolean> = [];
+  private readonly ancestorFilters: Entity[] = [];
+  private enabledFilter: boolean | null = true;
+  private parentFilter: Entity | null | undefined;
+
+  constructor(
+    private readonly world: QueryableWorld,
+    private readonly releaseToPool: (builder: QueryBuilder<ComponentTuple>) => void,
+  ) {}
+
+  reset(): void {
+    this.cache = null;
+    this.required.splice(0, this.required.length);
+    this.anyGroups.splice(0, this.anyGroups.length);
+    this.excluded.splice(0, this.excluded.length);
+    this.selected.splice(0, this.selected.length);
+    this.relationFilters.splice(0, this.relationFilters.length);
+    this.groupFilters.splice(0, this.groupFilters.length);
+    this.customFilters.splice(0, this.customFilters.length);
+    this.ancestorFilters.splice(0, this.ancestorFilters.length);
+    this.enabledFilter = true;
+    this.parentFilter = undefined;
+    this.invalidateListeners.clear();
+  }
+
+  release(): void {
+    this.reset();
+    this.releaseToPool(this as unknown as QueryBuilder<ComponentTuple>);
+  }
+
+  withAll<TAdditional extends ComponentTuple>(
+    ...components: ComponentConstraintTuple<TAdditional>
+  ): QueryBuilder<MergeComponentTuples<TComponents, TAdditional>> {
+    for (const constraint of components) {
+      const filter = normaliseConstraint(constraint);
+      this.required.push(filter);
+      this.selected.push(filter.handle);
+    }
+    this.cache = null;
+    return this as unknown as QueryBuilder<MergeComponentTuples<TComponents, TAdditional>>;
+  }
+
+  withAny<TOptional extends ComponentTuple>(
+    ...components: ComponentConstraintTuple<TOptional>
+  ): this {
+    if (components.length === 0) {
+      return this;
+    }
+    const group: NormalisedComponentFilter[] = [];
+    for (const constraint of components) {
+      group.push(normaliseConstraint(constraint));
+    }
+    this.anyGroups.push(group);
+    this.cache = null;
+    return this;
+  }
+
+  withNone<TExcluded extends ComponentTuple>(
+    ...components: ComponentConstraintTuple<TExcluded>
+  ): this {
+    for (const constraint of components) {
+      this.excluded.push(normaliseConstraint(constraint));
+    }
+    this.cache = null;
+    return this;
+  }
+
+  enabled(enabled = true): this {
+    this.enabledFilter = enabled;
+    this.cache = null;
+    return this;
+  }
+
+  anyEnabledState(): this {
+    this.enabledFilter = null;
+    this.cache = null;
+    return this;
+  }
+
+  withParent(parent: Entity | null): this {
+    this.parentFilter = parent;
+    this.cache = null;
+    return this;
+  }
+
+  withAncestor(ancestor: Entity): this {
+    this.ancestorFilters.push(ancestor);
+    this.cache = null;
+    return this;
+  }
+
+  withRelation(predicate: (entity: Entity) => boolean): this {
+    this.relationFilters.push(predicate);
+    this.cache = null;
+    return this;
+  }
+
+  withinGroup(entities: Iterable<Entity> | ReadonlySet<Entity>): this {
+    const collection = entities instanceof Set ? entities : new Set(entities);
+    this.groupFilters.push((entity) => collection.has(entity));
+    this.cache = null;
+    return this;
+  }
+
+  where(predicate: (entity: Entity) => boolean): this {
+    this.customFilters.push(predicate);
+    this.cache = null;
+    return this;
+  }
+
+  onInvalidate(listener: () => void): () => void {
+    this.invalidateListeners.add(listener);
+    return () => {
+      this.invalidateListeners.delete(listener);
+    };
+  }
+
+  offInvalidate(listener: () => void): void {
+    this.invalidateListeners.delete(listener);
+  }
+
+  collect(): QueryResult<TComponents>[] {
+    return [...this.ensureCache().results];
+  }
+
+  first(): QueryResult<TComponents> | null {
+    const cache = this.ensureCache();
+    return cache.results.length > 0 ? cache.results[0] : null;
+  }
+
+  iterate(): IterableIterator<QueryResult<TComponents>> {
+    const cache = this.ensureCache();
+    const self = this;
+    return (function* iterateResults() {
+      for (const result of cache.results) {
+        yield result;
+      }
+      self.cache = cache;
+    })();
+  }
+
+  forEach(callback: (result: QueryResult<TComponents>) => void): void {
+    for (const result of this.iterate()) {
+      callback(result);
+    }
+  }
+
+  private ensureCache(): QueryCacheSnapshot<TComponents> {
+    if (!this.cache) {
+      this.cache = this.rebuildCache();
+      return this.cache;
+    }
+
+    if (!this.isCacheCurrent(this.cache)) {
+      this.notifyInvalidated();
+      this.cache = this.rebuildCache();
+    }
+
+    return this.cache;
+  }
+
+  private notifyInvalidated(): void {
+    for (const listener of [...this.invalidateListeners]) {
+      try {
+        listener();
+      } catch (error) {
+        console.error('QueryBuilder invalidate listener failed', error);
+      }
+    }
+  }
+
+  private isCacheCurrent(cache: QueryCacheSnapshot<TComponents>): boolean {
+    if (cache.worldVersion !== this.world.getWorldVersion()) {
+      return false;
+    }
+
+    for (const [component, version] of cache.componentVersions) {
+      if (this.world.getComponentVersion(component) !== version) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private rebuildCache(): QueryCacheSnapshot<TComponents> {
+    const componentVersions = new Map<ComponentHandle<unknown>, number>();
+    const tracked = collectTrackedComponents(this.required, this.anyGroups, this.excluded);
+    for (const component of tracked) {
+      componentVersions.set(component, this.world.getComponentVersion(component));
+    }
+
+    const worldVersion = this.world.getWorldVersion();
+    const results = this.computeResults();
+
+    return { worldVersion, componentVersions, results };
+  }
+
+  private computeResults(): QueryResult<TComponents>[] {
+    const selected = this.selected as unknown as TComponents;
+    const results: QueryResult<TComponents>[] = [];
+
+    for (const entity of this.iterateCandidateEntities()) {
+      if (!this.matchesEntity(entity)) {
+        continue;
+      }
+
+      const values: unknown[] = [];
+      for (const handle of selected) {
+        values.push(handle.get(entity));
+      }
+      results.push([entity, ...values] as QueryResult<TComponents>);
+    }
+
+    return results;
+  }
+
+  private *iterateCandidateEntities(): IterableIterator<Entity> {
+    if (this.required.length > 0) {
+      const candidate = this.selectBestRequiredSource();
+      if (candidate) {
+        if (candidate.kind === 'index') {
+          for (const entity of candidate.entities) {
+            yield entity;
+          }
+          return;
+        }
+
+        for (const [entity] of candidate.filter.handle.entries()) {
+          yield entity;
+        }
+        return;
+      }
+    }
+
+    if (this.anyGroups.length > 0) {
+      const [firstGroup] = this.anyGroups;
+      const seen = new Set<Entity>();
+      for (const filter of firstGroup) {
+        const canUseIndex = this.enabledFilter === true;
+        const indexed = canUseIndex ? this.world.getEntitiesWith(filter.handle) : undefined;
+        if (canUseIndex && indexed && indexed.size > 0) {
+          for (const entity of indexed) {
+            if (!seen.has(entity)) {
+              seen.add(entity);
+              yield entity;
+            }
+          }
+          continue;
+        }
+
+        for (const [entity] of filter.handle.entries()) {
+          if (!seen.has(entity)) {
+            seen.add(entity);
+            yield entity;
+          }
+        }
+      }
+
+      for (const entity of this.world.entities) {
+        if (!seen.has(entity)) {
+          yield entity;
+        }
+      }
+      return;
+    }
+
+    yield* this.world.entities;
+  }
+
+  private selectBestRequiredSource():
+    | { kind: 'index'; filter: NormalisedComponentFilter; entities: ReadonlySet<Entity> }
+    | { kind: 'scan'; filter: NormalisedComponentFilter }
+    | null {
+    const canUseIndex = this.enabledFilter === true;
+
+    if (canUseIndex) {
+      let bestIndexed: { filter: NormalisedComponentFilter; entities: ReadonlySet<Entity> } | null = null;
+
+      for (const filter of this.required) {
+        const indexed = this.world.getEntitiesWith(filter.handle);
+        if (indexed.size === 0) {
+          continue;
+        }
+        if (!bestIndexed || indexed.size < bestIndexed.entities.size) {
+          bestIndexed = { filter, entities: indexed };
+        }
+      }
+
+      if (bestIndexed) {
+        return { kind: 'index', ...bestIndexed };
+      }
+    }
+
+    if (this.required.length === 0) {
+      return null;
+    }
+
+    return { kind: 'scan', filter: this.required[0] };
+  }
+
+  private matchesEntity(entity: Entity): boolean {
+    if (this.enabledFilter !== null && entity.enabled !== this.enabledFilter) {
+      return false;
+    }
+
+    if (this.parentFilter !== undefined && entity.parent !== this.parentFilter) {
+      return false;
+    }
+
+    for (const ancestor of this.ancestorFilters) {
+      if (!entity.hasAncestor(ancestor)) {
+        return false;
+      }
+    }
+
+    for (const filter of this.required) {
+      if (!entityHasComponent(filter, entity)) {
+        return false;
+      }
+    }
+
+    for (const group of this.anyGroups) {
+      let matched = false;
+      for (const filter of group) {
+        if (entityHasComponent(filter, entity)) {
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        return false;
+      }
+    }
+
+    for (const filter of this.excluded) {
+      if (entityFailsExcluded(filter, entity)) {
+        return false;
+      }
+    }
+
+    for (const predicate of this.relationFilters) {
+      if (!predicate(entity)) {
+        return false;
+      }
+    }
+
+    for (const predicate of this.groupFilters) {
+      if (!predicate(entity)) {
+        return false;
+      }
+    }
+
+    for (const predicate of this.customFilters) {
+      if (!predicate(entity)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/simulation/ecs/systems/debugOverlaySystem.ts
+++ b/src/simulation/ecs/systems/debugOverlaySystem.ts
@@ -51,7 +51,7 @@ export function createDebugOverlaySystem(
 ]> {
   return {
     name: 'DebugOverlaySystem',
-    components: [MechanismCore, ProgramRunner, SpriteRef, DebugOverlay],
+    createQuery: (world) => world.query.withAll(MechanismCore, ProgramRunner, SpriteRef, DebugOverlay),
     update: (_world, entities) => {
       const processed = new Set<Entity>();
 

--- a/src/simulation/ecs/systems/mechanismPhysicsSystem.ts
+++ b/src/simulation/ecs/systems/mechanismPhysicsSystem.ts
@@ -11,7 +11,7 @@ export function createMechanismPhysicsSystem({
 ]> {
   return {
     name: 'MechanismPhysicsSystem',
-    components: [MechanismCore, Transform],
+    createQuery: (world) => world.query.withAll(MechanismCore, Transform),
     update: (_world, entities, delta) => {
       for (const [entity, mechanism] of entities) {
         mechanism.tick(delta);

--- a/src/simulation/ecs/systems/programRunnerSystem.ts
+++ b/src/simulation/ecs/systems/programRunnerSystem.ts
@@ -9,7 +9,7 @@ export function createProgramRunnerSystem({
 ]> {
   return {
     name: 'ProgramRunnerSystem',
-    components: [ProgramRunner],
+    createQuery: (world) => world.query.withAll(ProgramRunner),
     update: (_world, entities, delta) => {
       for (const [, runner] of entities) {
         runner.update(delta);

--- a/src/simulation/ecs/systems/resourceFieldViewSystem.ts
+++ b/src/simulation/ecs/systems/resourceFieldViewSystem.ts
@@ -23,7 +23,7 @@ export function createResourceFieldViewSystem(
 
   return {
     name: 'ResourceFieldViewSystem',
-    components: [ResourceFieldView],
+    createQuery: (world) => world.query.withAll(ResourceFieldView),
     update: (world, entities) => {
       const activeEntities = new Set<Entity>();
 

--- a/src/simulation/ecs/systems/selectableSystem.ts
+++ b/src/simulation/ecs/systems/selectableSystem.ts
@@ -41,7 +41,7 @@ export function createSelectableSystem({
 
   return {
     name: 'SelectableSystem',
-    components: [Selectable, SpriteRef],
+    createQuery: (world) => world.query.withAll(Selectable, SpriteRef),
     update: (world, entities) => {
       const active = new Set<Entity>();
 

--- a/src/simulation/ecs/systems/spriteSyncSystem.ts
+++ b/src/simulation/ecs/systems/spriteSyncSystem.ts
@@ -11,7 +11,7 @@ export function createSpriteSyncSystem({
 ]> {
   return {
     name: 'SpriteSyncSystem',
-    components: [Transform, SpriteRef],
+    createQuery: (world) => world.query.withAll(Transform, SpriteRef),
     update: (_world, entities) => {
       for (const [, transform, sprite] of entities) {
         sprite.rotation = transform.rotation;

--- a/src/simulation/ecs/systems/statusIndicatorSystem.ts
+++ b/src/simulation/ecs/systems/statusIndicatorSystem.ts
@@ -18,7 +18,7 @@ export function createStatusIndicatorSystem(
 ]> {
   return {
     name: 'StatusIndicatorSystem',
-    components: [MechanismCore, StatusIndicator],
+    createQuery: (world) => world.query.withAll(MechanismCore, StatusIndicator),
     update: (_world, entities) => {
       for (const [, mechanismCore, { indicator }] of entities) {
         const hasStatusModule = Boolean(mechanismCore.moduleStack.getModule(statusModuleId));


### PR DESCRIPTION
## Summary
- add a reusable query builder with component filters, caching, and invalidation hooks
- expose a pooled `query` getter on `ECSWorld`, track world version changes, and migrate systems to use builder-based queries
- extend unit tests to cover the builder API and update existing ECS tests to the new helpers

## Testing
- `npm test`
- `npm run typecheck`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68d6fde459c4832e90007f868392e8d8