### PR TITLE
Add tree harvesting mechanics

### DIFF
--- a/src/simulation/assetService.ts
+++ b/src/simulation/assetService.ts
@@ -146,9 +146,66 @@ assetService.defineVectorAsset('resource/biotic-spore', () => {
   return graphic;
 });
 
+assetService.defineVectorAsset(
+  'resource/tree',
+  ({ foliage = 0x2e7d32, accent = 0x63c132, trunk = 0x8d6e63 }: Record<string, unknown> = {}) => {
+    const graphic = new Graphics();
+
+    graphic.beginPath();
+    graphic.roundRect(-8, -48, 16, 48, 4);
+    graphic.fill({ color: typeof trunk === 'number' ? trunk : 0x8d6e63, alpha: 0.95 });
+
+    const foliageColor = typeof foliage === 'number' ? foliage : 0x2e7d32;
+    const accentColor = typeof accent === 'number' ? accent : 0x63c132;
+
+    graphic.beginPath();
+    graphic.circle(0, -60, 26);
+    graphic.fill({ color: foliageColor, alpha: 0.9 });
+
+    graphic.beginPath();
+    graphic.ellipse(-12, -72, 18, 20);
+    graphic.fill({ color: accentColor, alpha: 0.78 });
+
+    graphic.beginPath();
+    graphic.ellipse(14, -68, 16, 18);
+    graphic.fill({ color: accentColor, alpha: 0.72 });
+
+    return graphic;
+  },
+);
+
+assetService.defineVectorAsset('resource/log', ({ bark = 0x8d6e63, ring = 0xc8a97e }: Record<string, unknown> = {}) => {
+  const graphic = new Graphics();
+
+  const barkColor = typeof bark === 'number' ? bark : 0x8d6e63;
+  const ringColor = typeof ring === 'number' ? ring : 0xc8a97e;
+
+  graphic.beginPath();
+  graphic.roundRect(-22, -8, 44, 16, 6);
+  graphic.fill({ color: barkColor, alpha: 0.92 });
+  graphic.setStrokeStyle({ width: 3, color: 0x5d4037, alpha: 0.9 });
+  graphic.stroke();
+
+  graphic.beginPath();
+  graphic.circle(-16, 0, 7);
+  graphic.fill({ color: ringColor, alpha: 0.9 });
+  graphic.setStrokeStyle({ width: 2, color: 0x5d4037, alpha: 0.85 });
+  graphic.stroke();
+
+  graphic.beginPath();
+  graphic.circle(16, 0, 7);
+  graphic.fill({ color: ringColor, alpha: 0.9 });
+  graphic.setStrokeStyle({ width: 2, color: 0x5d4037, alpha: 0.85 });
+  graphic.stroke();
+
+  return graphic;
+});
+
 export const RESOURCE_TEXTURE_IDS: Record<string, string> = {
   default: 'resource/default',
   'ferrous-ore': 'resource/ferrous-ore',
   'silicate-crystal': 'resource/silicate-crystal',
   'biotic-spore': 'resource/biotic-spore',
+  tree: 'resource/tree',
+  log: 'resource/log',
 };

--- a/src/simulation/resourceLayer.ts
+++ b/src/simulation/resourceLayer.ts
@@ -113,7 +113,11 @@ export class ResourceLayer {
     }
 
     const sprite = new Sprite(texture);
-    sprite.anchor.set(0.5);
+    if (node.type === 'tree') {
+      sprite.anchor.set(0.5, 1);
+    } else {
+      sprite.anchor.set(0.5);
+    }
     sprite.position.set(node.position.x, node.position.y);
 
     this.container.addChild(sprite);
@@ -133,12 +137,19 @@ export class ResourceLayer {
     }
 
     entry.sprite.position.set(node.position.x, node.position.y);
-    entry.maxQuantity = Math.max(entry.maxQuantity, Math.max(node.quantity, 1));
+    const metadata = node.metadata as { hitPoints?: unknown } | undefined;
+    const maxReference =
+      metadata && typeof metadata.hitPoints === 'number' && Number.isFinite(metadata.hitPoints) && metadata.hitPoints > 0
+        ? Math.max(metadata.hitPoints, 1)
+        : Math.max(node.quantity, 1);
+    entry.maxQuantity = Math.max(entry.maxQuantity, maxReference);
     const ratio = entry.maxQuantity > 0 ? clamp(node.quantity / entry.maxQuantity, 0, 1) : 0;
     const alpha = node.quantity > 0 ? 0.35 + ratio * 0.65 : 0;
     entry.sprite.alpha = alpha;
-    const scale = 0.8 + ratio * 0.4;
-    entry.sprite.scale.set(scale);
+    const baseScale = node.type === 'tree' ? 1.15 : node.type === 'log' ? 0.95 : 1;
+    const scale = baseScale * (0.75 + ratio * 0.45);
+    const yScale = node.type === 'tree' ? scale * 1.35 : scale;
+    entry.sprite.scale.set(scale, yScale);
   }
 
   private removeSprite(nodeId: string): void {


### PR DESCRIPTION
## Summary
- add tree resources with axe-gated hit metadata and log drops in the default field
- support strike-based harvesting and log spawning through a new ResourceField.registerHit
- draw tree and log vector assets and tune resource sprites for tall silhouettes
- cover tree depletion and log spawning in unit tests

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d7cbb4f4f4832eb163594df7a8dc97