### PR TITLE
Add use-item slot block and runtime execution

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -113,6 +113,31 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     paletteGroup: 'Actions',
   },
   {
+    id: 'use-item-slot',
+    label: 'Use Tool Slot',
+    category: 'action',
+    summary:
+      'Activate a tool stored in a specific inventory slot, preferring the latest scanned resource target.',
+    parameters: {
+      slotIndex: { kind: 'number', defaultValue: 1, min: 1, step: 1 },
+      slotLabel: { kind: 'string', defaultValue: 'Primary Tool' },
+      useScanHit: { kind: 'boolean', defaultValue: true },
+      scanHitIndex: { kind: 'number', defaultValue: 1, min: 1, step: 1 },
+      targetX: { kind: 'number', defaultValue: 0 },
+      targetY: { kind: 'number', defaultValue: 0 },
+    },
+    expressionInputs: ['slotIndex', 'useScanHit', 'scanHitIndex', 'targetX', 'targetY'],
+    expressionInputDefaults: {
+      slotIndex: ['literal-number'],
+      useScanHit: ['literal-boolean'],
+      scanHitIndex: ['literal-number'],
+      targetX: ['literal-number'],
+      targetY: ['literal-number'],
+    },
+    paletteGroup: 'Actions',
+    paletteTags: ['manipulation', 'tool', 'resource'],
+  },
+  {
     id: 'return-home',
     label: 'Return to Core',
     category: 'action',


### PR DESCRIPTION
## Summary
- add a Use Tool Slot block with slot selection and scan targeting parameters to the block library
- compile the new block into use-item instructions that preserve slot metadata and target hints
- execute use-item instructions in the runtime by invoking the manipulator with scan-driven targeting and swing timing
- extend compiler and runner unit tests to cover the new instruction and diagnostic handling

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d8eb11f164832e854052415776e7b3