### PR TITLE
feat: add storage box support for mechanisms

### DIFF
--- a/src/blocks/library.ts
+++ b/src/blocks/library.ts
@@ -152,6 +152,40 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     paletteGroup: 'Actions',
   },
   {
+    id: 'store-storage',
+    label: 'Store to Storage Box',
+    category: 'action',
+    summary: 'Move inventory into a storage box, defaulting to the base container when none is specified.',
+    parameters: {
+      boxId: { kind: 'string', defaultValue: 'storage.box.base' },
+      resource: { kind: 'string', defaultValue: '' },
+      amount: { kind: 'number', defaultValue: 0 },
+    },
+    expressionInputs: ['amount'],
+    expressionInputDefaults: {
+      amount: ['literal-number'],
+    },
+    paletteGroup: 'Actions',
+    paletteTags: ['storage', 'inventory'],
+  },
+  {
+    id: 'withdraw-storage',
+    label: 'Withdraw from Storage Box',
+    category: 'action',
+    summary: 'Retrieve resources from a storage box and return them to inventory.',
+    parameters: {
+      boxId: { kind: 'string', defaultValue: 'storage.box.base' },
+      resource: { kind: 'string', defaultValue: '' },
+      amount: { kind: 'number', defaultValue: 0 },
+    },
+    expressionInputs: ['amount'],
+    expressionInputDefaults: {
+      amount: ['literal-number'],
+    },
+    paletteGroup: 'Actions',
+    paletteTags: ['storage', 'inventory'],
+  },
+  {
     id: 'repeat',
     label: 'Repeat',
     category: 'c',

--- a/src/components/inspectors/MechanismProgrammingInspector.tsx
+++ b/src/components/inspectors/MechanismProgrammingInspector.tsx
@@ -17,6 +17,8 @@ const BLOCK_MODULE_REQUIREMENTS: Record<string, string[]> = {
   'scan-resources': ['sensor.survey'],
   'gather-resource': ['arm.manipulator'],
   'deposit-cargo': ['arm.manipulator'],
+  'store-storage': ['arm.manipulator'],
+  'withdraw-storage': ['arm.manipulator'],
   'toggle-status': ['status.signal'],
   'set-status': ['status.signal'],
   'broadcast-signal': ['status.signal'],

--- a/src/simulation/ecs/systems/debugOverlaySystem.ts
+++ b/src/simulation/ecs/systems/debugOverlaySystem.ts
@@ -327,6 +327,16 @@ function formatInstruction(instruction: BlockInstruction): string {
       return `scan${instruction.filter ? ` • ${instruction.filter}` : ''} • ${formatNumberBinding(instruction.duration, 1)}s`;
     case 'gather':
       return `gather • ${formatNumberBinding(instruction.duration, 1)}s`;
+    case 'store-storage': {
+      const box = instruction.boxId.value.trim() || 'default';
+      const resource = instruction.resource.value.trim() || 'all';
+      return `store → ${box} • ${resource} • ${formatNumberBinding(instruction.amount, 1)} units`;
+    }
+    case 'withdraw-storage': {
+      const box = instruction.boxId.value.trim() || 'default';
+      const resource = instruction.resource.value.trim() || 'all';
+      return `withdraw ← ${box} • ${resource} • ${formatNumberBinding(instruction.amount, 1)} units`;
+    }
     case 'deposit':
       return `deposit • ${formatNumberBinding(instruction.duration, 1)}s`;
     case 'status-toggle':

--- a/src/simulation/mechanism/MechanismChassis.ts
+++ b/src/simulation/mechanism/MechanismChassis.ts
@@ -10,6 +10,12 @@ import { MechanismState, type MechanismStateSnapshot, type MechanismStateOptions
 import type { MechanismModule } from './MechanismModule';
 import { InventoryStore } from './inventory';
 import { ResourceField, createDefaultResourceNodes } from '../resources/resourceField';
+import {
+  DEFAULT_STORAGE_BOX_ID,
+  createDefaultStorageRegistry,
+  type StorageRegistry,
+  type StorageRegistrySnapshot,
+} from '../storage/storageBox';
 import type { SlotMetadata, SlotSchema } from '../../types/slots';
 
 const DEFAULT_CAPACITY = 8;
@@ -91,6 +97,7 @@ export interface ModuleActionContext {
     mechanismStateUtils: typeof mechanismStateUtils;
     inventory: InventoryStore;
     resourceField: ResourceField;
+    storage: StorageRegistry;
   };
 }
 
@@ -104,6 +111,7 @@ export class MechanismChassis {
   readonly moduleStack: ModuleStack;
   readonly inventory: InventoryStore;
   readonly resourceField: ResourceField;
+  readonly storage: StorageRegistry;
   private readonly bus: ModuleBus;
   private readonly actuatorHandlers = new Map<string, ActuatorHandler>();
   private readonly pendingActuators = new Map<string, ActuatorRequest[]>();
@@ -117,6 +125,7 @@ export class MechanismChassis {
     this.bus = new ModuleBus();
     this.inventory = new InventoryStore();
     this.resourceField = new ResourceField(createDefaultResourceNodes());
+    this.storage = createDefaultStorageRegistry();
 
     this.inventory.setSlotConfiguration(0, {
       metadata: { stackable: false, moduleSubtype: 'Tool Bay' },
@@ -366,10 +375,19 @@ export class MechanismChassis {
         mechanismStateUtils,
         inventory: this.inventory,
         resourceField: this.resourceField,
+        storage: this.storage,
       },
     };
 
     return action.handler(payload, context);
+  }
+
+  getStorageSnapshot(): StorageRegistrySnapshot {
+    return this.storage.getSnapshot();
+  }
+
+  clearStorage(boxId: string = DEFAULT_STORAGE_BOX_ID): void {
+    this.storage.clear(boxId);
   }
 }
 

--- a/src/simulation/mechanism/modules/__tests__/moduleLibrary.test.ts
+++ b/src/simulation/mechanism/modules/__tests__/moduleLibrary.test.ts
@@ -49,6 +49,8 @@ describe('module library definitions', () => {
     const gripStrength = manipulatorValues?.gripStrength.value as number;
     expect(gripStrength).toBeGreaterThan(0);
     expect(manipulatorActions?.grip.metadata.label).toBe('Grip target');
+    expect(manipulatorActions?.storeInStorageBox.metadata.label).toBe('Store to storage box');
+    expect(manipulatorActions?.withdrawFromStorageBox.metadata.label).toBe('Withdraw from storage box');
 
     const cargoValues = telemetry.values['storage.cargo'];
     const cargoActions = telemetry.actions['storage.cargo'];
@@ -136,6 +138,7 @@ describe('module library definitions', () => {
     expect(manipulatorTelemetry?.heldItem.value).toBe('glyph');
     const totalHarvested = manipulatorTelemetry?.totalHarvested.value as number;
     expect(totalHarvested).toBeGreaterThanOrEqual(gatherResult.harvested);
+    expect(manipulatorTelemetry?.lastStorageTransfer.value).toBeNull();
 
     const fabricatorTelemetry = refreshedTelemetry.values['fabricator.basic'];
     const remainingQueue = fabricatorTelemetry?.queueLength.value as number;

--- a/src/simulation/mechanism/modules/moduleLibrary.ts
+++ b/src/simulation/mechanism/modules/moduleLibrary.ts
@@ -122,6 +122,16 @@ export const MODULE_LIBRARY: ModuleBlueprint[] = [
         label: 'Drop resource',
         description: 'Release stored resources to create or expand nearby ground piles.',
       },
+      {
+        name: 'storeInStorageBox',
+        label: 'Store to storage box',
+        description: 'Move inventory into a storage box, defaulting to the base container when unspecified.',
+      },
+      {
+        name: 'withdrawFromStorageBox',
+        label: 'Withdraw from storage box',
+        description: 'Retrieve stored resources from a storage box back into inventory.',
+      },
     ],
     telemetry: [
       {
@@ -163,6 +173,11 @@ export const MODULE_LIBRARY: ModuleBlueprint[] = [
         key: 'lastDrop',
         label: 'Last drop',
         description: 'Summary of the most recent drop operation.',
+      },
+      {
+        key: 'lastStorageTransfer',
+        label: 'Last storage transfer',
+        description: 'Summary of the most recent storage interaction.',
       },
     ],
     instantiate: () => new ManipulationModule(),

--- a/src/simulation/runtime/blockProgram.ts
+++ b/src/simulation/runtime/blockProgram.ts
@@ -157,6 +157,20 @@ export type BlockInstruction =
       target: 'auto';
     })
   | (BlockInstructionMetadata & {
+      kind: 'store-storage';
+      duration: NumberParameterBinding;
+      boxId: StringLiteralValue;
+      resource: StringLiteralValue;
+      amount: NumberParameterBinding;
+    })
+  | (BlockInstructionMetadata & {
+      kind: 'withdraw-storage';
+      duration: NumberParameterBinding;
+      boxId: StringLiteralValue;
+      resource: StringLiteralValue;
+      amount: NumberParameterBinding;
+    })
+  | (BlockInstructionMetadata & {
       kind: 'deposit';
       duration: NumberParameterBinding;
     })
@@ -1046,6 +1060,56 @@ const compileBlock = (
           sourceBlockId,
         },
       ];
+    case 'store-storage': {
+      const boxId = resolveStringParameter(block, 'boxId', diagnostics, {
+        fallback: 'storage.box.base',
+        allowEmpty: true,
+      });
+      const resource = resolveStringParameter(block, 'resource', diagnostics, {
+        fallback: '',
+        allowEmpty: true,
+      });
+      const amount = resolveNumberBinding(block, 'amount', diagnostics, {
+        label: formatParameterLabel(getBlockLabel('store-storage'), 'amount'),
+        fallback: 0,
+        minimum: 0,
+      });
+      return [
+        {
+          kind: 'store-storage',
+          duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Store Storage → duration' }),
+          boxId,
+          resource,
+          amount,
+          sourceBlockId,
+        },
+      ];
+    }
+    case 'withdraw-storage': {
+      const boxId = resolveStringParameter(block, 'boxId', diagnostics, {
+        fallback: 'storage.box.base',
+        allowEmpty: true,
+      });
+      const resource = resolveStringParameter(block, 'resource', diagnostics, {
+        fallback: '',
+        allowEmpty: true,
+      });
+      const amount = resolveNumberBinding(block, 'amount', diagnostics, {
+        label: formatParameterLabel(getBlockLabel('withdraw-storage'), 'amount'),
+        fallback: 0,
+        minimum: 0,
+      });
+      return [
+        {
+          kind: 'withdraw-storage',
+          duration: createNumberLiteralBinding(WAIT_DURATION, { label: 'Withdraw Storage → duration' }),
+          boxId,
+          resource,
+          amount,
+          sourceBlockId,
+        },
+      ];
+    }
     case 'toggle-status':
       return [
         {

--- a/src/simulation/storage/storageBox.ts
+++ b/src/simulation/storage/storageBox.ts
@@ -1,0 +1,247 @@
+import type { InventoryEntry } from '../mechanism/inventory';
+
+export interface StorageBoxSnapshot {
+  id: string;
+  label: string;
+  capacity: number;
+  used: number;
+  available: number;
+  contents: InventoryEntry[];
+}
+
+export interface StorageStoreResult {
+  stored: number;
+  overflow: number;
+  total: number;
+}
+
+export interface StorageWithdrawResult {
+  withdrawn: number;
+  remaining: number;
+  total: number;
+}
+
+export interface StorageBoxOptions {
+  id: string;
+  label?: string;
+  capacity?: number;
+}
+
+const normaliseResourceId = (resource: string | null | undefined): string | null => {
+  const trimmed = resource?.trim().toLowerCase();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
+
+export class StorageBox {
+  readonly id: string;
+  readonly label: string;
+  private capacity: number;
+  private readonly contents = new Map<string, number>();
+
+  constructor({ id, label, capacity = 120 }: StorageBoxOptions) {
+    if (!id?.trim()) {
+      throw new Error('Storage boxes require an identifier.');
+    }
+    this.id = id.trim();
+    this.label = label?.trim() || this.id;
+    this.capacity = Math.max(capacity, 0);
+  }
+
+  configureCapacity(capacity: number): void {
+    if (!Number.isFinite(capacity) || capacity < 0) {
+      return;
+    }
+    this.capacity = Math.max(capacity, 0);
+  }
+
+  getCapacity(): number {
+    return this.capacity;
+  }
+
+  getUsed(): number {
+    let used = 0;
+    for (const quantity of this.contents.values()) {
+      used += Math.max(quantity, 0);
+    }
+    return used;
+  }
+
+  getAvailable(): number {
+    return Math.max(this.capacity - this.getUsed(), 0);
+  }
+
+  getQuantity(resource: string): number {
+    const id = normaliseResourceId(resource);
+    if (!id) {
+      return 0;
+    }
+    return Math.max(this.contents.get(id) ?? 0, 0);
+  }
+
+  store(resource: string, amount: number): StorageStoreResult {
+    const id = normaliseResourceId(resource);
+    const safeAmount = Number.isFinite(amount) ? Math.max(amount, 0) : 0;
+    if (!id || safeAmount <= 0) {
+      return { stored: 0, overflow: 0, total: this.getQuantity(id ?? '') };
+    }
+
+    const available = this.getAvailable();
+    const stored = Math.min(safeAmount, available);
+    const overflow = safeAmount - stored;
+    if (stored > 0) {
+      const current = this.contents.get(id) ?? 0;
+      this.contents.set(id, clamp(current + stored, 0, Number.POSITIVE_INFINITY));
+    }
+
+    return {
+      stored,
+      overflow,
+      total: this.getQuantity(id),
+    } satisfies StorageStoreResult;
+  }
+
+  withdraw(resource: string, amount: number): StorageWithdrawResult {
+    const id = normaliseResourceId(resource);
+    const safeAmount = Number.isFinite(amount) ? Math.max(amount, 0) : 0;
+    if (!id || safeAmount <= 0) {
+      return { withdrawn: 0, remaining: this.getQuantity(id ?? ''), total: this.getQuantity(id ?? '') };
+    }
+
+    const current = this.contents.get(id) ?? 0;
+    const withdrawn = Math.min(current, safeAmount);
+    if (withdrawn > 0) {
+      const next = clamp(current - withdrawn, 0, Number.POSITIVE_INFINITY);
+      if (next <= 0) {
+        this.contents.delete(id);
+      } else {
+        this.contents.set(id, next);
+      }
+    }
+
+    const remaining = this.getQuantity(id);
+    return { withdrawn, remaining, total: remaining } satisfies StorageWithdrawResult;
+  }
+
+  clear(): void {
+    this.contents.clear();
+  }
+
+  getSnapshot(): StorageBoxSnapshot {
+    const entries: InventoryEntry[] = [];
+    for (const [resource, quantity] of this.contents.entries()) {
+      if (quantity > 0) {
+        entries.push({ resource, quantity });
+      }
+    }
+    entries.sort((a, b) => a.resource.localeCompare(b.resource));
+
+    return {
+      id: this.id,
+      label: this.label,
+      capacity: this.capacity,
+      used: this.getUsed(),
+      available: this.getAvailable(),
+      contents: entries,
+    } satisfies StorageBoxSnapshot;
+  }
+}
+
+export interface StorageRegistrySnapshot {
+  boxes: StorageBoxSnapshot[];
+}
+
+export interface ConfigureStorageBoxOptions {
+  capacity?: number;
+}
+
+export class StorageRegistry {
+  private readonly boxes = new Map<string, StorageBox>();
+
+  constructor(initialBoxes: StorageBoxOptions[] = []) {
+    for (const box of initialBoxes) {
+      this.addBox(box);
+    }
+  }
+
+  addBox(options: StorageBoxOptions): StorageBox {
+    const existing = this.boxes.get(options.id);
+    if (existing) {
+      return existing;
+    }
+    const box = new StorageBox(options);
+    this.boxes.set(box.id, box);
+    return box;
+  }
+
+  getBox(id: string): StorageBox | null {
+    const trimmed = id?.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return this.boxes.get(trimmed) ?? null;
+  }
+
+  getBoxSnapshot(id: string): StorageBoxSnapshot | null {
+    const box = this.getBox(id);
+    return box ? box.getSnapshot() : null;
+  }
+
+  configureBox(id: string, options: ConfigureStorageBoxOptions): void {
+    const box = this.getBox(id);
+    if (!box) {
+      return;
+    }
+    if (Number.isFinite(options.capacity)) {
+      box.configureCapacity(Math.max(options.capacity as number, 0));
+    }
+  }
+
+  store(boxId: string, resource: string, amount: number): StorageStoreResult {
+    const box = this.getBox(boxId);
+    if (!box) {
+      return { stored: 0, overflow: 0, total: 0 };
+    }
+    return box.store(resource, amount);
+  }
+
+  withdraw(boxId: string, resource: string, amount: number): StorageWithdrawResult {
+    const box = this.getBox(boxId);
+    if (!box) {
+      return { withdrawn: 0, remaining: 0, total: 0 };
+    }
+    return box.withdraw(resource, amount);
+  }
+
+  clear(boxId: string): void {
+    const box = this.getBox(boxId);
+    box?.clear();
+  }
+
+  getSnapshot(): StorageRegistrySnapshot {
+    const boxes = [...this.boxes.values()].map((box) => box.getSnapshot());
+    boxes.sort((a, b) => a.id.localeCompare(b.id));
+    return { boxes } satisfies StorageRegistrySnapshot;
+  }
+}
+
+export const DEFAULT_STORAGE_BOX_ID = 'storage.box.base';
+
+export const createDefaultStorageRegistry = (): StorageRegistry => {
+  return new StorageRegistry([
+    { id: DEFAULT_STORAGE_BOX_ID, label: 'Base Storage', capacity: 240 },
+  ]);
+};
+


### PR DESCRIPTION
## Summary
- add a storage registry and wire the manipulator module to move cargo into named boxes
- expose store/withdraw actions and blocks, and update the runtime to execute the new instructions
- adjust deposit handling and extend automated tests to cover storage interactions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd20ad82b8832eb8f63287d6d70598