### PR TITLE
Synchronise overlay persistence with runtime

### DIFF
--- a/src/state/__tests__/overlayPersistence.test.ts
+++ b/src/state/__tests__/overlayPersistence.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultOverlayPersistenceAdapter } from '../overlayPersistence';
+import { simulationRuntime } from '../simulationRuntime';
+import { chassisState, inventoryState, telemetryState } from '../runtime';
+import { MechanismChassis, createModuleInstance } from '../../simulation/mechanism';
+import type { MechanismOverlayUpdate, RootScene } from '../../simulation/rootScene';
+import { reconcileMechanismOverlayState } from '../../simulation/rootScene';
+import { DEFAULT_MECHANISM_ID } from '../../simulation/runtime/simulationWorld';
+import type { EntityOverlayData } from '../../types/overlay';
+import type { EntityId } from '../../simulation/ecs/world';
+
+const createMechanismScene = () => {
+  const mechanism = new MechanismChassis();
+  mechanism.attachModule(createModuleInstance('core.movement'));
+  mechanism.attachModule(createModuleInstance('storage.cargo'));
+  mechanism.attachModule(createModuleInstance('arm.manipulator'));
+
+  const inventory = mechanism.inventory;
+  let selectedMechanismId: string | null = DEFAULT_MECHANISM_ID;
+
+  const scene = {
+    mechanism,
+    subscribeProgramStatus: vi.fn(() => () => {}),
+    runProgram: vi.fn(),
+    stopProgram: vi.fn(),
+    getInventorySnapshot: vi.fn(() => inventory.getSnapshot()),
+    subscribeInventory: vi.fn((listener: (snapshot: ReturnType<typeof inventory.getSnapshot>) => void) => {
+      return inventory.subscribe(listener);
+    }),
+    subscribeTelemetry: vi.fn((listener: (snapshot: unknown, mechanismId: string | null) => void) => {
+      listener({ values: {}, actions: {} }, DEFAULT_MECHANISM_ID);
+      return () => {};
+    }),
+    getTelemetrySnapshot: vi.fn(() => ({ values: {}, actions: {} })),
+    subscribeProgramDebug: vi.fn((listener: (state: unknown, mechanismId: string) => void) => {
+      listener({ status: 'idle', program: null, currentInstruction: null, timeRemaining: 0, frames: [] }, DEFAULT_MECHANISM_ID);
+      return () => {};
+    }),
+    getProgramDebugState: vi.fn(() => ({ status: 'idle', program: null, currentInstruction: null, timeRemaining: 0, frames: [] })),
+    subscribeChassis: vi.fn((listener: (snapshot: ReturnType<MechanismChassis['getSlotSchemaSnapshot']>) => void) => {
+      return mechanism.subscribeSlots(listener);
+    }),
+    getChassisSnapshot: vi.fn(() => mechanism.getSlotSchemaSnapshot()),
+    getSelectedMechanism: vi.fn(() => selectedMechanismId),
+    selectMechanism: vi.fn((mechanismId: string) => {
+      selectedMechanismId = mechanismId;
+    }),
+    clearMechanismSelection: vi.fn(() => {
+      selectedMechanismId = null;
+    }),
+    reconcileMechanismOverlay: vi.fn((mechanismId: string, overlay: MechanismOverlayUpdate) => {
+      if (mechanismId !== DEFAULT_MECHANISM_ID) {
+        return;
+      }
+      reconcileMechanismOverlayState(mechanism, overlay);
+    }),
+  } as unknown as RootScene & {
+    mechanism: MechanismChassis;
+  };
+
+  return scene;
+};
+
+describe('overlay persistence integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    simulationRuntime.stopProgram(DEFAULT_MECHANISM_ID);
+    simulationRuntime.clearSelectedMechanism();
+    inventoryState.clear();
+    chassisState.clear();
+    telemetryState.clear();
+  });
+
+  it('persists chassis modules moved into inventory across scene snapshots', async () => {
+    const scene = createMechanismScene();
+    simulationRuntime.registerScene(scene);
+
+    const manipulatorSnapshot = scene.mechanism.getSlotSchemaSnapshot();
+    const manipulatorSlot = manipulatorSnapshot.slots.find((slot) => slot.occupantId === 'arm.manipulator');
+    expect(manipulatorSlot).toBeTruthy();
+
+    const inventorySnapshot = scene.mechanism.inventory.getSlotSchemaSnapshot();
+    expect(inventorySnapshot.slots[0]).toBeTruthy();
+
+    const entityId: EntityId = 1 as EntityId;
+
+    const previous: EntityOverlayData = {
+      entityId,
+      mechanismId: DEFAULT_MECHANISM_ID,
+      name: 'Test Mechanism',
+      overlayType: 'complex',
+      chassis: {
+        capacity: manipulatorSnapshot.capacity,
+        slots: manipulatorSnapshot.slots.map((slot) => ({ ...slot, metadata: { ...slot.metadata } })),
+      },
+      inventory: {
+        capacity: inventorySnapshot.capacity,
+        slots: inventorySnapshot.slots.map((slot) => ({ ...slot, metadata: { ...slot.metadata } })),
+      },
+    };
+
+    const next: EntityOverlayData = {
+      ...previous,
+      chassis: {
+        capacity: manipulatorSnapshot.capacity,
+        slots: manipulatorSnapshot.slots.map((slot) =>
+          slot.id === manipulatorSlot?.id
+            ? { ...slot, occupantId: null, metadata: { ...slot.metadata } }
+            : { ...slot, metadata: { ...slot.metadata } },
+        ),
+      },
+      inventory: {
+        capacity: inventorySnapshot.capacity,
+        slots: inventorySnapshot.slots.map((slot, index) =>
+          index === 0
+            ? {
+                ...slot,
+                occupantId: 'arm.manipulator',
+                stackCount: undefined,
+                metadata: { ...slot.metadata, stackable: false },
+              }
+            : { ...slot, metadata: { ...slot.metadata } },
+        ),
+      },
+    };
+
+    const adapter = getDefaultOverlayPersistenceAdapter();
+    await adapter.saveEntity(next, previous);
+
+    expect(scene.reconcileMechanismOverlay).toHaveBeenCalledWith(
+      DEFAULT_MECHANISM_ID,
+      expect.objectContaining({
+        chassis: expect.objectContaining({ slots: expect.any(Array) }),
+        inventory: expect.objectContaining({ slots: expect.any(Array) }),
+      }),
+    );
+
+    const chassisAfter = scene.mechanism.getSlotSchemaSnapshot();
+    const updatedManipulatorSlot = chassisAfter.slots.find((slot) => slot.id === manipulatorSlot?.id);
+    expect(updatedManipulatorSlot?.occupantId).toBeNull();
+
+    const inventoryAfter = scene.mechanism.inventory.getSnapshot();
+    const storedModuleSlot = inventoryAfter.slots.find((slot) => slot.occupantId === 'arm.manipulator');
+    expect(storedModuleSlot).toBeTruthy();
+
+    simulationRuntime.unregisterScene(scene);
+  });
+});
+

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -111,6 +111,7 @@ const createSceneStub = () => {
         listener(snapshot);
       }
     },
