### PR TITLE
Refactor ECS systems to class-based scheduling

### DIFF
--- a/src/simulation/ecs/index.ts
+++ b/src/simulation/ecs/index.ts
@@ -3,3 +3,4 @@ export * from './systems';
 export * from './entity';
 export * from './signal';
 export * from './queryBuilder';
+export * from './system';

--- a/src/simulation/ecs/system.ts
+++ b/src/simulation/ecs/system.ts
@@ -1,0 +1,62 @@
+import { QueryBuilder } from './queryBuilder';
+import type { ECSWorld, ComponentTuple, QueryResult } from './world';
+
+export interface SystemOptions {
+  readonly name?: string;
+  readonly group?: string;
+  readonly active?: boolean;
+  readonly paused?: boolean;
+  readonly processEmpty?: boolean;
+  readonly parallelProcessing?: boolean;
+  readonly dependencies?: Iterable<string>;
+  readonly before?: Iterable<string>;
+  readonly after?: Iterable<string>;
+  readonly subSystems?: Iterable<System>;
+}
+
+export class System<TComponents extends ComponentTuple = ComponentTuple> {
+  readonly name: string;
+  readonly group: string;
+  active: boolean;
+  paused: boolean;
+  processEmpty: boolean;
+  parallelProcessing: boolean;
+  readonly dependencies: Set<string>;
+  readonly before: Set<string>;
+  readonly after: Set<string>;
+  readonly subSystems: readonly System[];
+
+  private readonly queryCache = new WeakMap<ECSWorld, QueryBuilder<TComponents>>();
+
+  constructor(options: SystemOptions = {}) {
+    this.name = options.name ?? this.constructor.name ?? 'System';
+    this.group = options.group ?? 'default';
+    this.active = options.active ?? true;
+    this.paused = options.paused ?? false;
+    this.processEmpty = options.processEmpty ?? false;
+    this.parallelProcessing = options.parallelProcessing ?? false;
+    this.dependencies = new Set(options.dependencies ?? []);
+    this.before = new Set(options.before ?? []);
+    this.after = new Set(options.after ?? []);
+    this.subSystems = options.subSystems ? [...options.subSystems] : [];
+  }
+
+  protected query(world: ECSWorld): QueryBuilder<TComponents> {
+    return world.query as unknown as QueryBuilder<TComponents>;
+  }
+
+  getQuery(world: ECSWorld): QueryBuilder<TComponents> {
+    let builder = this.queryCache.get(world);
+    if (!builder) {
+      builder = this.query(world);
+      this.queryCache.set(world, builder);
+    }
+    return builder;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  process(_entity: QueryResult<TComponents>, _delta: number, _world: ECSWorld): void {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  processAll?(_world: ECSWorld, _entities: QueryResult<TComponents>[], _delta: number): void;
+}

--- a/src/simulation/ecs/systems/mechanismPhysicsSystem.ts
+++ b/src/simulation/ecs/systems/mechanismPhysicsSystem.ts
@@ -1,26 +1,43 @@
 import type { MechanismChassis } from '../../mechanism';
 import type { SimulationWorldComponents, TransformComponent } from '../../runtime/simulationWorld';
-import type { ComponentHandle, System } from '../world';
+import type { ComponentHandle, QueryResult, ECSWorld } from '../world';
+import { System } from '../system';
+
+class MechanismPhysicsSystem extends System<[
+  ComponentHandle<MechanismChassis>,
+  ComponentHandle<TransformComponent>,
+]> {
+  constructor(
+    private readonly MechanismCore: ComponentHandle<MechanismChassis>,
+    private readonly Transform: ComponentHandle<TransformComponent>,
+  ) {
+    super({ name: 'MechanismPhysicsSystem' });
+  }
+
+  protected override query(world: ECSWorld) {
+    return world.query.withAll(this.MechanismCore, this.Transform);
+  }
+
+  override process(
+    [entity, mechanism]: QueryResult<[
+      ComponentHandle<MechanismChassis>,
+      ComponentHandle<TransformComponent>,
+    ]>,
+    delta: number,
+    _world: ECSWorld,
+  ): void {
+    mechanism.tick(delta);
+    const state = mechanism.getStateSnapshot();
+    this.Transform.set(entity, {
+      position: { x: state.position.x, y: state.position.y },
+      rotation: state.orientation,
+    });
+  }
+}
 
 export function createMechanismPhysicsSystem({
   MechanismCore,
   Transform,
-}: Pick<SimulationWorldComponents, 'MechanismCore' | 'Transform'>): System<[
-  ComponentHandle<MechanismChassis>,
-  ComponentHandle<TransformComponent>,
-]> {
-  return {
-    name: 'MechanismPhysicsSystem',
-    createQuery: (world) => world.query.withAll(MechanismCore, Transform),
-    update: (_world, entities, delta) => {
-      for (const [entity, mechanism] of entities) {
-        mechanism.tick(delta);
-        const state = mechanism.getStateSnapshot();
-        Transform.set(entity, {
-          position: { x: state.position.x, y: state.position.y },
-          rotation: state.orientation,
-        });
-      }
-    },
-  };
+}: Pick<SimulationWorldComponents, 'MechanismCore' | 'Transform'>): MechanismPhysicsSystem {
+  return new MechanismPhysicsSystem(MechanismCore, Transform);
 }

--- a/src/simulation/ecs/systems/programRunnerSystem.ts
+++ b/src/simulation/ecs/systems/programRunnerSystem.ts
@@ -1,19 +1,28 @@
 import type { BlockProgramRunner } from '../../runtime/blockProgramRunner';
 import type { SimulationWorldComponents } from '../../runtime/simulationWorld';
-import type { ComponentHandle, System } from '../world';
+import type { ComponentHandle, QueryResult, ECSWorld } from '../world';
+import { System } from '../system';
+
+class ProgramRunnerSystem extends System<[ComponentHandle<BlockProgramRunner>]> {
+  constructor(private readonly ProgramRunner: ComponentHandle<BlockProgramRunner>) {
+    super({ name: 'ProgramRunnerSystem' });
+  }
+
+  protected override query(world: ECSWorld) {
+    return world.query.withAll(this.ProgramRunner);
+  }
+
+  override process(
+    [, runner]: QueryResult<[ComponentHandle<BlockProgramRunner>]>,
+    delta: number,
+    _world: ECSWorld,
+  ): void {
+    runner.update(delta);
+  }
+}
 
 export function createProgramRunnerSystem({
   ProgramRunner,
-}: Pick<SimulationWorldComponents, 'ProgramRunner'>): System<[
-  ComponentHandle<BlockProgramRunner>,
-]> {
-  return {
-    name: 'ProgramRunnerSystem',
-    createQuery: (world) => world.query.withAll(ProgramRunner),
-    update: (_world, entities, delta) => {
-      for (const [, runner] of entities) {
-        runner.update(delta);
-      }
-    },
-  };
+}: Pick<SimulationWorldComponents, 'ProgramRunner'>): ProgramRunnerSystem {
+  return new ProgramRunnerSystem(ProgramRunner);
 }

