### PR TITLE
Restrict palette blocks based on installed modules

### DIFF
--- a/src/components/MechanismProgrammingPanel.tsx
+++ b/src/components/MechanismProgrammingPanel.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, type DragEvent } from 'react';
-import BlockPalette from './BlockPalette';
+import BlockPalette, { type PaletteBlockEntry } from './BlockPalette';
 import Workspace from './Workspace';
 import RuntimeControls from './RuntimeControls';
-import { BLOCK_LIBRARY } from '../blocks/library';
 import type { WorkspaceState, DropTarget, BlockInstance, DragPayload } from '../types/blocks';
 import styles from '../styles/MechanismProgrammingPanel.module.css';
 import useMechanismTelemetry from '../hooks/useMechanismTelemetry';
@@ -10,6 +9,7 @@ import type { Diagnostic } from '../simulation/runtime/blockProgram';
 import type { RunProgramResult } from '../state/ProgrammingInspectorContext';
 
 interface MechanismProgrammingPanelProps {
+  paletteBlocks: PaletteBlockEntry[];
   workspace: WorkspaceState;
   onDrop: (event: DragEvent<HTMLElement>, target: DropTarget) => void;
   onTouchDrop: (payload: DragPayload, target: DropTarget) => void;
@@ -27,6 +27,7 @@ interface MechanismProgrammingPanelProps {
 }
 
 const MechanismProgrammingPanel = ({
+  paletteBlocks,
   workspace,
   onDrop,
   onTouchDrop,
@@ -74,7 +75,7 @@ const MechanismProgrammingPanel = ({
           data-read-only={isReadOnly ? 'true' : undefined}
         >
           <h4>Block palette</h4>
-          <BlockPalette blocks={BLOCK_LIBRARY} onTouchDrop={onTouchDrop} />
+          <BlockPalette blocks={paletteBlocks} onTouchDrop={onTouchDrop} />
         </aside>
         <section className={styles.workspace} data-read-only={isReadOnly ? 'true' : undefined}>
           <h4>Workspace</h4>

--- a/src/components/__tests__/BlockPaletteInteractions.test.tsx
+++ b/src/components/__tests__/BlockPaletteInteractions.test.tsx
@@ -1,8 +1,13 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import BlockPalette from '../BlockPalette';
+import BlockPalette, { type PaletteBlockEntry } from '../BlockPalette';
 import BlockView from '../BlockView';
 import { BLOCK_LIBRARY, createBlockInstance } from '../../blocks/library';
+
+const paletteBlocks: PaletteBlockEntry[] = BLOCK_LIBRARY.map((definition) => ({
+  definition,
+  isLocked: false,
+}));
 
 const createMockDataTransfer = (): DataTransfer => {
   const store = new Map<string, string>();
@@ -32,7 +37,7 @@ const createMockDataTransfer = (): DataTransfer => {
 
 describe('BlockPalette value and operator blocks', () => {
   it('renders grouped value and operator sections with badges', () => {
-    render(<BlockPalette blocks={BLOCK_LIBRARY} />);
+    render(<BlockPalette blocks={paletteBlocks} />);
 
     expect(screen.getByText('Values & Signals')).toBeInTheDocument();
     expect(screen.getByText('Operators')).toBeInTheDocument();
@@ -54,7 +59,7 @@ describe('BlockPalette value and operator blocks', () => {
 
     render(
       <div>
-        <BlockPalette blocks={BLOCK_LIBRARY} />
+        <BlockPalette blocks={paletteBlocks} />
         <BlockView block={conditional} path={[]} onDrop={handleDrop} />
       </div>,
     );
@@ -87,7 +92,7 @@ describe('BlockPalette value and operator blocks', () => {
 
     render(
       <div>
-        <BlockPalette blocks={BLOCK_LIBRARY} />
+        <BlockPalette blocks={paletteBlocks} />
         <BlockView block={repeat} path={[]} onDrop={handleDrop} />
       </div>,
     );
@@ -112,7 +117,7 @@ describe('BlockPalette value and operator blocks', () => {
   });
 
   it('filters palette items using the search input', () => {
-    render(<BlockPalette blocks={BLOCK_LIBRARY} />);
+    render(<BlockPalette blocks={paletteBlocks} />);
 
     const filters = screen.getAllByLabelText('Filter blocks');
     filters.forEach((input) => {

--- a/src/styles/BlockPalette.module.css
+++ b/src/styles/BlockPalette.module.css
@@ -83,6 +83,12 @@
   align-self: start;
 }
 
+.paletteItemLocked {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
 .paletteItem:active {
   cursor: grabbing;
   transform: scale(0.98);
@@ -167,6 +173,12 @@
   margin-top: var(--space-2);
   pointer-events: auto;
   inline-size: 100%;
+}
+
+.paletteLockMessage {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
 }
 
 .paletteItemActive {


### PR DESCRIPTION
## Summary
- derive allowed programming blocks from installed chassis modules and pass availability to the programming panel
- update the block palette UI to show locked blocks with accessible messaging instead of allowing them to be dragged
- extend programming inspector and palette tests to cover module-dependent availability changes

## Testing
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7c7937a54832e82f5cd4a8f26fdaa