### PR TITLE
Add inventory equipment handling and axe tool action

### DIFF
--- a/playwright/module-inventory.spec.ts
+++ b/playwright/module-inventory.spec.ts
@@ -45,8 +45,20 @@ test.describe('module inventory management', () => {
 
     await overlay.getByRole('tab', { name: 'Systems' }).click();
 
-    const inventorySlot = overlay.getByTestId('inventory-slot-inventory-0');
-    await expect(inventorySlot).toContainText('Empty slot');
+    const toolSlot = overlay.getByTestId('inventory-slot-inventory-0');
+    await expect(toolSlot).toContainText(/Axe/i);
+
+    const inventorySlotLocator = overlay
+      .locator('[data-testid^="inventory-slot-"]')
+      .filter({ hasText: 'Empty slot' })
+      .first();
+    await expect(inventorySlotLocator).toContainText('Empty slot');
+
+    const inventorySlotId = await inventorySlotLocator.getAttribute('data-testid');
+    if (!inventorySlotId) {
+      throw new Error('Unable to resolve inventory slot identifier.');
+    }
+    const inventorySlot = overlay.getByTestId(inventorySlotId);
 
     await page.waitForFunction(() => Boolean(window.__mfEntityOverlayManager));
 
@@ -103,6 +115,7 @@ test.describe('module inventory management', () => {
 
     const sensorSlot = overlay.getByTestId('chassis-slot-sensor-0');
     await expect(sensorSlot).toContainText('Empty slot');
+    await expect(toolSlot).toContainText(/Axe/i);
     await expect(inventorySlot).toContainText('Survey Scanner Suite');
 
     await overlay.getByRole('tab', { name: 'Programming' }).click();

--- a/src/simulation/mechanism/MechanismChassis.ts
+++ b/src/simulation/mechanism/MechanismChassis.ts
@@ -118,6 +118,11 @@ export class MechanismChassis {
     this.inventory = new InventoryStore();
     this.resourceField = new ResourceField(createDefaultResourceNodes());
 
+    this.inventory.setSlotConfiguration(0, {
+      metadata: { stackable: false, moduleSubtype: 'Tool Bay' },
+      occupantId: 'axe',
+    });
+
     const initialSlots = Array.isArray(slotSchema) && slotSchema.length > 0 ? slotSchema : DEFAULT_CHASSIS_SLOTS;
     for (const definition of initialSlots) {
       this.registerSlotDefinition(definition);

--- a/src/simulation/mechanism/__tests__/inventory.test.ts
+++ b/src/simulation/mechanism/__tests__/inventory.test.ts
@@ -113,5 +113,21 @@ describe('InventoryStore slot schema integration', () => {
     expect(nextSnapshot?.metadata.locked).toBe(true);
     expect(nextSnapshot?.metadata.stackable).toBe(false);
   });
+
+  it('tracks fixed equipment separately from bulk resources', () => {
+    const store = new InventoryStore();
+    store.setSlotConfiguration(0, {
+      metadata: { stackable: false, moduleSubtype: 'Tool Bay' },
+      occupantId: 'axe',
+    });
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.entries).toEqual([]);
+    expect(snapshot.equipment).toEqual([
+      expect.objectContaining({ slotId: 'inventory-0', index: 0, itemId: 'axe' }),
+    ]);
+    expect(store.getSlotOccupantByIndex(0)).toBe('axe');
+    expect(store.getQuantity('axe')).toBe(0);
+  });
 });
 

--- a/src/simulation/mechanism/modules/cargoHoldModule.ts
+++ b/src/simulation/mechanism/modules/cargoHoldModule.ts
@@ -145,6 +145,7 @@ export class CargoHoldModule extends MechanismModule {
         entries: [],
         slots: [],
         slotCapacity: 0,
+        equipment: [],
       });
     }
   }

--- a/src/simulation/rootScene.ts
+++ b/src/simulation/rootScene.ts
@@ -500,7 +500,7 @@ export class RootScene {
   getInventorySnapshot(mechanismId: string = this.getActiveMechanismId()): InventorySnapshot {
     const mechanismCore = this.context?.getMechanismCore(mechanismId);
     if (!mechanismCore) {
-      return { capacity: 0, used: 0, available: 0, entries: [], slots: [], slotCapacity: 0 };
+      return { capacity: 0, used: 0, available: 0, entries: [], slots: [], slotCapacity: 0, equipment: [] };
     }
     return mechanismCore.getInventorySnapshot();
   }

--- a/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
+++ b/src/simulation/runtime/__tests__/blockProgramRunner.test.ts
@@ -343,7 +343,8 @@ describe('BlockProgramRunner', () => {
     mechanism.tick(1);
 
     const inventoryAfter = mechanism.getInventorySnapshot();
-    expect(inventoryAfter.used).toBe(0);
+    expect(inventoryAfter.used).toBe(1);
+    expect(inventoryAfter.entries).toEqual([]);
 
     const mechanismState = mechanism.getStateSnapshot();
     const nodes = mechanism.resourceField.list();

--- a/src/state/__tests__/simulationRuntime.test.ts
+++ b/src/state/__tests__/simulationRuntime.test.ts
@@ -39,6 +39,7 @@ const createSceneStub = () => {
       entries: [],
       slots: [],
       slotCapacity: 0,
+      equipment: [],
     })),
     subscribeInventory: vi.fn(() => () => {}),
     subscribeTelemetry: vi.fn((listener: (snapshot: SimulationTelemetrySnapshot, mechanismId: string | null) => void) => {
@@ -266,9 +267,9 @@ describe('simulationRuntime', () => {
     expect(snapshot.slotCapacity).toBe(4);
     expect(snapshot.used).toBe(4);
     expect(snapshot.available).toBe(0);
-    expect(snapshot.entries).toEqual([
-      { resource: 'core.movement', quantity: 1 },
-      { resource: 'resource.ore', quantity: 3 },
+    expect(snapshot.entries).toEqual([{ resource: 'resource.ore', quantity: 3 }]);
+    expect(snapshot.equipment).toEqual([
+      expect.objectContaining({ slotId: 'inventory-0', itemId: 'core.movement' }),
     ]);
     expect(snapshot.slots).toHaveLength(3);
 


### PR DESCRIPTION
## Summary
- extend the inventory store with equipment tracking, slot configuration helpers, and stackable-aware resource accounting
- seed the tutorial chassis with an axe and expose a manipulation module action that swings the tool against resource nodes
- surface equipment data across runtime state and adjust UI tests to account for the starting tool loadout

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d82071c0b4832e8ec7325ab5dd5c17