--- a/src/simulation/ecs/systems/resourceFieldViewSystem.ts
+++ b/src/simulation/ecs/systems/resourceFieldViewSystem.ts
@@ -4,8 +4,9 @@ import type {
   ResourceFieldViewComponent,
   SimulationWorldComponents,
 } from '../../runtime/simulationWorld';
-import type { ComponentHandle, System } from '../world';
+import type { ComponentHandle, QueryResult, ECSWorld } from '../world';
 import type { Entity } from '../entity';
+import { System } from '../system';
 
 interface ResourceFieldViewSystemDependencies
   extends Pick<SimulationWorldComponents, 'ResourceFieldView'> {}
@@ -15,65 +16,80 @@ interface ResourceFieldViewSystemOptions {
   container: Container;
 }
 
+class ResourceFieldViewSystem extends System<[ComponentHandle<ResourceFieldViewComponent>]> {
+  private readonly layers = new Map<Entity, ResourceLayer>();
+
+  constructor(
+    private readonly ResourceFieldView: ComponentHandle<ResourceFieldViewComponent>,
+    private readonly renderer: Renderer,
+    private readonly container: Container,
+  ) {
+    super({ name: 'ResourceFieldViewSystem', processEmpty: true });
+  }
+
+  protected override query(world: ECSWorld) {
+    return world.query.withAll(this.ResourceFieldView);
+  }
+
+  override processAll(
+    world: ECSWorld,
+    entities: QueryResult<[ComponentHandle<ResourceFieldViewComponent>]>[],
+  ): void {
+    const activeEntities = new Set<Entity>();
+
+    for (const [entity, view] of entities) {
+      activeEntities.add(entity);
+
+      let layer = this.layers.get(entity);
+
+      if (!layer) {
+        layer = view.layer ?? new ResourceLayer(this.renderer, view.resourceField);
+        this.layers.set(entity, layer);
+      } else if (view.layer && view.layer !== layer) {
+        this.layers.set(entity, view.layer);
+        if (layer !== view.layer) {
+          if (layer.view.parent) {
+            layer.view.parent.removeChild(layer.view);
+          }
+          layer.dispose();
+        }
+        layer = view.layer;
+      }
+
+      if (view.layer !== layer) {
+        view.layer = layer;
+      }
+
+      if (layer.view.parent !== this.container) {
+        this.container.addChild(layer.view);
+      }
+
+      layer.view.zIndex = Math.min(layer.view.zIndex ?? 0, -10);
+    }
+
+    for (const [entity, layer] of this.layers.entries()) {
+      if (activeEntities.has(entity) && world.hasEntity(entity) && this.ResourceFieldView.has(entity)) {
+        continue;
+      }
+
+      if (layer.view.parent === this.container) {
+        this.container.removeChild(layer.view);
+      }
+
+      layer.dispose();
+      this.layers.delete(entity);
+
+      const component = this.ResourceFieldView.get(entity);
+      if (component) {
+        component.layer = null;
+      }
+    }
+  }
+}
+
 export function createResourceFieldViewSystem(
   { ResourceFieldView }: ResourceFieldViewSystemDependencies,
   { renderer, container }: ResourceFieldViewSystemOptions,
-): System<[ComponentHandle<ResourceFieldViewComponent>]> {
-  const layers = new Map<Entity, ResourceLayer>();
-
-  return {
-    name: 'ResourceFieldViewSystem',
-    createQuery: (world) => world.query.withAll(ResourceFieldView),
-    update: (world, entities) => {
-      const activeEntities = new Set<Entity>();
-
-      for (const [entity, view] of entities) {
-        activeEntities.add(entity);
-
-        let layer = layers.get(entity);
-
-        if (!layer) {
-          layer = view.layer ?? new ResourceLayer(renderer, view.resourceField);
-          layers.set(entity, layer);
-        } else if (view.layer && view.layer !== layer) {
-          layers.set(entity, view.layer);
-          if (layer !== view.layer) {
-            if (layer.view.parent) {
-              layer.view.parent.removeChild(layer.view);
-            }
-            layer.dispose();
-          }
-          layer = view.layer;
-        }
-
-        if (view.layer !== layer) {
-          view.layer = layer;
-        }
-
-        if (layer.view.parent !== container) {
-          container.addChild(layer.view);
-        }
-
-        layer.view.zIndex = Math.min(layer.view.zIndex ?? 0, -10);
-      }
-
-      for (const [entity, layer] of layers.entries()) {
-        if (activeEntities.has(entity) && world.hasEntity(entity) && ResourceFieldView.has(entity)) {
-          continue;
-        }
-
-        if (layer.view.parent === container) {
-          container.removeChild(layer.view);
-        }
-
-        layer.dispose();
-        layers.delete(entity);
-
-        const component = ResourceFieldView.get(entity);
-        if (component) {
-          component.layer = null;
-        }
-      }
-    },
-  };
+): ResourceFieldViewSystem {
+  return new ResourceFieldViewSystem(ResourceFieldView, renderer, container);
 }


### PR DESCRIPTION
## Summary
- introduce a reusable System base class that caches queries, tracks dependencies, and exposes process/processAll hooks
- update ECSWorld scheduling and refactor all existing systems to extend the new base class while honouring group ordering and active states
- expand integration tests to cover grouped execution, dependency ordering, and query caching alongside updated world behaviour

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d792d5d880832e85c5cd58eada3516