### PR TITLE
Prevent touch scrolling on drag buttons

### DIFF
--- a/src/styles/ChassisInspector.module.css
+++ b/src/styles/ChassisInspector.module.css
@@ -132,6 +132,8 @@
   align-items: center;
   gap: var(--space-3);
   cursor: pointer;
+  -ms-touch-action: none;
+  touch-action: none;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
 }
 

--- a/src/styles/InventoryInspector.module.css
+++ b/src/styles/InventoryInspector.module.css
@@ -126,6 +126,8 @@
   align-items: center;
   gap: var(--space-3);
   cursor: pointer;
+  -ms-touch-action: none;
+  touch-action: none;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
   min-height: 100px;
 }


### PR DESCRIPTION
## Summary
- disable touch scrolling on chassis module drag buttons to keep pointer sessions active
- apply the same touch-action override to inventory item buttons for touch carry interactions

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d7967573fc832e81d9a726fdb805cd