### PR TITLE
Prevent resource sprites from reappearing after depletion

### DIFF
--- a/src/simulation/__tests__/resourceLayer.test.ts
+++ b/src/simulation/__tests__/resourceLayer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Renderer } from 'pixi.js';
+
+import { assetService } from '../assetService';
+import { ResourceLayer } from '../resourceLayer';
+import { ResourceField } from '../resources/resourceField';
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('ResourceLayer', () => {
+  it('does not reattach sprites for depleted nodes after pending load resolves', async () => {
+    const field = new ResourceField([
+      {
+        id: 'tree-1',
+        type: 'tree',
+        position: { x: 0, y: 0 },
+        quantity: 1,
+      },
+    ]);
+
+    const renderer = {} as Renderer;
+    const deferred = createDeferred<unknown>();
+    const loadSpy = vi
+      .spyOn(assetService, 'loadTexture')
+      .mockImplementation(() => deferred.promise as Promise<never>);
+
+    const layer = new ResourceLayer(renderer, field);
+
+    expect(loadSpy).toHaveBeenCalledOnce();
+
+    const hitResult = field.registerHit({ nodeId: 'tree-1' });
+    expect(hitResult.status).toBe('depleted');
+
+    const container = layer.view as unknown as { children: unknown[] };
+    expect(container.children).toHaveLength(0);
+
+    deferred.resolve({});
+    await loadSpy.mock.results[0]!.value;
+    await Promise.resolve();
+
+    expect(container.children).toHaveLength(0);
+
+    layer.destroy();
+    loadSpy.mockRestore();
+  });
+});

--- a/src/simulation/resourceLayer.ts
+++ b/src/simulation/resourceLayer.ts
@@ -107,26 +107,34 @@ export class ResourceLayer {
       return;
     }
 
+    const currentNode = this.resourceField
+      .list()
+      .find((entry) => entry.id === node.id);
+
+    if (!currentNode || currentNode.quantity <= 0) {
+      return;
+    }
+
     if (this.spriteEntries.has(node.id)) {
-      this.updateSprite(node);
+      this.updateSprite(currentNode);
       return;
     }
 
     const sprite = new Sprite(texture);