+    reconcileMechanismOverlay: vi.fn(),
   } as unknown as RootScene & {
     triggerStatus: (mechanismId: string, status: ProgramRunnerStatus) => void;
     triggerTelemetry: (mechanismId: string, snapshot: SimulationTelemetrySnapshot) => void;

--- a/src/state/overlayPersistence.ts
+++ b/src/state/overlayPersistence.ts
@@ -1,6 +1,7 @@
 import type { EntityId } from '../simulation/ecs/world';
 import type { EntityOverlayData } from '../types/overlay';
 import { chassisState, inventoryState } from './runtime';
+import { simulationRuntime } from './simulationRuntime';
 
 export interface OverlayPersistenceAdapter {
   saveEntity: (next: EntityOverlayData, previous: EntityOverlayData | undefined) => Promise<void>;
@@ -18,6 +19,7 @@ const defaultAdapter: OverlayPersistenceAdapter = {
     if (next.inventory) {
       inventoryState.applyOverlayUpdate(next.inventory);
     }
+    simulationRuntime.applyOverlayPersistence(next);
   },
   async removeEntity() {
     // Complex overlays remain in memory so there is no persistence layer to clear.


### PR DESCRIPTION
## Summary
- forward complex overlay saves through the runtime so the active scene reconciles chassis and inventory state
- add runtime and root scene helpers to attach/detach modules and update inventory slots based on overlay schema
- add coverage confirming that moving a chassis module into inventory survives the next scene snapshot

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d7bb62c4a0832e8cec62bb449834a6