-    if (node.type === 'tree') {
+    if (currentNode.type === 'tree') {
       sprite.anchor.set(0.5, 1);
     } else {
       sprite.anchor.set(0.5);
     }
-    sprite.position.set(node.position.x, node.position.y);
+    sprite.position.set(currentNode.position.x, currentNode.position.y);
 
     this.container.addChild(sprite);
     this.spriteEntries.set(node.id, {
       sprite,
-      maxQuantity: Math.max(node.quantity, 1),
+      maxQuantity: Math.max(currentNode.quantity, 1),
     });
 
-    this.updateSprite(node);
+    this.updateSprite(currentNode);
   }
 
   private updateSprite(node: ResourceNode): void {
@@ -153,6 +161,7 @@ export class ResourceLayer {
   }
 
   private removeSprite(nodeId: string): void {
+    this.pendingLoads.delete(nodeId);
     const entry = this.spriteEntries.get(nodeId);
     if (!entry) {
       return;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,6 +12,65 @@ vi.mock('pixi.js', () => {
     height = 0;
     events: Record<string, unknown> = {};
     generateTexture = vi.fn(() => ({ destroy: vi.fn() }));
+    destroy = vi.fn();
+  }
+
+  class MockContainer {
+    children: unknown[] = [];
+
+    addChild<T>(child: T): T {
+      this.children.push(child);
+      return child;
+    }
+
+    removeChild<T>(child: T): T {
+      this.children = this.children.filter((entry) => entry !== child);
+      return child;
+    }
+
+    destroy = vi.fn();
+  }
+
+  class MockGraphics extends MockContainer {
+    lineStyle(): this {
+      return this;
+    }
+    moveTo(): this {
+      return this;
+    }
+    lineTo(): this {
+      return this;
+    }
+  }
+
+  class MockSprite extends MockContainer {
+    anchor = {
+      x: 0,
+      y: 0,
+      set: vi.fn((x: number, y?: number) => {
+        this.anchor.x = x;
+        this.anchor.y = y ?? x;
+      }),
+    };
+    position = {
+      x: 0,
+      y: 0,
+      set: vi.fn((x: number, y: number) => {
+        this.position.x = x;
+        this.position.y = y;
+      }),
+    };
+    scale = {
+      x: 1,
+      y: 1,
+      set: vi.fn((x: number, y?: number) => {
+        this.scale.x = x;
+        this.scale.y = y ?? x;
+      }),
+    };
+    alpha = 1;
+    rotation = 0;
+    destroy = vi.fn();
   }
 
   class MockApplication {
@@ -29,41 +88,11 @@ vi.mock('pixi.js', () => {
     destroy(): void {}
   }
 
-  class MockContainer {
-    children: unknown[] = [];
-
-    addChild<T>(child: T): T {
-      this.children.push(child);
-      return child;
-    }
-
-    removeChild<T>(child: T): void {
-      this.children = this.children.filter((entry) => entry !== child);
-    }
-  }
-
-  class MockGraphics extends MockContainer {
-    lineStyle(): this {
-      return this;
-    }
-    moveTo(): this {
-      return this;
-    }
-    lineTo(): this {
-      return this;
-    }
-  }
-
-  class MockSprite extends MockContainer {
-    anchor = { set: vi.fn() };
-    position = { set: vi.fn() };
-    rotation = 0;
-  }
-
   return {
     Application: MockApplication,
     Container: MockContainer,
     Graphics: MockGraphics,
+    Renderer: MockRenderer,
     Sprite: MockSprite,
   };
 });

--- a/src/test/stubs/pixi.ts
+++ b/src/test/stubs/pixi.ts
@@ -1,10 +1,5 @@
 export class Application {
-  renderer = {
-    width: 0,
-    height: 0,
-    events: {},
-    generateTexture: () => ({ destroy: () => {} }),
-  };
+  renderer = new Renderer();
   ticker = { add: () => {}, remove: () => {} };
   stage = { addChild: () => {}, destroy: () => {} };
   view = { remove: () => {} };
@@ -20,8 +15,19 @@ export class Application {
 }
 
 export class Container {
-  addChild(): void {}
-  removeChild(): void {}
+  children: unknown[] = [];
+
+  addChild<T>(child: T): T {
+    this.children.push(child);
+    return child;
+  }
+
+  removeChild<T>(child: T): T {
+    this.children = this.children.filter((entry) => entry !== child);
+    return child;
+  }
+
+  destroy(): void {}
 }
 
 export class Graphics extends Container {
@@ -36,8 +42,50 @@ export class Graphics extends Container {
   }
 }
 
+export class Renderer {
+  width = 0;
+  height = 0;
+  events: Record<string, unknown> = {};
+
+  generateTexture(): { destroy: () => void } {
+    return { destroy: () => {} };
+  }
+
+  destroy(): void {}
+}
+
 export class Sprite extends Container {
-  anchor = { set: () => {} };
-  position = { set: () => {} };
+  anchor = {
+    x: 0,
+    y: 0,
+    set: (x: number, y?: number) => {
+      this.anchor.x = x;
+      this.anchor.y = y ?? x;
+    },
+  };
+  position = {
+    x: 0,
+    y: 0,
+    set: (x: number, y: number) => {
+      this.position.x = x;
+      this.position.y = y;
+    },
+  };
+  scale = {
+    x: 1,
+    y: 1,
+    set: (x: number, y?: number) => {
+      this.scale.x = x;
+      this.scale.y = y ?? x;
+    },
+  };
+  alpha = 1;
   rotation = 0;
+
+  constructor(public texture?: unknown) {
+    super();
+    this.texture = texture;
+  }
+
+  destroy(): void {}
 }


### PR DESCRIPTION
## Summary
- guard ResourceLayer sprite creation with a post-load state check and clear pending loads when nodes are removed
- extend Pixi test stubs to expose renderer and sprite behaviours exercised by the layer
- add a regression test that waits for a delayed texture load after a tree is depleted to ensure no sprite returns

## Testing
- npm test
- npm run typecheck
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68dd02a4a6a4832e8cbb68da7c99f807